### PR TITLE
Port Data.Bits from Haskell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ tmp/
 *.swp
 *~.nib
 local.properties
+*.iml
 .settings/
 .loadpath
 

--- a/frege/compiler/types/Global.fr
+++ b/frege/compiler/types/Global.fr
@@ -13,7 +13,7 @@ import  frege.compiler.enums.TokenID(TokenID)
 import  frege.compiler.types.Positions
 import  frege.compiler.types.Tokens
 import  frege.compiler.Classtools  as  CT()
-import  frege.data.Bits  (BitSet.BitSet, BitSet.member, BitSet.union bitunion, BitSet.intersection, BitSet.difference)
+import  frege.data.Bits  (BitSet.BitSet, BitSet.member, BitSet.union bitunion, BitSet.intersection, BitSet.difference, Bits.xor)
 import  frege.compiler.types.NSNames
 import  frege.compiler.enums.Literals
 import  frege.compiler.types.JNames
@@ -464,6 +464,6 @@ uniqid :: StG Int
 uniqid = do
     g <- getST
     putST g.{unique <- (1+)}
-    stio ((g.unique `bxor` 0x5555) + 1)
+    stio ((g.unique `xor` 0x5555) + 1)
 
 

--- a/frege/data/Bits.fr
+++ b/frege/data/Bits.fr
@@ -22,16 +22,16 @@ data BitSet e = BitSet { !set :: Long } where
                      
     --- A set with one argument
     singleton :: Enum α => α -> BitSet α
-    singleton !a = BitSet (1L `bshl` ord a)
+    singleton !a = BitSet (1L `shiftL` ord a)
     --- @a `union` b@ -- a set with all elements that are members of a or members of b
     union :: BitSet α -> BitSet α -> BitSet α
-    union BitSet{set=set1} BitSet{set=set2}  = BitSet (set1 `bor` set2)
+    union BitSet{set=set1} BitSet{set=set2}  = BitSet (set1 `.|.` set2)
     --- @a `intersection` b@ -- a set with all elements that are members of a and members of b
     intersection :: BitSet α -> BitSet α -> BitSet α
-    intersection BitSet{set=set1} BitSet{set=set2}  = BitSet (set1 `band` set2)
+    intersection BitSet{set=set1} BitSet{set=set2}  = BitSet (set1 `.&.` set2)
     --- @a `difference` b@ -- a set with all elements that are members of a and not members of b
     difference :: BitSet α -> BitSet α -> BitSet α
-    difference BitSet{set=set1} BitSet{set=set2}  = BitSet (set1 `band` bcmpl set2)
+    difference BitSet{set=set1} BitSet{set=set2}  = BitSet (set1 `.&.` complement set2)
     --- @a `unionE` e@ = @a `union` {e}@
     unionE bs = union bs . singleton
     --- @a `intersectionE` e@ = @a `intersection` {e}@
@@ -47,14 +47,14 @@ data BitSet e = BitSet { !set :: Long } where
     member a bs = singleton a `subset` bs
     --- Predicate that tells if one set is a subset of another
     subset :: BitSet α -> BitSet α -> Bool
-    subset BitSet{set=set1} BitSet{set=set2} = (set1 `band` set2) == set1
+    subset BitSet{set=set1} BitSet{set=set2} = (set1 `.&.` set2) == set1
     
     --- tell the number of elements in a 'BitSet'
     size BitSet{set} = go set 0 where
         go 0L n = n
         go s  n
-            | even s    = go (s `ushr` 1) n
-            | otherwise = go (s `ushr` 1) (n+1)
+            | even s    = go (s `ushiftR` 1) n
+            | otherwise = go (s `ushiftR` 1) (n+1)
             
     --- convert a list to a 'BitSet'
     fromList = fold (\acc\e -> acc `union` singleton e) empty
@@ -64,8 +64,8 @@ data BitSet e = BitSet { !set :: Long } where
         where
             go 0L !c = []
             go  n !c 
-                | odd  n    = Enum.from c : go (n `ushr` 1) (c+1)
-                | otherwise = go (n `ushr` 1) (c+1)  
+                | odd  n    = Enum.from c : go (n `ushiftR` 1) (c+1)
+                | otherwise = go (n `ushiftR` 1) (c+1)
     
 instance Monoid (BitSet a) where
     mempty  = BitSet.empty
