### PR TITLE
fix a few small typos

### DIFF
--- a/doc/chapterdeclarations.tex
+++ b/doc/chapterdeclarations.tex
@@ -361,7 +361,7 @@ The generated code will contain the native type string and this will make the \j
 
 Note that \texttt{void} is not a valid native type name since \texttt{void} is not a proper type.
 
-For one and the same native type, more than one native data type declaration can exist. Becaue every reference type is its own supertype, the type checker will not regard those types as different (see also \autoref{polymorphism}).
+For one and the same native type, more than one native data type declaration can exist. Because every reference type is its own supertype, the type checker will not regard those types as different (see also \autoref{polymorphism}).
 
 Native data types can be used like any other type, for example, they can serve as building blocks for algebraic data types, or be parts of function types. However, since there is no constructor nor any knowledge about the implementation of the type, no pattern matching on values of native data types is possible. Basic operations on the type can be introduced with \hyperref[nativefun]{native function declarations}.
 
@@ -445,7 +445,7 @@ A \emph{class declaration} introduces a new class and the operations (\emph{clas
 \texttt{class} $C$ \hspace{0.2cm} ($S_1$ $u$,$\cdots$,$S_k$ $u$)  $=>$ $u$\hspace{0.2cm} \texttt{where} \hspace{0.2cm} \emph{decls}
 \end{quote}
 
-This introduces a new class name $C$ with class variabe $u$ and so called superclasses $S_i$.
+This introduces a new class name $C$ with class variable $u$ and so called superclasses $S_i$.
 
 A class variable stands for potential types that will be instances of the type class. It is also possible that the class variable is higher kinded, i.e. that it is applied to other types in the class operation annotations. The kind of the class variable must be the same in all class operations and in all superclasses.
 

--- a/doc/chaptermodules.tex
+++ b/doc/chaptermodules.tex
@@ -35,7 +35,7 @@ except the last one should be in lowercase. This is because the \java{}
 package name is derived from these components and \java{} has the
 convention that the package name should be all lowercase.
 
-Neither file name of the \frege{} source code file nor the path where that file is stored have to reflect or match the package name. However, the intermediate \java{} source file and the final class files are subject the the customs of \java{}. That means that the files reside in a path that resembles the package name and the file name is the class name plus a suffix.
+Neither file name of the \frege{} source code file nor the path where that file is stored have to reflect or match the package name. However, the intermediate \java{} source file and the final class files are subject to the customs of \java{}. That means that the files reside in a path that resembles the package name and the file name is the class name plus a suffix.
 
 \section{Execution of \frege{} Packages} \label{execution}
 
@@ -282,7 +282,7 @@ Hence, after the import of the example, the names \term{Rational.gcd}, \term{gre
 
 \subsection{Re-exporting imported items} \label{reexport}
 
-It is possible to have a packages re-export all or some of its imported items 
+It is possible to have a package re-export all or some of its imported items 
 along with the items declared in the package itself, if any\footnote{
 It is perfectly legal for a package to contain nothing but import declarations.}, 
 so that importing  packages can import many related items from possibly many different packages with one import.

--- a/frege/compiler/Typecheck.fr
+++ b/frege/compiler/Typecheck.fr
@@ -1302,7 +1302,7 @@ resolveOver v sym = do
                 return (Right x)
             _ -> do 
                 E.error v.pos (text "overloaded " <+> text (nicer v g) 
-                    <+>  text " is ambiguos at type "
+                    <+>  text " is ambiguous at type "
                     <+/> text (nicer sigma g)
                     </>  text "It could mean one of "
                     </>  stack [ text (nicer (Symbol.name s) g) 


### PR DESCRIPTION
Found a few small typos in the documentation.  (And one in a compiler error message.)