### PR TITLE
Converted mainCode output to two spaces.

### DIFF
--- a/frege/compiler/GenJava7.fr
+++ b/frege/compiler/GenJava7.fr
@@ -414,16 +414,16 @@ ppSSC xss = do
 --- the java code to run the main function
 mainCode g sym = [
     "public static void main(final java.lang.String[] argv) {",
-    "    final long t1 = java.lang.System.nanoTime();",
-    "    frege.runtime.Runtime.runMain(",
-    "       " ++ pPreludeBase.unpack g ++ ".TST.performUnsafe(",
-    "           " ++ show (extFname g sym) ++ ".inst.apply(" 
-                        ++ pPreludeBase.unpack g 
-                        ++ "._toList(argv)).<frege.runtime.Lambda>forced()));",
-    "   final long t2 = java.lang.System.nanoTime();",
-    "   frege.runtime.Runtime.stderr.println(",
-    "     \"runtime \" + ((((t2 - t1) + 500000) / 1000000) / 1e3) + \" wallclock seconds.\");",
-    "   frege.runtime.Runtime.exit();",
+    "  final long t1 = java.lang.System.nanoTime();",
+    "  frege.runtime.Runtime.runMain(",
+    "    " ++ pPreludeBase.unpack g ++ ".TST.performUnsafe(",
+    "      " ++ show (extFname g sym) ++ ".inst.apply(" 
+                ++ pPreludeBase.unpack g 
+                ++ "._toList(argv)).<frege.runtime.Lambda>forced()));",
+    "  final long t2 = java.lang.System.nanoTime();",
+    "  frege.runtime.Runtime.stderr.println(",
+    "    \"runtime \" + ((((t2 - t1) + 500000) / 1000000) / 1e3) + \" wallclock seconds.\");",
+    "  frege.runtime.Runtime.exit();",
     "}"
     ]
     


### PR DESCRIPTION
Against the wiki recommendations I peered into the generated java file.

Main had some odd indentation, 4 spaces one most lines and 3 spaces on a few. So I converted it to 2 spaces to match the rest of the file.
