### PR TITLE
Greek letters issue 76

### DIFF
--- a/frege/prelude/PreludeList.fr
+++ b/frege/prelude/PreludeList.fr
@@ -341,7 +341,7 @@ concatMap f as = concat (map f as) -- [ x | xs <- map f as, x <- xs ]
 {--
     @cycle xs@ builds a value that is an infinite repetition of _xs_, which must not be empty.
     -}
-cycle :: [a] -> [a]    
+cycle :: [α] -> [α]
 cycle xs | null xs   = error "Prelude.cycle []"
          | otherwise = xs ++ cycle xs
 
@@ -449,7 +449,7 @@ scanl1 f _       = error "Prelude.scanl1 f []"
 --- 'scanr' is the right-to-left dual of 'scanl'.
 --- Note that
 --- > head (scanr f z xs) == foldr f z xs.
-scanr :: (α->β->β) -> β -> [α] -> [β]
+scanr :: (α -> β -> β) -> β -> [α] -> [β]
 scanr f q0 (x:xs)       =  f x q : qs
                            where qs = scanr f q0 xs
                                  q  = head qs


### PR DESCRIPTION
Issue 76 should be fine now for the whole of PreludeList.

What is not yet fully consistent is that most top-level functions do not have a type declaration, some have (e.g. scanr), and some have it commented (e.g. scanr1, foldr). The commented type declarations have not been switched to greek.

make fregec.jar
was fine on my machine but since this is touching core I'd rather like a second pair of eyes accept the pull request.
