### PR TITLE
Add java to frege and frege to java collection conversion methods

### DIFF
--- a/frege/java/Util.fr
+++ b/frege/java/Util.fr
@@ -26,23 +26,23 @@ data Enumeration e = native java.util.Enumeration where
                 loop acc = do
                     more <- enum.hasMoreElements
                     if more
-                    then do
-                        elem <- enum.nextElement   
+                      then do
+                        elem <- enum.nextElement
                         loop (elem:acc)
                     else return (reverse acc)
 
 {--
-    A value of this type is used to generate a stream of pseudorandom numbers. 
-    The type uses a 48-bit seed, which is modified using a linear congruential formula. 
+    A value of this type is used to generate a stream of pseudorandom numbers.
+    The type uses a 48-bit seed, which is modified using a linear congruential formula.
     (See Donald Knuth, The Art of Computer Programming, Volume 2, Section 3.2.1.)
 
-    If two 'Random' values are created with the same seed, 
-    and the same sequence of method calls is made for each, 
-    they will generate and return identical sequences of numbers. 
-    In order to guarantee this property, particular algorithms are 
-    specified for the class Random. 
+    If two 'Random' values are created with the same seed,
+    and the same sequence of method calls is made for each,
+    they will generate and return identical sequences of numbers.
+    In order to guarantee this property, particular algorithms are
+    specified for the class Random.
 
-    Many applications will find the function 'frege.prelude.Math#random' 
+    Many applications will find the function 'frege.prelude.Math#random'
     simpler to use.
 -}
 data Random = native java.util.Random  where
@@ -544,7 +544,13 @@ data LinkedHashMap k v = native java.util.LinkedHashMap where
 
   native containsValue :: Mutable s (LinkedHashMap k v) -> Object -> ST s Bool
 
-  native get :: Mutable s (LinkedHashMap k v) -> Object -> ST s v
+  native get :: Mutable s (LinkedHashMap k v) -> a -> ST s v
+
+  fromList :: [(k, v)] -> STMutable s (LinkedHashMap k v)
+  fromList xs = do
+    m <- LinkedHashMap.new ()
+    m.addAllFromList xs
+    return m
 
 instance Serializable (LinkedHashMap k v)
 
@@ -699,6 +705,12 @@ data IdentityHashMap k v = native java.util.IdentityHashMap where
 
   native values :: Mutable s (IdentityHashMap k v) -> STMutable s (Collection v)
 
