### PR TITLE
Fix Frege/frege#71 ArrayIndexOutOfBoundsException on JArray.fold

### DIFF
--- a/frege/prelude/PreludeArrays.fr
+++ b/frege/prelude/PreludeArrays.fr
@@ -242,7 +242,7 @@ data JArray a = native "java.lang.reflect.Array" where
     
     --- Equivalent of 'fold' for mutable arrays. 
     fold :: ArrayElem α => (β->α->β) -> β -> ArrayOf γ α -> ST γ β
-    fold f acc arr = arr.getLength >>= foldM collect acc . enumFromTo 0
+    fold f acc arr = arr.getLength >>= foldM collect acc . enumFromTo 0 . pred
         where
             collect acc i = ArrayElem.getAt arr i >>= return . maybe acc (f acc)      
     


### PR DESCRIPTION
Fixes `ArrayIndexOutOfBoundsException` on `JArray.fold` by not accessing the element at `array.length`.