@@ -83,3 +83,165 @@ instance Ord (BitSet a) where
 instance Show (Show a, Enum a) => BitSet a where
     show bs = "{" ++ joined ", " members ++ "}" where
         members = map show bs.toList
+
+{--
+The 'Bits' class defines bitwise operations over integral types.
+
+* Bits are numbered from 0 with bit 0 being the least
+  significant bit.
+
+Minimal complete definition: '.&.', '.|.', 'xor', 'complement',
+('shift' or ('shiftL' and 'shiftR')), ('rotate' or ('rotateL' and 'rotateR')),
+'bitSize' and 'isSigned'.
+-}
+class Bits Num a => a where
+    --- Bitwise \"and\"
+    (.&.) :: a -> a -> a
+
+    --- Bitwise \"or\"
+    (.|.) :: a -> a -> a
+
+    --- Bitwise \"xor\"
+    xor :: a -> a -> a
+
+    {-- Reverse all the bits in the argument -}
+    complement        :: a -> a
+
+    {-- @'shift' x i@ shifts @x@ left by @i@ bits if @i@ is positive,
+        or right by @-i@ bits otherwise.
+        Right shifts perform sign extension on signed number types;
+        i.e. they fill the top bits with 1 if the @x@ is negative
+        and with 0 otherwise.
+
+        An instance can define either this unified 'shift' or 'shiftL' and
+        'shiftR', depending on which is more convenient for the type in
+        question. -}
+    shift             :: a -> Int -> a
+
+    x `shift`   i | i<0       = x `shiftR` (-i)
+                  | i>0       = x `shiftL` i
+                  | otherwise = x
+
+    {-- @'rotate' x i@ rotates @x@ left by @i@ bits if @i@ is positive,
+        or right by @-i@ bits otherwise.
+
+        For unbounded types like 'Integer', 'rotate' is equivalent to 'shift'.
+
+        An instance can define either this unified 'rotate' or 'rotateL' and
+        'rotateR', depending on which is more convenient for the type in
+        question. -}
+    rotate            :: a -> Int -> a
+
+    x `rotate`  i | i<0       = x `rotateR` (-i)
+                  | i>0       = x `rotateL` i
+                  | otherwise = x
+
+    {-
+    -- Rotation can be implemented in terms of two shifts, but care is
+    -- needed for negative values.  This suggested implementation assumes
+    -- 2's-complement arithmetic.  It is commented out because it would
+    -- require an extra context (Ord a) on the signature of 'rotate'.
+    x `rotate`  i | i<0 && isSigned x && x<0
+                         = let left = i+bitSize x in
+                           ((x `shift` i) .&. complement ((-1) `shift` left))
+                           .|. (x `shift` left)
+                  | i<0  = (x `shift` i) .|. (x `shift` (i+bitSize x))
+                  | i==0 = x
+                  | i>0  = (x `shift` i) .|. (x `shift` (i-bitSize x))
+    -}
+
+    --- @bit i@ is a value with the @i@th bit set
+    bit               :: Int -> a
+
+    --- @x \`setBit\` i@ is the same as @x .|. bit i@
+    setBit            :: a -> Int -> a
+
+    --- @x \`clearBit\` i@ is the same as @x .&. complement (bit i)@
+    clearBit          :: a -> Int -> a
+
+    --- @x \`complementBit\` i@ is the same as @x \`xor\` bit i@
+    complementBit     :: a -> Int -> a
+
+    --- Return 'true' if the @n@th bit of the argument is 1
+    testBit           :: a -> Int -> Bool
+
+    {-- Return the number of bits in the type of the argument.  The actual
+        value of the argument is ignored.  The function 'bitSize' is
+        undefined for types that do not have a fixed bitsize, like 'Integer'.
+        -}
+    bitSize           :: a -> Int
+
+    {-- Return 'true' if the argument is a signed type.  The actual
+        value of the argument is ignored -}
+    isSigned          :: a -> Bool
+
+    bit i               = 1 `shiftL` i
+    x `setBit` i        = x .|. bit i
+    x `clearBit` i      = x .&. complement (bit i)
+    x `complementBit` i = x `xor` bit i
+    x `testBit` i       = (x .&. bit i) /= 0
+
+    {-- Shift the argument left by the specified number of bits
+        (which must be non-negative).
+
+        An instance can define either this and 'shiftR' or the unified
+        'shift', depending on which is more convenient for the type in
+        question. -}
+    shiftL            :: a -> Int -> a
+    x `shiftL`  i = x `shift`  i
+
+    {-- Shift the first argument right by the specified number of bits
+        (which must be non-negative).
+        Right shifts perform sign extension on signed number types;
+        i.e. they fill the top bits with 1 if the @x@ is negative
+        and with 0 otherwise.
+
+        An instance can define either this and 'shiftL' or the unified
+        'shift', depending on which is more convenient for the type in
+        question. -}
+    shiftR            :: a -> Int -> a
+    x `shiftR`  i = x `shift`  (-i)
+
+    --- Unsigned shift right
+    ushiftR            :: a -> Int -> a
+
+    {-- Rotate the argument left by the specified number of bits
+        (which must be non-negative).
+
+        An instance can define either this and 'rotateR' or the unified
+        'rotate', depending on which is more convenient for the type in
+        question. -}
+    rotateL           :: a -> Int -> a
+    x `rotateL` i = x `rotate` i
+
+    {-- Rotate the argument right by the specified number of bits
+        (which must be non-negative).
+
+        An instance can define either this and 'rotateL' or the unified
+        'rotate', depending on which is more convenient for the type in
+        question. -}
+    rotateR           :: a -> Int -> a
+    x `rotateR` i = x `rotate` (-i)
+
+
+instance Bits Int where
+
+    bitSize  _ = Int.size
+
+    isSigned _ = true
+
+instance Bits Long where
+
+    bitSize  _ = Long.size
+
+    isSigned _ = true
+
+instance Bits Integer where
+
+    rotate x i = shift x i   -- since an Integer never wraps around
+
+    bitSize _  = error "Data.Bits.bitSize(Integer)"
+
+    isSigned _ = true
+
+

--- a/frege/prelude/PreludeBase.fr
+++ b/frege/prelude/PreludeBase.fr
@@ -94,9 +94,9 @@ infixl 14 `*` `/` `%` `mod` `rem` `div` `quot`
 infix  14 `\\`
 infixl 13 `+`  -- `-` is handled specially
 infixr 13 `++` `<+>`  mplus mappend <>
-infixl 12 `<<` `bshl` `bshr` `ushr`
-infixl 11 `band`
-infixl 10 `bor` `bxor`
+infixl 12 `<<` `shift` `rotate` `shiftL` `shiftR` `rotateL` `rotateR` `ushiftR`
+infixl 11 `.&.`
+infixl 10 `.|.` `xor`
 infix  9 `<=` `>=` `<` `>` `elem` `notElem`
 infix  8 `<=>` `compare`
 infix  7 `==` `!=` `/=` `===` `!==` -- `<>`
@@ -248,12 +248,31 @@ data Int = native int where
     --- Result is only valid for integers in the range 0..65535
     pure native char "(char)"  ::            Int -> Char
     --- Computes binary /or/ of two integers. Uses the java @|@-operator.
-    pure native bor  "|" :: Int -> Int -> Int
+    pure native (.|.)  "|" :: Int -> Int -> Int
     --- Computes binary /exclusive or/ of two integers. Uses the java @^@-operator.
-    pure native bxor "^" :: Int -> Int -> Int
+    pure native xor "^" :: Int -> Int -> Int
     --- Computes binary /and/ of two integers. Uses the java @&@-operator.
-    pure native band "&" :: Int -> Int -> Int
-    -- Compare 2 integers, use java operator
+
+    pure native (.&.) "&" :: Int -> Int -> Int
+
+    --- The number of bits used to represent an int value in two's complement binary form
+    pure native size java.lang.Integer.SIZE :: Int
+
+    pure native shiftL "<<" :: Int -> Int -> Int
+    pure native shiftR ">>" :: Int -> Int -> Int
+    --- unsigned right shift
+    pure native ushiftR ">>>" :: Int -> Int -> Int
+    pure native complement "~" :: Int -> Int
+
+    --- Returns the value obtained by rotating the two's complement binary representation of the specified int value left
+    --- by the specified number of bits.
+    pure native rotateL java.lang.Integer.rotateLeft :: Int -> Int -> Int
+
+    --- Returns the value obtained by rotating the two's complement binary representation of the specified int value
+    --- right by the specified number of bits.
+    pure native rotateR java.lang.Integer.rotateRight :: Int -> Int -> Int
+
+    -- Compare 2 intergers, use java operator
     -- pure native (==) :: Int -> Int -> Bool   // is defined in Eq
     --- convert to a hexadecimal string
     pure native toHexString java.lang.Integer.toHexString :: Int -> String
@@ -291,24 +310,24 @@ data Integer = native java.math.BigInteger where
     pure  native max                                  :: Integer -> Integer -> Integer
     pure  native min                                  :: Integer -> Integer -> Integer
     -- shift
-    pure  native bshr    shiftRight                   :: Integer -> Int -> Integer
-    pure  native bshl    shiftLeft                    :: Integer -> Int -> Integer
+    pure  native shiftR    shiftRight                 :: Integer -> Int -> Integer
+    pure  native shiftL    shiftLeft                  :: Integer -> Int -> Integer
     --- unsigned right shift on big integers does not really make sense ...
-    b `ushr` i = abs b `bshr` i 
+    b `ushiftR` i = abs b `shiftR` i
     -- bit arithmetic
-    pure  native bor     or                           :: Integer -> Integer -> Integer
-    pure  native band    and                          :: Integer -> Integer -> Integer
-    pure  native bxor    xor                          :: Integer -> Integer -> Integer
-    pure  native bcmpl   not                          :: Integer -> Integer 
-    -- miscellaneous
-    pure native bitLength                            :: Integer -> Int
-    pure native toString                             :: Integer -> String
-    pure native sign    signum                       :: Integer -> Int
-    pure native long    longValue                    :: Integer -> Long
-    pure native int     intValue                     :: Integer -> Int
-    pure native double  doubleValue                  :: Integer -> Double
-    pure native hashCode                             :: Integer -> Int
-    pure native gcd                                  :: Integer -> Integer -> Integer
+    pure  native (.|.)     or                         :: Integer -> Integer -> Integer
+    pure  native (.&.)    and                         :: Integer -> Integer -> Integer
+    pure  native xor    xor                           :: Integer -> Integer -> Integer
+    pure  native complement   not                     :: Integer -> Integer
+    -- miscellanous
+    pure native bitLength                             :: Integer -> Int
+    pure native toString                              :: Integer -> String
+    pure native sign    signum                        :: Integer -> Int
+    pure native long    longValue                     :: Integer -> Long
+    pure native int     intValue                      :: Integer -> Int
+    pure native double  doubleValue                   :: Integer -> Double
+    pure native hashCode                              :: Integer -> Int
+    pure native gcd                                   :: Integer -> Integer -> Integer
 
 {--
  * 'Long' values are based on Java's primitive @long@ values.
@@ -328,13 +347,25 @@ data Long = native long  where
     --- Uses a java cast to convert a 'Long' to an 'Int'. This is a _narrowing primitive conversion_ in java parlance.
     pure native int "(int)"  ::          Long -> Int
     --- Computes binary _or_ of two long integers. Uses the java @|@-operator.
-    pure native bor  "|" :: Long -> Long -> Long
+    pure native (.|.)  "|" :: Long -> Long -> Long
     --- Computes binary _exclusive or_ of two long integers. Uses the java @^@-operator.
-    pure native bxor "^" :: Long -> Long -> Long
+    pure native xor "^" :: Long -> Long -> Long
     --- Computes binary _and_ of two integers. Uses the java @&@-operator.
-    pure native band "&" :: Long -> Long -> Long
+    pure native (.&.) "&" :: Long -> Long -> Long
+
+    pure native shiftL "<<" :: Long -> Int -> Long
+
+    pure native shiftR ">>" :: Long -> Int -> Long
+
+    --- unsigned right shift
+    pure native ushiftR ">>>" :: Long -> Int -> Long
+
+    pure native complement "~" :: Long -> Long
+
+    pure native size java.lang.Long.SIZE :: Int
+
     --- hash code is upper half and lower half xor'ed
-    hashCode l = (int l).bxor (int (l `bshr` 32))
+    hashCode l = (int l).xor (int (l `shiftR` 32))
 
 --- 'Char' values are based on Java's primitive @char@ values.
 --- This type has many native functions based on the methods in @java.lang.Character@. 
@@ -444,8 +475,7 @@ data Char = native char where
     -}
     pure native isSurrogatePair  java.lang.Character.isSurrogatePair :: Char -> Char -> Bool
     
-
-{-- 
+{--
     'String' values are based on Java\'s @java.lang.String@ objects.
     'String' is an alias for 'StringJ' 'Char'
     -}
@@ -1183,11 +1213,13 @@ instance Integral Integer where
     fromInt i = Int.big i
     fromInteger b = b           -- identity
     big b     = b               -- i am already big
+    even n = (n Integer.`.&.` one) == zero
+    odd  n = (n Integer.`.&.` one) != zero
 
 
 toInteger = Integral.big
 
---- Class 'Integral' provides bit arithmetic, division and remainder operations for integral numbers.
+--- Class 'Integral' provides division and remainder operations for integral numbers.
 class Integral Num integ => integ where
     --- integer division
     div, quot :: integ -> integ -> integ
@@ -1212,22 +1244,6 @@ class Integral Num integ => integ where
                     q | (a >= zero) == (b >= zero) = q              -- a and b have same sign
                       | q * b       == a           = q
                       | otherwise                  = q-one
-
-    --- binary and, supposed to work like Java @&@ on all integral types
-    band :: integ -> integ -> integ
-    --- binary exclusive or, supposed to work like Java @^@ on all integral types
-    bxor :: integ -> integ -> integ
-    --- binary or, supposed to work like Java @|@ on all integral types
-    bor  :: integ -> integ -> integ
-    --- binary left shift, supposed to work like Java @<<@ on all integral types
-    bshl :: integ -> Int -> integ
-    --- binary right shift, supposed to work like Java @>>@ on all integral types
-    bshr :: integ -> Int -> integ
-    --- unsigned right shift, supposed to work like Java @>>>@ on all integral types
-    ushr :: integ -> Int -> integ
-    --- one's complement, supposed to work like Java operator @~@
-    bcmpl :: integ -> integ
-    bcmpl x = x `bxor` fromInt (-1)
 
     --- every integral number can be converted to a big 'Integer'
     big :: integ -> Integer
@@ -1257,10 +1273,6 @@ class Integral Num integ => integ where
         | x == zero || y == zero = zero
         | otherwise              =  abs ((x `quot` (gcd x y)) * y)
 
-    even, odd :: integ -> Bool
-    even n = n `band` one == zero
-    odd  n = n `band` one != zero
-    
     --- @ x ^ n @  raise _x_ to the _n_-th power
     --- The exponent must be positive. 
     (^) :: Num a => a -> integ -> a
@@ -1269,7 +1281,9 @@ class Integral Num integ => integ where
         | y0 == 0   = 1
         | otherwise = powf x0 y0
     
-    --- helper for 'Integral.^'    
+    even, odd :: integ -> Bool
+
+    --- helper for 'Integral.^'
     private powf :: Num a => a -> integ -> a
     private powf x y 
         | even y    = powf (x * x) (y `quot` 2)
@@ -1491,22 +1505,20 @@ instance Enum Long where
 instance Integral Int where
     pure native rem  %    :: Int -> Int -> Int
     pure native quot /    :: Int -> Int -> Int
-    pure native bshl "<<" :: Int -> Int -> Int
-    pure native bshr ">>" :: Int -> Int -> Int
-    --- unsigned right shift
-    pure native ushr ">>>" :: Int -> Int -> Int
-    pure native bcmpl "~" :: Int -> Int
+
+    even n = (n Int.`.&.` one) == zero
+    odd  n = (n Int.`.&.` one) != zero
+
     big l = Integer.valueOf l.long
+
 
 instance Integral Long where
     pure native rem %      :: Long -> Long -> Long
     pure native quot /     :: Long -> Long -> Long
-    pure native bshl "<<"  :: Long -> Int -> Long
-    pure native bshr ">>"  :: Long -> Int -> Long
-    pure native bcmpl "~"  :: Long -> Long
+    even n = (n Long.`.&.` one) == zero
+    odd  n = (n Long.`.&.` one) != zero
     big l = Integer.valueOf l
-    --- unsigned right shift
-    pure native ushr ">>>" :: Long -> Int -> Long
+
 
 --############# Bool instances ########################################
 

--- a/frege/system/Random.fr
+++ b/frege/system/Random.fr
@@ -17,6 +17,7 @@
 module frege.system.Random where
 
 import Java.Util as J()     -- access java type
+import Data.Bits
 
 
 --- The class 'RandomGen' provides a common interface to random number generators.
@@ -159,7 +160,7 @@ instance Random Int where
                 i = li.long
                 r = u - l + 1L
                 n = abs (i `mod` r) + l
-                !g0 = (n `band` 0xffffffffL).int
+                !g0 = (n `.&.` 0xffffffffL).int
             in (g0, g1)
 
 instance Random Integer where

--- a/shadow/frege/prelude/PreludeBase.fr
+++ b/shadow/frege/prelude/PreludeBase.fr
@@ -94,9 +94,9 @@ infixl 14 `*` `/` `%` `mod` `rem` `div` `quot`
 infix  14 `\\`
 infixl 13 `+`  -- `-` is handled specially
 infixr 13 `++` `<+>`  mplus mappend <>
-infixl 12 `<<` `bshl` `bshr` `ushr`
-infixl 11 `band`
-infixl 10 `bor` `bxor`
+infixl 12 `<<` `shift` `rotate` `shiftL` `shiftR` `rotateL` `rotateR` `ushiftR`
+infixl 11 `.&.`
+infixl 10 `.|.` `xor`
 infix  9 `<=` `>=` `<` `>` `elem` `notElem`
 infix  8 `<=>` `compare`
 infix  7 `==` `!=` `/=` `===` `!==` -- `<>`
@@ -111,6 +111,7 @@ infixr 2 `:=` `=<<` `@` `seq`    -- so that in x@a:bs x is bound to the list
 infixl 2 either catch finally
 infixl 1 on
 infixr 1 `$` `$!`
+
 
 -- -----------------------------------------------------------------------------
 --          CLASS SECTION
@@ -248,11 +249,29 @@ data Int = native int where
     --- Result is only valid for integers in the range 0..65535
     pure native char "(char)"  ::            Int -> Char
     --- Computes binary /or/ of two integers. Uses the java @|@-operator.
-    pure native bor  "|" :: Int -> Int -> Int
+    pure native (.|.)  "|" :: Int -> Int -> Int
     --- Computes binary /exclusive or/ of two integers. Uses the java @^@-operator.
-    pure native bxor "^" :: Int -> Int -> Int
+    pure native xor "^" :: Int -> Int -> Int
     --- Computes binary /and/ of two integers. Uses the java @&@-operator.
-    pure native band "&" :: Int -> Int -> Int
+    pure native (.&.) "&" :: Int -> Int -> Int
+
+    --- The number of bits used to represent an int value in two's complement binary form
+    pure native size java.lang.Integer.SIZE :: Int
+
+    pure native shiftL "<<" :: Int -> Int -> Int
+    pure native shiftR ">>" :: Int -> Int -> Int
+    --- unsigned right shift
+    pure native ushiftR ">>>" :: Int -> Int -> Int
+    pure native complement "~" :: Int -> Int
+
+    --- Returns the value obtained by rotating the two's complement binary representation of the specified int value left
+    --- by the specified number of bits.
+    pure native rotateL java.lang.Integer.rotateLeft :: Int -> Int -> Int
+
+    --- Returns the value obtained by rotating the two's complement binary representation of the specified int value
+    --- right by the specified number of bits.
+    pure native rotateR java.lang.Integer.rotateRight :: Int -> Int -> Int
+
     -- Compare 2 intergers, use java operator
     -- pure native (==) :: Int -> Int -> Bool   // is defined in Eq
     --- convert to a hexadecimal string
@@ -291,24 +310,24 @@ data Integer = native java.math.BigInteger where
     pure  native max                                  :: Integer -> Integer -> Integer
     pure  native min                                  :: Integer -> Integer -> Integer
     -- shift
-    pure  native bshr    shiftRight                   :: Integer -> Int -> Integer
-    pure  native bshl    shiftLeft                    :: Integer -> Int -> Integer
+    pure  native shiftR    shiftRight                 :: Integer -> Int -> Integer
+    pure  native shiftL    shiftLeft                  :: Integer -> Int -> Integer
     --- unsigned right shift on big integers does not really make sense ...
-    b `ushr` i = abs b `bshr` i 
+    b `ushiftR` i = abs b `shiftR` i
     -- bit arithmetic
-    pure  native bor     or                           :: Integer -> Integer -> Integer
-    pure  native band    and                          :: Integer -> Integer -> Integer
-    pure  native bxor    xor                          :: Integer -> Integer -> Integer
-    pure  native bcmpl   not                          :: Integer -> Integer 
+    pure  native (.|.)     or                         :: Integer -> Integer -> Integer
+    pure  native (.&.)    and                         :: Integer -> Integer -> Integer
+    pure  native xor    xor                           :: Integer -> Integer -> Integer
+    pure  native complement   not                     :: Integer -> Integer
     -- miscellanous
-    pure native bitLength                            :: Integer -> Int
-    pure native toString                             :: Integer -> String
-    pure native sign    signum                       :: Integer -> Int
-    pure native long    longValue                    :: Integer -> Long
-    pure native int     intValue                     :: Integer -> Int
-    pure native double  doubleValue                  :: Integer -> Double
-    pure native hashCode                             :: Integer -> Int
-    pure native gcd                                  :: Integer -> Integer -> Integer
+    pure native bitLength                             :: Integer -> Int
+    pure native toString                              :: Integer -> String
+    pure native sign    signum                        :: Integer -> Int
+    pure native long    longValue                     :: Integer -> Long
+    pure native int     intValue                      :: Integer -> Int
+    pure native double  doubleValue                   :: Integer -> Double
+    pure native hashCode                              :: Integer -> Int
+    pure native gcd                                   :: Integer -> Integer -> Integer
 
 {--
  * 'Long' values are based on Java's primitive @long@ values.
@@ -328,13 +347,25 @@ data Long = native long  where
     --- Uses a java cast to convert a 'Long' to an 'Int'. This is a _narrowing primitive conversion_ in java parlance.
     pure native int "(int)"  ::          Long -> Int
     --- Computes binary _or_ of two long integers. Uses the java @|@-operator.
-    pure native bor  "|" :: Long -> Long -> Long
+    pure native (.|.)  "|" :: Long -> Long -> Long
     --- Computes binary _exclusive or_ of two long integers. Uses the java @^@-operator.
-    pure native bxor "^" :: Long -> Long -> Long
+    pure native xor "^" :: Long -> Long -> Long
     --- Computes binary _and_ of two integers. Uses the java @&@-operator.
-    pure native band "&" :: Long -> Long -> Long
+    pure native (.&.) "&" :: Long -> Long -> Long
+
+    pure native shiftL "<<" :: Long -> Int -> Long
+
+    pure native shiftR ">>" :: Long -> Int -> Long
+
+    --- unsigned right shift
+    pure native ushiftR ">>>" :: Long -> Int -> Long
+
+    pure native complement "~" :: Long -> Long
+
+    pure native size java.lang.Long.SIZE :: Int
+
     --- hash code is upper half and lower half xor'ed
-    hashCode l = (int l).bxor (int (l `bshr` 32))
+    hashCode l = (int l).xor (int (l `shiftR` 32))
 
 --- 'Char' values are based on Java's primitive @char@ values.
 --- This type has many native functions based on the methods in @java.lang.Character@. 
@@ -444,8 +475,7 @@ data Char = native char where
     -}
     pure native isSurrogatePair  java.lang.Character.isSurrogatePair :: Char -> Char -> Bool
     
-
-{-- 
+{--
     'String' values are based on Java\'s @java.lang.String@ objects.
     'String' is an alias for 'StringJ' 'Char'
     -}
@@ -1183,11 +1213,13 @@ instance Integral Integer where
     fromInt i = Int.big i
     fromInteger b = b           -- identity
     big b     = b               -- i am already big
+    even n = (n Integer.`.&.` one) == zero
+    odd  n = (n Integer.`.&.` one) != zero
 
 
 toInteger = Integral.big
 
---- Class 'Integral' provides bit arithmetic, division and remainder operations for integral numbers.
+--- Class 'Integral' provides division and remainder operations for integral numbers.
 class Integral Num integ => integ where
     --- integer division
     div, quot :: integ -> integ -> integ
@@ -1212,22 +1244,6 @@ class Integral Num integ => integ where
                     q | (a >= zero) == (b >= zero) = q              -- a and b have same sign
                       | q * b       == a           = q
                       | otherwise                  = q-one
-
-    --- binary and, supposed to work like Java @&@ on all integral types
-    band :: integ -> integ -> integ
-    --- binary exclusive or, supposed to work like Java @^@ on all integral types
-    bxor :: integ -> integ -> integ
-    --- binary or, supposed to work like Java @|@ on all integral types
-    bor  :: integ -> integ -> integ
-    --- binary left shift, supposed to work like Java @<<@ on all integral types
-    bshl :: integ -> Int -> integ
-    --- binary right shift, supposed to work like Java @>>@ on all integral types
-    bshr :: integ -> Int -> integ
-    --- unsigned right shift, supposed to work like Java @>>>@ on all integral types
-    ushr :: integ -> Int -> integ
-    --- one's complement, supposed to work like Java operator @~@
-    bcmpl :: integ -> integ
-    bcmpl x = x `bxor` fromInt (-1)
 
     --- every integral number can be converted to a big 'Integer'
     big :: integ -> Integer
@@ -1257,10 +1273,6 @@ class Integral Num integ => integ where
         | x == zero || y == zero = zero
         | otherwise              =  abs ((x `quot` (gcd x y)) * y)
 
-    even, odd :: integ -> Bool
-    even n = n `band` one == zero
-    odd  n = n `band` one != zero
-    
     --- @ x ^ n @  raise _x_ to the _n_-th power
     --- The exponent must be positive. 
     (^) :: Num a => a -> integ -> a
@@ -1269,7 +1281,10 @@ class Integral Num integ => integ where
         | y0 == 0   = 1
         | otherwise = powf x0 y0
     
-    --- helper for 'Integral.^'    
+    even, odd :: integ -> Bool
+
+
+    --- helper for 'Integral.^'
     private powf :: Num a => a -> integ -> a
     private powf x y 
         | even y    = powf (x * x) (y `quot` 2)
@@ -1491,22 +1506,20 @@ instance Enum Long where
 instance Integral Int where
     pure native rem  %    :: Int -> Int -> Int
     pure native quot /    :: Int -> Int -> Int
-    pure native bshl "<<" :: Int -> Int -> Int
-    pure native bshr ">>" :: Int -> Int -> Int
-    --- unsigned right shift
-    pure native ushr ">>>" :: Int -> Int -> Int
-    pure native bcmpl "~" :: Int -> Int
+
+    even n = (n Int.`.&.` one) == zero
+    odd  n = (n Int.`.&.` one) != zero
+
     big l = Integer.valueOf l.long
+
 
 instance Integral Long where
     pure native rem %      :: Long -> Long -> Long
     pure native quot /     :: Long -> Long -> Long
-    pure native bshl "<<"  :: Long -> Int -> Long
-    pure native bshr ">>"  :: Long -> Int -> Long
-    pure native bcmpl "~"  :: Long -> Long
+    even n = (n Long.`.&.` one) == zero
+    odd  n = (n Long.`.&.` one) != zero
     big l = Integer.valueOf l
-    --- unsigned right shift
-    pure native ushr ">>>" :: Long -> Int -> Long
+
 
 --############# Bool instances ########################################
 


### PR DESCRIPTION
1. Added class `Bits` in Data.Bits
2. Removed bitwise operations from Integral
3. All the usages of existing bitwise functions are replaced with these new functions
4. `even` and `odd` functions are still in Integral but they don't have default implementations. They are implemented in respective instances using `.&.`.

@Ingo60 Could you please review?
