### PR TITLE
fix "no main manifest attribute" issue when build frege from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ COMPS   = frege/compiler
 FREGE    = $(JAVA) -Xss4m -Xmx1800m -cp build
 
 #	compile using the fregec.jar in the working directory
-FREGECJ  = $(FREGE)  -jar fregec.jar  -d build -hints
+FREGECJ  = $(FREGE)  -cp fregec.jar frege.compiler.Main -d build -hints
 
 #	compile compiler1 with fregec.jar, uses prelude sources from shadow/
 FREGEC0  = $(FREGECJ) -prefix a -sp shadow:.


### PR DESCRIPTION
the `frage-3.xx.vvv.jar` is not an executable jar file cause there is no `Main-Class` attribute in the `MANIFEST.MF` file

so when run `make runtime compiler` it will throw exception:

```java "-Dfrege.javac=internal" -Xss4m -Xmx1800m -cp build  -jar fregec.jar  -d build -hints -prefix a -sp shadow:.  -make frege.compiler.Main no main manifest attribute in fregec.jar```

so i think we should use `java -cp fregec.jar frege.compiler.Main` instead of use `java -jar fregec.jar` 