+  fromList :: [(k, v)] -> STMutable s (IdentityHashMap k v)
+  fromList xs = do
+    m <- IdentityHashMap.new ()
+    m.addAllFromList xs
+    return m
+
 instance Serializable (IdentityHashMap k v)
 
 {--
@@ -842,13 +854,13 @@ data HashMap k v = native java.util.HashMap where
 
   native clone :: Mutable s (HashMap k v) -> ST s Object
 
-  native containsKey :: Mutable s (HashMap k v) -> Object -> ST s Bool
+  native containsKey :: Mutable s (HashMap k v) -> a -> ST s Bool
 
-  native containsValue :: Mutable s (HashMap k v) -> Object -> ST s Bool
+  native containsValue :: Mutable s (HashMap k v) -> a -> ST s Bool
 
   native entrySet :: Mutable s (HashMap k v) -> STMutable s (Set (MapEntry k v))
 
-  native get :: Mutable s (HashMap k v) -> Object -> ST s v
+  native get :: Mutable s (HashMap k v) -> a -> ST s v
 
   native isEmpty :: Mutable s (HashMap k v) -> ST s Bool
 
@@ -863,6 +875,12 @@ data HashMap k v = native java.util.HashMap where
   native size :: Mutable s (HashMap k v) -> ST s Int
 
   native values :: Mutable s (HashMap k v) -> STMutable s (Collection v)
+
+  fromList :: [(k, v)] -> STMutable s (HashMap k v)
+  fromList xs = do
+    m <- HashMap.new ()
+    m.addAllFromList xs
+    return m
 
 instance Serializable (HashMap k v)
 
@@ -888,9 +906,9 @@ data TreeMap k v = native java.util.TreeMap where
 
   native comparator :: Mutable s (TreeMap k v) -> ST s (Comparator k)
 
-  native containsKey :: Mutable s (TreeMap k v) -> Object -> ST s Bool
+  native containsKey :: Mutable s (TreeMap k v) -> a -> ST s Bool
 
-  native containsValue :: Mutable s (TreeMap k v) -> Object -> ST s Bool
+  native containsValue :: Mutable s (TreeMap k v) -> a -> ST s Bool
 
   native descendingKeySet :: Mutable s (TreeMap k v) -> STMutable s (NavigableSet k)
 
@@ -906,7 +924,7 @@ data TreeMap k v = native java.util.TreeMap where
 
   native floorKey :: Mutable s (TreeMap k v) -> k -> ST s k
 
-  native get :: Mutable s (TreeMap k v) -> Object -> ST s v
+  native get :: Mutable s (TreeMap k v) -> a -> ST s v
 
   native headMap :: Mutable s (TreeMap k v) -> k -> Bool -> STMutable s (NavigableMap k v)
                   | Mutable s (TreeMap k v) -> k -> STMutable s (SortedMap k v)
@@ -935,7 +953,7 @@ data TreeMap k v = native java.util.TreeMap where
 
   native putAll :: Mutable s (TreeMap k v) -> Mutable s (Map k v) -> ST s ()
 
-  native remove :: Mutable s (TreeMap k v) -> Object -> ST s v
+  native remove :: Mutable s (TreeMap k v) -> a -> ST s v
 
   native size :: Mutable s (TreeMap k v) -> ST s Int
 
@@ -946,6 +964,12 @@ data TreeMap k v = native java.util.TreeMap where
                   | Mutable s (TreeMap k v) -> k -> STMutable s (SortedMap k v)
 
   native values :: Mutable s (TreeMap k v) -> STMutable s (Collection v)
+
+  fromList :: [(k, v)] -> STMutable s (TreeMap k v)
+  fromList xs = do
+    m <- TreeMap.new ()
+    m.addAllFromList xs
+    return m
 
 instance Serializable (TreeMap k v)
 
@@ -1349,6 +1373,13 @@ data Collection e = native java.util.Collection where
   native toArray :: Mutable s (Collection e) -> STMutable s (JArray Object)
                   | Mutable s (Collection e) -> Mutable s (JArray Object) -> STMutable s (JArray Object)
 
+  addAllFromList :: Mutable s (Collection a) -> [a] -> ST s ()
+  addAllFromList collection [] = return ()
+  addAllFromList collection (x:xs) = collection.add x >> addAllFromList collection xs
+
+  toList :: Mutable s (Collection e) -> ST s [e]
+  toList collection = collection.iterator >>= Iterator.toList
+
 {--
  A specialized Map implementation for use with enum type keys.
  More: 'https://docs.oracle.com/javase/7/docs/api/java/util/EnumMap.html JavaDoc'
@@ -1369,9 +1400,9 @@ data EnumMap k v = native java.util.EnumMap where
 
   native entrySet :: Mutable s (EnumMap k v) -> STMutable s (Set (MapEntry k v))
 
-  native equals :: Mutable s (EnumMap k v) -> Object -> ST s Bool
+  native equals :: Mutable s (EnumMap k v) -> a -> ST s Bool
 
-  native get :: Mutable s (EnumMap k v) -> Object -> ST s v
+  native get :: Mutable s (EnumMap k v) -> a -> ST s v
 
   native hashCode :: Mutable s (EnumMap k v) -> ST s Int
 
@@ -1381,7 +1412,7 @@ data EnumMap k v = native java.util.EnumMap where
 
   native putAll :: Mutable s (EnumMap k v) -> Mutable s (Map k v) -> ST s ()
 
-  native remove :: Mutable s (EnumMap k v) -> Object -> ST s v
+  native remove :: Mutable s (EnumMap k v) -> a -> ST s v
 
   native size :: Mutable s (EnumMap k v) -> ST s Int
 
@@ -1395,7 +1426,7 @@ instance Serializable (EnumMap k v)
 -}
 data Observer = native java.util.Observer where
 
-  native update :: Mutable s Observer -> Mutable s Observable -> Object -> ST s ()
+  native update :: Mutable s Observer -> Mutable s Observable -> a -> ST s ()
 
 {--
   Hash table based implementation of the Map interface, with weak keys.
@@ -1410,13 +1441,13 @@ data WeakHashMap k v = native java.util.WeakHashMap where
 
   native clear :: Mutable s (WeakHashMap k v) -> ST s ()
 
-  native containsKey :: Mutable s (WeakHashMap k v) -> Object -> ST s Bool
+  native containsKey :: Mutable s (WeakHashMap k v) -> a -> ST s Bool
 
-  native containsValue :: Mutable s (WeakHashMap k v) -> Object -> ST s Bool
+  native containsValue :: Mutable s (WeakHashMap k v) -> a -> ST s Bool
 
   native entrySet :: Mutable s (WeakHashMap k v) -> STMutable s (Set (MapEntry k v))
 
-  native get :: Mutable s (WeakHashMap k v) -> Object -> ST s v
+  native get :: Mutable s (WeakHashMap k v) -> a -> ST s v
 
   native isEmpty :: Mutable s (WeakHashMap k v) -> ST s Bool
 
@@ -1426,7 +1457,7 @@ data WeakHashMap k v = native java.util.WeakHashMap where
 
   native putAll :: Mutable s (WeakHashMap k v) -> Mutable s (Map k v) -> ST s ()
 
-  native remove :: Mutable s (WeakHashMap k v) -> Object -> ST s v
+  native remove :: Mutable s (WeakHashMap k v) -> a -> ST s v
 
   native size :: Mutable s (WeakHashMap k v) -> ST s Int
 
@@ -1482,7 +1513,7 @@ data LinkedList e = native java.util.LinkedList where
 
   native clone :: Mutable s (LinkedList e) -> ST s Object
 
-  native contains :: Mutable s (LinkedList e) -> Object -> ST s Bool
+  native contains :: Mutable s (LinkedList e) -> a -> ST s Bool
 
   native descendingIterator :: Mutable s (LinkedList e) -> STMutable s (Iterator e)
 
@@ -1494,9 +1525,9 @@ data LinkedList e = native java.util.LinkedList where
 
   native getLast :: Mutable s (LinkedList e) -> ST s e
 
-  native indexOf :: Mutable s (LinkedList e) -> Object -> ST s Int
+  native indexOf :: Mutable s (LinkedList e) -> a -> ST s Int
 
-  native lastIndexOf :: Mutable s (LinkedList e) -> Object -> ST s Int
+  native lastIndexOf :: Mutable s (LinkedList e) -> a -> ST s Int
 
   native listIterator :: Mutable s (LinkedList e) -> Int -> STMutable s (ListIterator e)
 
@@ -1524,15 +1555,15 @@ data LinkedList e = native java.util.LinkedList where
 
   native remove :: Mutable s (LinkedList e) -> Int -> ST s e
                  | Mutable s (LinkedList e) -> ST s e
-                 | Mutable s (LinkedList e) -> Object -> ST s Bool
+                 | Mutable s (LinkedList e) -> a -> ST s Bool
 
   native removeFirst :: Mutable s (LinkedList e) -> ST s e
 
-  native removeFirstOccurrence :: Mutable s (LinkedList e) -> Object -> ST s Bool
+  native removeFirstOccurrence :: Mutable s (LinkedList e) -> a -> ST s Bool
 
   native removeLast :: Mutable s (LinkedList e) -> ST s e
 
-  native removeLastOccurrence :: Mutable s (LinkedList e) -> Object -> ST s Bool
+  native removeLastOccurrence :: Mutable s (LinkedList e) -> a -> ST s Bool
 
   native set :: Mutable s (LinkedList e) -> Int -> e -> ST s e
 
@@ -1541,6 +1572,11 @@ data LinkedList e = native java.util.LinkedList where
   native toArray :: Mutable s (LinkedList e) -> Mutable s (JArray Object) -> STMutable s (JArray Object)
                   | Mutable s (LinkedList e) -> STMutable s (JArray Object)
 
+  fromList :: [a] -> STMutable s (LinkedList a)
+  fromList xs = do
+      jlist <- LinkedList.new ()
+      jlist.addAllFromList xs
+      return jlist
 
 instance Serializable (LinkedList e)
 
@@ -1565,29 +1601,29 @@ data ArrayList e = native java.util.ArrayList where
 
   native clone :: Mutable s (ArrayList e) -> ST s Object
 
-  native contains :: Mutable s (ArrayList e) -> Object -> ST s Bool
+  native contains :: Mutable s (ArrayList e) -> a -> ST s Bool
 
   native ensureCapacity :: Mutable s (ArrayList e) -> Int -> ST s ()
 
   native get :: Mutable s (ArrayList e) -> Int -> ST s e
 
-  native indexOf :: Mutable s (ArrayList e) -> Object -> ST s Int
+  native indexOf :: Mutable s (ArrayList e) -> a -> ST s Int
 
   native isEmpty :: Mutable s (ArrayList e) -> ST s Bool
 
   native iterator :: Mutable s (ArrayList e) -> STMutable s (Iterator e)
 
-  native lastIndexOf :: Mutable s (ArrayList e) -> Object -> ST s Int
+  native lastIndexOf :: Mutable s (ArrayList e) -> a -> ST s Int
 
   native listIterator :: Mutable s (ArrayList e) -> Int -> STMutable s (ListIterator e)
                        | Mutable s (ArrayList e) -> STMutable s (ListIterator e)
 
   native remove :: Mutable s (ArrayList e) -> Int -> ST s e
-                 | Mutable s (ArrayList e) -> Object -> ST s Bool
+                 | Mutable s (ArrayList e) -> a -> ST s Bool
 
-  native removeAll :: Mutable s (ArrayList e) -> Mutable s (Collection Object) -> ST s Bool
+  native removeAll :: Mutable s (ArrayList e) -> Mutable s (Collection a) -> ST s Bool
 
-  native retainAll :: Mutable s (ArrayList e) -> Mutable s (Collection Object) -> ST s Bool
+  native retainAll :: Mutable s (ArrayList e) -> Mutable s (Collection a) -> ST s Bool
 
   native set :: Mutable s (ArrayList e) -> Int -> e -> ST s e
 
@@ -1599,6 +1635,12 @@ data ArrayList e = native java.util.ArrayList where
                   | Mutable s (ArrayList e) -> Mutable s (JArray Object) -> STMutable s (JArray Object)
 
   native trimToSize :: Mutable s (ArrayList e) -> ST s ()
+
+  fromList :: [a] -> STMutable s (ArrayList a)
+  fromList xs = do
+      jlist <- ArrayList.new xs.length
+      jlist.addAllFromList xs
+      return jlist
 
 instance Serializable (ArrayList e)
 
@@ -1658,9 +1700,9 @@ data Vector e = native java.util.Vector where
 
   native clone :: Mutable s (Vector e) -> ST s Object
 
-  native contains :: Mutable s (Vector e) -> Object -> ST s Bool
+  native contains :: Mutable s (Vector e) -> a -> ST s Bool
 
-  native containsAll :: Mutable s (Vector e) -> Mutable s (Collection Object) -> ST s Bool
+  native containsAll :: Mutable s (Vector e) -> Mutable s (Collection a) -> ST s Bool
 
   native copyInto :: Mutable s (Vector e) -> Mutable s (JArray Object) -> ST s ()
 
@@ -1670,7 +1712,7 @@ data Vector e = native java.util.Vector where
 
   native ensureCapacity :: Mutable s (Vector e) -> Int -> ST s ()
 
-  native equals :: Mutable s (Vector e) -> Object -> ST s Bool
+  native equals :: Mutable s (Vector e) -> a -> ST s Bool
 
   native firstElement :: Mutable s (Vector e) -> ST s e
 
@@ -1678,8 +1720,8 @@ data Vector e = native java.util.Vector where
 
   native hashCode :: Mutable s (Vector e) -> ST s Int
 
-  native indexOf :: Mutable s (Vector e) -> Object -> ST s Int
-                  | Mutable s (Vector e) -> Object -> Int -> ST s Int
+  native indexOf :: Mutable s (Vector e) -> a -> ST s Int
+                  | Mutable s (Vector e) -> a -> Int -> ST s Int
 
   native insertElementAt :: Mutable s (Vector e) -> e -> Int -> ST s ()
 
@@ -1689,24 +1731,24 @@ data Vector e = native java.util.Vector where
 
   native lastElement :: Mutable s (Vector e) -> ST s e
 
-  native lastIndexOf :: Mutable s (Vector e) -> Object -> Int -> ST s Int
-                      | Mutable s (Vector e) -> Object -> ST s Int
+  native lastIndexOf :: Mutable s (Vector e) -> a -> Int -> ST s Int
+                      | Mutable s (Vector e) -> a -> ST s Int
 
   native listIterator :: Mutable s (Vector e) -> STMutable s (ListIterator e)
                        | Mutable s (Vector e) -> Int -> STMutable s (ListIterator e)
 
-  native remove :: Mutable s (Vector e) -> Object -> ST s Bool
+  native remove :: Mutable s (Vector e) -> a -> ST s Bool
                  | Mutable s (Vector e) -> Int -> ST s e
 
-  native removeAll :: Mutable s (Vector e) -> Mutable s (Collection Object) -> ST s Bool
+  native removeAll :: Mutable s (Vector e) -> Mutable s (Collection a) -> ST s Bool
 
   native removeAllElements :: Mutable s (Vector e) -> ST s ()
 
-  native removeElement :: Mutable s (Vector e) -> Object -> ST s Bool
+  native removeElement :: Mutable s (Vector e) -> a -> ST s Bool
 
   native removeElementAt :: Mutable s (Vector e) -> Int -> ST s ()
 
-  native retainAll :: Mutable s (Vector e) -> Mutable s (Collection Object) -> ST s Bool
+  native retainAll :: Mutable s (Vector e) -> Mutable s (Collection a) -> ST s Bool
 
   native set :: Mutable s (Vector e) -> Int -> e -> ST s e
 
@@ -1725,6 +1767,12 @@ data Vector e = native java.util.Vector where
 
   native trimToSize :: Mutable s (Vector e) -> ST s ()
 
+  fromList :: [a] -> STMutable s (Vector a)
+  fromList xs = do
+      jlist <- Vector.new xs.length
+      jlist.addAllFromList xs
+      return jlist
+
 instance Serializable (Vector e)
 
 {--
@@ -1735,15 +1783,15 @@ data Map k v = native java.util.Map where
 
   native clear :: Mutable s (Map k v) -> ST s ()
 
-  native containsKey :: Mutable s (Map k v) -> Object -> ST s Bool
+  native containsKey :: Mutable s (Map k v) -> a -> ST s Bool
 
-  native containsValue :: Mutable s (Map k v) -> Object -> ST s Bool
+  native containsValue :: Mutable s (Map k v) -> a -> ST s Bool
 
   native entrySet :: Mutable s (Map k v) -> STMutable s (Set (MapEntry k v))
 
-  native equals :: Mutable s (Map k v) -> Object -> ST s Bool
+  native equals :: Mutable s (Map k v) -> a -> ST s Bool
 
-  native get :: Mutable s (Map k v) -> Object -> ST s v
+  native get :: Mutable s (Map k v) -> a -> ST s v
 
   native hashCode :: Mutable s (Map k v) -> ST s Int
 
@@ -1755,11 +1803,25 @@ data Map k v = native java.util.Map where
 
   native putAll :: Mutable s (Map k v) -> Mutable s (Map k v) -> ST s ()
 
-  native remove :: Mutable s (Map k v) -> Object -> ST s v
+  native remove :: Mutable s (Map k v) -> a -> ST s v
 
   native size :: Mutable s (Map k v) -> ST s Int
 
   native values :: Mutable s (Map k v) -> STMutable s (Collection v)
+
+  addAllFromList :: Mutable s (Map k v) -> [(k, v)] -> ST s ()
+  addAllFromList jmap [] = return ()
+  addAllFromList jmap ((k, v): xs) = jmap.put k v >> addAllFromList jmap xs
+
+  toList :: Mutable s (Map k v) -> ST s [(k, v)]
+  toList jmap = do
+        isEmpty <- jmap.isEmpty
+        if isEmpty
+          then return []
+          else do
+            keySet <- jmap.keySet
+            keys <- keySet.iterator >>= Iterator.toList
+            mapM (\k -> jmap.get k >>= (\v -> return (k, v))) keys
 
 {--
  A map entry (key-value pair).
@@ -1767,7 +1829,7 @@ data Map k v = native java.util.Map where
 -}
 data MapEntry k v = native java.util.Map.Entry where
 
-  native equals :: Mutable s (MapEntry k v) -> Object -> ST s Bool
+  native equals :: Mutable s (MapEntry k v) -> a -> ST s Bool
 
   native getKey :: Mutable s (MapEntry k v) -> ST s k
 
@@ -1785,15 +1847,15 @@ data AbstractMap k v = native java.util.AbstractMap where
 
   native clear :: Mutable s (AbstractMap k v) -> ST s ()
 
-  native containsKey :: Mutable s (AbstractMap k v) -> Object -> ST s Bool
+  native containsKey :: Mutable s (AbstractMap k v) -> a -> ST s Bool
 
-  native containsValue :: Mutable s (AbstractMap k v) -> Object -> ST s Bool
+  native containsValue :: Mutable s (AbstractMap k v) -> a -> ST s Bool
 
   native entrySet :: Mutable s (AbstractMap k v) -> STMutable s (Set (MapEntry k v))
 
-  native equals :: Mutable s (AbstractMap k v) -> Object -> ST s Bool
+  native equals :: Mutable s (AbstractMap k v) -> a -> ST s Bool
 
-  native get :: Mutable s (AbstractMap k v) -> Object -> ST s v
+  native get :: Mutable s (AbstractMap k v) -> a -> ST s v
 
   native hashCode :: Mutable s (AbstractMap k v) -> ST s Int
 
@@ -1805,7 +1867,7 @@ data AbstractMap k v = native java.util.AbstractMap where
 
   native putAll :: Mutable s (AbstractMap k v) -> Mutable s (Map k v) -> ST s ()
 
-  native remove :: Mutable s (AbstractMap k v) -> Object -> ST s v
+  native remove :: Mutable s (AbstractMap k v) -> a -> ST s v
 
   native size :: Mutable s (AbstractMap k v) -> ST s Int
 
@@ -1870,6 +1932,15 @@ data Iterator e = native java.util.Iterator where
 
   native remove :: Mutable s (Iterator e) -> ST s ()
 
+  toList :: Mutable s (Iterator e) -> ST s [e]
+  toList itr = reverse <$> toList' []
+    where
+      toList' acc = do
+        hasNext <- itr.hasNext
+        if hasNext
+          then itr.next >>= (\item -> toList' (item : acc))
+          else return acc
+
 {--
  An ordered collection (also known as a sequence).
 
@@ -1885,33 +1956,33 @@ data List e = native java.util.List where
 
   native clear :: Mutable s (List e) -> ST s ()
 
-  native contains :: Mutable s (List e) -> Object -> ST s Bool
+  native contains :: Mutable s (List e) -> a -> ST s Bool
 
-  native containsAll :: Mutable s (List e) -> Mutable s (Collection Object) -> ST s Bool
+  native containsAll :: Mutable s (List e) -> Mutable s (Collection a) -> ST s Bool
 
-  native equals :: Mutable s (List e) -> Object -> ST s Bool
+  native equals :: Mutable s (List e) -> a -> ST s Bool
 
   native get :: Mutable s (List e) -> Int -> ST s e
 
   native hashCode :: Mutable s (List e) -> ST s Int
 
-  native indexOf :: Mutable s (List e) -> Object -> ST s Int
+  native indexOf :: Mutable s (List e) -> a -> ST s Int
 
   native isEmpty :: Mutable s (List e) -> ST s Bool
 
   native iterator :: Mutable s (List e) -> STMutable s (Iterator e)
 
-  native lastIndexOf :: Mutable s (List e) -> Object -> ST s Int
+  native lastIndexOf :: Mutable s (List e) -> a -> ST s Int
 
   native listIterator :: Mutable s (List e) -> STMutable s (ListIterator e)
                        | Mutable s (List e) -> Int -> STMutable s (ListIterator e)
 
-  native remove :: Mutable s (List e) -> Object -> ST s Bool
+  native remove :: Mutable s (List e) -> a -> ST s Bool
                  | Mutable s (List e) -> Int -> ST s e
 
-  native removeAll :: Mutable s (List e) -> Mutable s (Collection Object) -> ST s Bool
+  native removeAll :: Mutable s (List e) -> Mutable s (Collection a) -> ST s Bool
 
-  native retainAll :: Mutable s (List e) -> Mutable s (Collection Object) -> ST s Bool
+  native retainAll :: Mutable s (List e) -> Mutable s (Collection a) -> ST s Bool
 
   native set :: Mutable s (List e) -> Int -> e -> ST s e
 
@@ -1921,73 +1992,6 @@ data List e = native java.util.List where
 
   native toArray :: Mutable s (List e) -> STMutable s (JArray Object)
                   | Mutable s (List e) -> Mutable s (JArray Object) -> STMutable s (JArray Object)
-
-{--
-  An engine that performs match operations on a
-  'https://docs.oracle.com/javase/7/docs/api/java/lang/CharSequence.html character sequence' by interpreting a
-  'https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html Pattern'.
-
-  More: 'https://docs.oracle.com/javase/7/docs/api/java/util/regex/Matcher.html JavaDoc'
--}
-data RegexMatcher = native java.util.regex.Matcher where
-
-  native appendReplacement :: Mutable s RegexMatcher -> Mutable s StringBuffer -> String -> STMutable s RegexMatcher
-
-  native appendTail :: Mutable s RegexMatcher -> Mutable s StringBuffer -> STMutable s StringBuffer
-
-  native end :: Mutable s RegexMatcher -> Int -> ST s Int
-              | Mutable s RegexMatcher -> ST s Int
-
-  native find :: Mutable s RegexMatcher -> ST s Bool
-               | Mutable s RegexMatcher -> Int -> ST s Bool
-
-  native group :: Mutable s RegexMatcher -> String -> ST s String
-                | Mutable s RegexMatcher -> Int -> ST s String
-                | Mutable s RegexMatcher -> ST s String
-
-  native groupCount :: Mutable s RegexMatcher -> ST s Int
-
-  native hasAnchoringBounds :: Mutable s RegexMatcher -> ST s Bool
-
-  native hasTransparentBounds :: Mutable s RegexMatcher -> ST s Bool
-
-  native hitEnd :: Mutable s RegexMatcher -> ST s Bool
-
-  native lookingAt :: Mutable s RegexMatcher -> ST s Bool
-
-  native matches :: Mutable s RegexMatcher -> ST s Bool
-
-  native pattern :: Mutable s RegexMatcher -> ST s Regex
-
-  pure native quoteReplacement java.util.regex.Matcher.quoteReplacement :: String -> String
-
-  native region :: Mutable s RegexMatcher -> Int -> Int -> STMutable s RegexMatcher
-
-  native regionEnd :: Mutable s RegexMatcher -> ST s Int
-
-  native regionStart :: Mutable s RegexMatcher -> ST s Int
-
-  native replaceAll :: Mutable s RegexMatcher -> String -> ST s String
-
-  native replaceFirst :: Mutable s RegexMatcher -> String -> ST s String
-
-  native requireEnd :: Mutable s RegexMatcher -> ST s Bool
-
-  native reset :: Mutable s RegexMatcher -> CharSequence -> STMutable s RegexMatcher
-                | Mutable s RegexMatcher -> STMutable s RegexMatcher
-
-  native start :: Mutable s RegexMatcher -> ST s Int
-                | Mutable s RegexMatcher -> Int -> ST s Int
-
-  native toMatchResult :: Mutable s RegexMatcher -> ST s MatchResult
-
-  native toString :: Mutable s RegexMatcher -> ST s String
-
-  native useAnchoringBounds :: Mutable s RegexMatcher -> Bool -> STMutable s RegexMatcher
-
-  native usePattern :: Mutable s RegexMatcher -> Regex -> STMutable s RegexMatcher
-
-  native useTransparentBounds :: Mutable s RegexMatcher -> Bool -> STMutable s RegexMatcher
 
 {--
   Builder is used to build instances of Locale from values configured by the setters.
@@ -2037,11 +2041,11 @@ data Set e = native java.util.Set where
 
   native clear :: Mutable s (Set e) -> ST s ()
 
-  native contains :: Mutable s (Set e) -> Object -> ST s Bool
+  native contains :: Mutable s (Set e) -> a -> ST s Bool
 
-  native containsAll :: Mutable s (Set e) -> Mutable s (Collection Object) -> ST s Bool
+  native containsAll :: Mutable s (Set e) -> Mutable s (Collection a) -> ST s Bool
 
-  native equals :: Mutable s (Set e) -> Object -> ST s Bool
+  native equals :: Mutable s (Set e) -> a -> ST s Bool
 
   native hashCode :: Mutable s (Set e) -> ST s Int
 
@@ -2049,16 +2053,19 @@ data Set e = native java.util.Set where
 
   native iterator :: Mutable s (Set e) -> STMutable s (Iterator e)
 
-  native remove :: Mutable s (Set e) -> Object -> ST s Bool
+  native remove :: Mutable s (Set e) -> a -> ST s Bool
 
-  native removeAll :: Mutable s (Set e) -> Mutable s (Collection Object) -> ST s Bool
+  native removeAll :: Mutable s (Set e) -> Mutable s (Collection a) -> ST s Bool
 
-  native retainAll :: Mutable s (Set e) -> Mutable s (Collection Object) -> ST s Bool
+  native retainAll :: Mutable s (Set e) -> Mutable s (Collection a) -> ST s Bool
 
   native size :: Mutable s (Set e) -> ST s Int
 
   native toArray :: Mutable s (Set e) -> STMutable s (JArray Object)
                   | Mutable s (Set e) -> Mutable s (JArray Object) -> STMutable s (JArray Object)
+
+  toList :: Mutable s (Set e) -> ST s [e]
+  toList set = set.iterator >>= Iterator.toList
 
 {--
   This class contains various methods for manipulating arrays (such as sorting and searching).
@@ -2067,7 +2074,7 @@ data Set e = native java.util.Set where
 -}
 data Arrays = pure native java.util.Arrays where
 
-  native asList java.util.Arrays.asList :: Mutable s (JArray Object) -> STMutable s (List t)
+  native asList java.util.Arrays.asList :: Mutable s (JArray t) -> STMutable s (List t)
 
   native binarySearch java.util.Arrays.binarySearch :: Mutable s (JArray Char) -> Int -> Int -> Char -> ST s Int
                                                      | Mutable s (JArray Char) -> Char -> ST s Int


### PR DESCRIPTION
1.  Add methods to convert from Frege list to Java collection and from Java collection to Frege list.
2. Java methods that take an `Object` now take a generic type parameter so that we don't have to convert Frege values into Java objects