### PR TITLE
#138 add getResource to native ClassLoader definition

### DIFF
--- a/frege/java/Lang.fr
+++ b/frege/java/Lang.fr
@@ -126,9 +126,12 @@ data Runnable = native java.lang.Runnable where
 
 private pure native md "frege.runtime.Meta.FregePackage.class" :: Class a
 
+import frege.java.Net (URL)
+
 data ClassLoader = mutable native java.lang.ClassLoader where
-        native getClassLoader :: Class a -> IO ClassLoader
-        current = getClassLoader md
+    native getClassLoader :: Class a -> IO ClassLoader
+    current = getClassLoader md
+    native getResource :: ClassLoader -> String -> IO URL
 
 protected data PrintStream = mutable native java.io.PrintStream
 


### PR DESCRIPTION
needed in many places, e.g. when loading fxml files for javafx from the classpath