### PR TITLE
Implement Haskell Lambda Syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 before_script:
   - mkdir -p build dist doc
   # Get the latest fregec.jar to compile the compiler
-  - curl -L -o fregec.jar https://github.com/Frege/frege/releases/download/3.23.288/frege3.23.288-gaa3af0c.jar
+  - curl -L -o fregec.jar https://github.com/Frege/frege/releases/download/3.23.288/frege3.23.343-g9e41848.jar
 
 script:
   - make runtime fregec.jar dist

--- a/doc/chapterexpr.tex
+++ b/doc/chapterexpr.tex
@@ -341,9 +341,9 @@ The conditions will be checked in the order listed here and the first possible t
 Because the compiler creates functions for access to fields in \hyperref[fieldconstructor]{algebraic data types with field labels} that happen to have the same name as the field label, this syntax is most prominent for extraction of field values.
 
 \label{confusedots}For \hyperref[qualified names]{lexical reasons}, when $e$ is a nullary value constructor such as \texttt{Nothing} one cannot write for instance \texttt{Nothing.show} as a shorthand for \texttt{Show.show Nothing}
-This is because the lexical analyzer will tokenize this as \nont{qvarid}
-and then during name resolution \texttt{Nothing} would be interpreted as name of a type or name space (which would probably fail).
-One can avoid this by writing one of \texttt{Nothing . show} (with space before the dot so as to make interpretation as qualified variable impossible) or \texttt{(Nothing).show}
+This is because the lexical analyzer will tokenize this as qualifier (\nont{qvarid})
+and then during name resolution \texttt{Nothing.} would be interpreted as name of a type or name space (which would probably fail).
+One can avoid this by writing one of \texttt{Nothing .show} (with space before the dot so as to make interpretation as qualified variable impossible) or \texttt{(Nothing).show}
 
 \subsection{Field Existence Test} \label{field existence}
 \index{expression!primary!field existence}
@@ -578,17 +578,16 @@ $1$& right & \texttt{\$} & application\\
 A lambda expression defines an anonymous function.
 
 \begin{flushleft}
-\rul{lambda} \sym{$\backslash$} \nont{pattern} \nont{lambda}
-  \alt \sym{$\backslash$} \nont{pattern} \sym{->} \nont{expr}
+\rul{lambda} \sym{$\backslash$} \nont{lpats} \nont{lambda}
+  \alt \sym{$\backslash$} \nont{lpats} \sym{->} \nont{expr}
 \end{flushleft}
 
-The syntax of patterns and semantics of pattern matching are explained below, see \autoref{patternmatch}.
+The syntax of patterns (\nont{lpats})and semantics of pattern matching are explained below, see \autoref{patternmatch}.
 
-A lambda expression $\backslash{}p_1\rightarrow{}\backslash{}p_2 \rightarrow{}\cdots{}\backslash{}p_k \rightarrow{} e$ can be abbreviated\\ $\backslash{}p_1 \backslash{}p_2 \cdots{} \backslash{}p_k \rightarrow{} e$.
+A lambda expression $\backslash{}p_1\rightarrow{}\backslash{}p_2 \rightarrow{}\cdots{}\backslash{}p_k \rightarrow{} e$ can be abbreviated\\ $\backslash{}p_1 \backslash{}p_2 \cdots{} \backslash{}p_k \rightarrow{} e$ or $\backslash{}p_1 p_2 \cdots{} p_k \rightarrow{} e$ 
 
 A lambda expression $\backslash{}p \rightarrow{} e$ has type $a \rightarrow{} b$ where $a$ is the type of the pattern $p$ and $b$ the type of the expression $e$.
 
-\hasdiff{Each pattern must be introduced with a backslash. Separated this way, even complex patterns don't need parentheses around them, thus something like \texttt{$\backslash$x:\_ $\rightarrow$ x} is valid.}
 
 \trans{
 Application of a lambda expression is equivalent to a case expression (see \autoref{caseex})\\
@@ -728,6 +727,8 @@ Patterns have this syntax:
 
  \rul{pvar} \nont{varid}   \gcom{variable}
     \alt \regex{\_}           \gcom{anonymous variable}\\
+
+\rul{lpats} \more{\nont{strictpattern}}
 
 \rul{patternfields} \liste{\nont{varid}\sym{=}\nont{pattern}}{\sym{,}}\\
 \end{flushleft}

--- a/frege/compiler/grammar/Frege.fr
+++ b/frege/compiler/grammar/Frege.fr
@@ -109,6 +109,7 @@ data YYsi res tok  =
 	| YYNTannoitem Token
 	| YYNTannoitems [Token]
 	| YYNTannotation [Def]
+	| YYNTapats [Exp]
 	| YYNTappex Exp
 	| YYNTbinex Exp
 	| YYNTboundvar String
@@ -163,6 +164,7 @@ data YYsi res tok  =
 	| YYNTjtokens [Token]
 	| YYNTkind Kind
 	| YYNTlambda Exp
+	| YYNTlambdabody Exp
 	| YYNTlcqual Qual
 	| YYNTlcquals [Qual]
 	| YYNTletdef [Def]
@@ -240,6 +242,7 @@ showsi (YYStart  _) = "%start ";
 	showsi (YYNTannoitem _) = "<annoitem>";
 	showsi (YYNTannoitems _) = "<annoitems>";
 	showsi (YYNTannotation _) = "<annotation>";
+	showsi (YYNTapats _) = "<apats>";
 	showsi (YYNTappex _) = "<appex>";
 	showsi (YYNTbinex _) = "<binex>";
 	showsi (YYNTboundvar _) = "<boundvar>";
@@ -294,6 +297,7 @@ showsi (YYStart  _) = "%start ";
 	showsi (YYNTjtokens _) = "<jtokens>";
 	showsi (YYNTkind _) = "<kind>";
 	showsi (YYNTlambda _) = "<lambda>";
+	showsi (YYNTlambdabody _) = "<lambdabody>";
 	showsi (YYNTlcqual _) = "<lcqual>";
 	showsi (YYNTlcquals _) = "<lcquals>";
 	showsi (YYNTletdef _) = "<letdef>";
@@ -545,7 +549,7 @@ private yyaction25 t = YYAction (-186);
 private yyaction26 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
-  '{' -> YYAction (-380);
+  '{' -> YYAction (-383);
   _ ->   case yytoken t of {
     VARID -> YYAction 74;
     CONID -> YYAction 75;
@@ -722,12 +726,10 @@ private yyaction43 t =   case yychar t of {
 private yyaction44 t = YYAction (-195);
 private yyaction45 t = YYAction (-194);
 private yyaction46 t =   case yychar t of {
-  '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
-  '\\' -> YYAction 46;
   '_' -> YYAction 47;
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
@@ -735,9 +737,6 @@ private yyaction46 t =   case yychar t of {
     QUALIFIER -> YYAction 26;
     TRUE -> YYAction 27;
     FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
     DO -> YYAction 32;
     INTCONST -> YYAction 33;
     STRCONST -> YYAction 34;
@@ -750,51 +749,51 @@ private yyaction46 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction47 t = YYAction (-398);
+private yyaction47 t = YYAction (-401);
 private yyaction48 t = YYAction (-3);
 private yyaction49 t = YYAction (-4);
-private yyaction50 t = YYAction (-396);
+private yyaction50 t = YYAction (-399);
 private yyaction51 t =   case yychar t of {
   '{' -> YYAction 98;
-  '-' -> YYAction (-399);
-  ';' -> YYAction (-399);
-  '}' -> YYAction (-399);
-  '.' -> YYAction (-399);
-  '(' -> YYAction (-399);
-  ')' -> YYAction (-399);
-  ',' -> YYAction (-399);
-  '|' -> YYAction (-399);
-  '[' -> YYAction (-399);
-  ']' -> YYAction (-399);
-  '?' -> YYAction (-399);
-  '!' -> YYAction (-399);
-  '=' -> YYAction (-399);
-  '\\' -> YYAction (-399);
-  '_' -> YYAction (-399);
+  '-' -> YYAction (-402);
+  ';' -> YYAction (-402);
+  '}' -> YYAction (-402);
+  '.' -> YYAction (-402);
+  '(' -> YYAction (-402);
+  ')' -> YYAction (-402);
+  ',' -> YYAction (-402);
+  '|' -> YYAction (-402);
+  '[' -> YYAction (-402);
+  ']' -> YYAction (-402);
+  '?' -> YYAction (-402);
+  '!' -> YYAction (-402);
+  '=' -> YYAction (-402);
+  '\\' -> YYAction (-402);
+  '_' -> YYAction (-402);
   _ ->   case yytoken t of {
-    VARID -> YYAction (-399);
-    CONID -> YYAction (-399);
-    QUALIFIER -> YYAction (-399);
-    WHERE -> YYAction (-399);
-    TRUE -> YYAction (-399);
-    FALSE -> YYAction (-399);
-    THEN -> YYAction (-399);
-    ELSE -> YYAction (-399);
-    OF -> YYAction (-399);
-    DO -> YYAction (-399);
-    INTCONST -> YYAction (-399);
-    STRCONST -> YYAction (-399);
-    LONGCONST -> YYAction (-399);
-    FLTCONST -> YYAction (-399);
-    DBLCONST -> YYAction (-399);
-    CHRCONST -> YYAction (-399);
-    REGEXP -> YYAction (-399);
-    BIGCONST -> YYAction (-399);
-    ARROW -> YYAction (-399);
-    DCOLON -> YYAction (-399);
-    GETS -> YYAction (-399);
-    DOTDOT -> YYAction (-399);
-    SOMEOP -> YYAction (-399);
+    VARID -> YYAction (-402);
+    CONID -> YYAction (-402);
+    QUALIFIER -> YYAction (-402);
+    WHERE -> YYAction (-402);
+    TRUE -> YYAction (-402);
+    FALSE -> YYAction (-402);
+    THEN -> YYAction (-402);
+    ELSE -> YYAction (-402);
+    OF -> YYAction (-402);
+    DO -> YYAction (-402);
+    INTCONST -> YYAction (-402);
+    STRCONST -> YYAction (-402);
+    LONGCONST -> YYAction (-402);
+    FLTCONST -> YYAction (-402);
+    DBLCONST -> YYAction (-402);
+    CHRCONST -> YYAction (-402);
+    REGEXP -> YYAction (-402);
+    BIGCONST -> YYAction (-402);
+    ARROW -> YYAction (-402);
+    DCOLON -> YYAction (-402);
+    GETS -> YYAction (-402);
+    DOTDOT -> YYAction (-402);
+    SOMEOP -> YYAction (-402);
     _ -> (YYAction yyErr);
   };
 };
@@ -824,45 +823,43 @@ private yyaction52 t =   case yychar t of {
 };
 private yyaction53 t =   case yychar t of {
   '-' -> YYAction 102;
-  ';' -> YYAction (-362);
-  '}' -> YYAction (-362);
-  ')' -> YYAction (-362);
-  ',' -> YYAction (-362);
-  '|' -> YYAction (-362);
-  ']' -> YYAction (-362);
-  '=' -> YYAction (-362);
-  '\\' -> YYAction (-362);
+  ';' -> YYAction (-363);
+  '}' -> YYAction (-363);
+  ')' -> YYAction (-363);
+  ',' -> YYAction (-363);
+  '|' -> YYAction (-363);
+  ']' -> YYAction (-363);
+  '=' -> YYAction (-363);
   _ ->   case yytoken t of {
     DCOLON -> YYAction 100;
     SOMEOP -> YYAction 101;
-    WHERE -> YYAction (-362);
-    THEN -> YYAction (-362);
-    ELSE -> YYAction (-362);
-    OF -> YYAction (-362);
-    ARROW -> YYAction (-362);
-    GETS -> YYAction (-362);
-    DOTDOT -> YYAction (-362);
+    WHERE -> YYAction (-363);
+    THEN -> YYAction (-363);
+    ELSE -> YYAction (-363);
+    OF -> YYAction (-363);
+    ARROW -> YYAction (-363);
+    GETS -> YYAction (-363);
+    DOTDOT -> YYAction (-363);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction54 t = YYAction (-397);
-private yyaction55 t = YYAction (-374);
-private yyaction56 t = YYAction (-370);
+private yyaction54 t = YYAction (-400);
+private yyaction55 t = YYAction (-375);
+private yyaction56 t = YYAction (-371);
 private yyaction57 t =   case yychar t of {
   '(' -> YYAction 42;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   '_' -> YYAction 47;
-  '-' -> YYAction (-375);
-  ';' -> YYAction (-375);
-  '}' -> YYAction (-375);
-  ')' -> YYAction (-375);
-  ',' -> YYAction (-375);
-  '|' -> YYAction (-375);
-  ']' -> YYAction (-375);
-  '=' -> YYAction (-375);
-  '\\' -> YYAction (-375);
+  '-' -> YYAction (-376);
+  ';' -> YYAction (-376);
+  '}' -> YYAction (-376);
+  ')' -> YYAction (-376);
+  ',' -> YYAction (-376);
+  '|' -> YYAction (-376);
+  ']' -> YYAction (-376);
+  '=' -> YYAction (-376);
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
     CONID -> YYAction 25;
@@ -878,59 +875,59 @@ private yyaction57 t =   case yychar t of {
     CHRCONST -> YYAction 38;
     REGEXP -> YYAction 39;
     BIGCONST -> YYAction 40;
-    WHERE -> YYAction (-375);
-    THEN -> YYAction (-375);
-    ELSE -> YYAction (-375);
-    OF -> YYAction (-375);
-    ARROW -> YYAction (-375);
-    DCOLON -> YYAction (-375);
-    GETS -> YYAction (-375);
-    DOTDOT -> YYAction (-375);
-    SOMEOP -> YYAction (-375);
+    WHERE -> YYAction (-376);
+    THEN -> YYAction (-376);
+    ELSE -> YYAction (-376);
+    OF -> YYAction (-376);
+    ARROW -> YYAction (-376);
+    DCOLON -> YYAction (-376);
+    GETS -> YYAction (-376);
+    DOTDOT -> YYAction (-376);
+    SOMEOP -> YYAction (-376);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction58 t = YYAction (-376);
+private yyaction58 t = YYAction (-377);
 private yyaction59 t =   case yychar t of {
   '.' -> YYAction 104;
-  '-' -> YYAction (-378);
-  ';' -> YYAction (-378);
-  '}' -> YYAction (-378);
-  '(' -> YYAction (-378);
-  ')' -> YYAction (-378);
-  ',' -> YYAction (-378);
-  '|' -> YYAction (-378);
-  '[' -> YYAction (-378);
-  ']' -> YYAction (-378);
-  '?' -> YYAction (-378);
-  '!' -> YYAction (-378);
-  '=' -> YYAction (-378);
-  '\\' -> YYAction (-378);
-  '_' -> YYAction (-378);
+  '-' -> YYAction (-379);
+  ';' -> YYAction (-379);
+  '}' -> YYAction (-379);
+  '(' -> YYAction (-379);
+  ')' -> YYAction (-379);
+  ',' -> YYAction (-379);
+  '|' -> YYAction (-379);
+  '[' -> YYAction (-379);
+  ']' -> YYAction (-379);
+  '?' -> YYAction (-379);
+  '!' -> YYAction (-379);
+  '=' -> YYAction (-379);
+  '\\' -> YYAction (-379);
+  '_' -> YYAction (-379);
   _ ->   case yytoken t of {
-    VARID -> YYAction (-378);
-    CONID -> YYAction (-378);
-    QUALIFIER -> YYAction (-378);
-    WHERE -> YYAction (-378);
-    TRUE -> YYAction (-378);
-    FALSE -> YYAction (-378);
-    THEN -> YYAction (-378);
-    ELSE -> YYAction (-378);
-    OF -> YYAction (-378);
-    DO -> YYAction (-378);
-    INTCONST -> YYAction (-378);
-    STRCONST -> YYAction (-378);
-    LONGCONST -> YYAction (-378);
-    FLTCONST -> YYAction (-378);
-    DBLCONST -> YYAction (-378);
-    CHRCONST -> YYAction (-378);
-    REGEXP -> YYAction (-378);
-    BIGCONST -> YYAction (-378);
-    ARROW -> YYAction (-378);
-    DCOLON -> YYAction (-378);
-    GETS -> YYAction (-378);
-    DOTDOT -> YYAction (-378);
-    SOMEOP -> YYAction (-378);
+    VARID -> YYAction (-379);
+    CONID -> YYAction (-379);
+    QUALIFIER -> YYAction (-379);
+    WHERE -> YYAction (-379);
+    TRUE -> YYAction (-379);
+    FALSE -> YYAction (-379);
+    THEN -> YYAction (-379);
+    ELSE -> YYAction (-379);
+    OF -> YYAction (-379);
+    DO -> YYAction (-379);
+    INTCONST -> YYAction (-379);
+    STRCONST -> YYAction (-379);
+    LONGCONST -> YYAction (-379);
+    FLTCONST -> YYAction (-379);
+    DBLCONST -> YYAction (-379);
+    CHRCONST -> YYAction (-379);
+    REGEXP -> YYAction (-379);
+    BIGCONST -> YYAction (-379);
+    ARROW -> YYAction (-379);
+    DCOLON -> YYAction (-379);
+    GETS -> YYAction (-379);
+    DOTDOT -> YYAction (-379);
+    SOMEOP -> YYAction (-379);
     _ -> (YYAction yyErr);
   };
 };
@@ -938,7 +935,7 @@ private yyaction60 t =   case yychar t of {
   '{' -> YYAction 105;
   _ -> (YYAction yyErr);
 };
-private yyaction61 t = YYAction (-382);
+private yyaction61 t = YYAction (-385);
 private yyaction62 t = YYAction (-22);
 private yyaction63 t =   case yychar t of {
   '{' -> YYAction 106;
@@ -1037,7 +1034,7 @@ private yyaction75 t = YYAction (-185);
 private yyaction76 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
-  '{' -> YYAction (-381);
+  '{' -> YYAction (-384);
   _ ->   case yytoken t of {
     VARID -> YYAction 74;
     CONID -> YYAction 157;
@@ -1115,7 +1112,7 @@ private yyaction82 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction83 t = YYAction (-369);
+private yyaction83 t = YYAction (-370);
 private yyaction84 t = YYAction (-193);
 private yyaction85 t =   case yychar t of {
   '(' -> YYAction 42;
@@ -1146,10 +1143,10 @@ private yyaction85 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction86 t = YYAction (-402);
+private yyaction86 t = YYAction (-405);
 private yyaction87 t =   case yychar t of {
   ',' -> YYAction 87;
-  ')' -> YYAction (-418);
+  ')' -> YYAction (-421);
   _ -> (YYAction yyErr);
 };
 private yyaction88 t =   case yychar t of {
@@ -1219,22 +1216,22 @@ private yyaction91 t =   case yychar t of {
 };
 private yyaction92 t =   case yychar t of {
   '-' -> YYAction 182;
-  ';' -> YYAction (-362);
-  ')' -> YYAction (-362);
-  ',' -> YYAction (-362);
+  ';' -> YYAction (-363);
+  ')' -> YYAction (-363);
+  ',' -> YYAction (-363);
   _ ->   case yytoken t of {
     DCOLON -> YYAction 100;
     SOMEOP -> YYAction 181;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction93 t = YYAction (-413);
+private yyaction93 t = YYAction (-416);
 private yyaction94 t =   case yychar t of {
   ',' -> YYAction 184;
   '|' -> YYAction 185;
-  ']' -> YYAction (-431);
+  ']' -> YYAction (-434);
   _ ->   case yytoken t of {
-    DOTDOT -> YYAction (-431);
+    DOTDOT -> YYAction (-434);
     _ -> (YYAction yyErr);
   };
 };
@@ -1245,30 +1242,55 @@ private yyaction95 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction96 t = YYAction (-333);
-private yyaction97 t =   case yychar t of {
+private yyaction96 t =   case yychar t of {
   '\\' -> YYAction 46;
   _ ->   case yytoken t of {
     ARROW -> YYAction 188;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction98 t =   case yychar t of {
-  '}' -> YYAction 191;
+private yyaction97 t =   case yychar t of {
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '_' -> YYAction 47;
+  '\\' -> YYAction (-381);
   _ ->   case yytoken t of {
-    VARID -> YYAction 190;
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    ARROW -> YYAction (-381);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction99 t = YYAction (-379);
-private yyaction100 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction98 t =   case yychar t of {
+  '}' -> YYAction 193;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 192;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction99 t = YYAction (-380);
+private yyaction100 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
@@ -1330,20 +1352,20 @@ private yyaction102 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction103 t = YYAction (-377);
+private yyaction103 t = YYAction (-378);
 private yyaction104 t =   case yychar t of {
-  '{' -> YYAction 213;
-  '[' -> YYAction 214;
+  '{' -> YYAction 215;
+  '[' -> YYAction 216;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
-    VARID -> YYAction 212;
+    VARID -> YYAction 214;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction105 t =   case yytoken t of {
-    VARID -> YYAction 217;
+    VARID -> YYAction 219;
     _ -> (YYAction yyErr);
   };
 private yyaction106 t =   case yychar t of {
@@ -1436,43 +1458,43 @@ private yyaction109 t =   case yytoken t of {
     _ -> (YYAction yyErr);
   };
 private yyaction110 t =   case yytoken t of {
-    INTCONST -> YYAction 222;
-    _ -> (YYAction yyErr);
-  };
-private yyaction111 t =   case yytoken t of {
-    INTCONST -> YYAction 223;
-    _ -> (YYAction yyErr);
-  };
-private yyaction112 t =   case yytoken t of {
     INTCONST -> YYAction 224;
     _ -> (YYAction yyErr);
   };
+private yyaction111 t =   case yytoken t of {
+    INTCONST -> YYAction 225;
+    _ -> (YYAction yyErr);
+  };
+private yyaction112 t =   case yytoken t of {
+    INTCONST -> YYAction 226;
+    _ -> (YYAction yyErr);
+  };
 private yyaction113 t =   case yychar t of {
-  '-' -> YYAction 226;
-  '(' -> YYAction 227;
+  '-' -> YYAction 228;
+  '(' -> YYAction 229;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
-    VARID -> YYAction 190;
-    PACKAGE -> YYAction 225;
+    VARID -> YYAction 192;
+    PACKAGE -> YYAction 227;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction114 t =   case yytoken t of {
-    CONID -> YYAction 231;
+    CONID -> YYAction 233;
     _ -> (YYAction yyErr);
   };
 private yyaction115 t =   case yytoken t of {
-    CONID -> YYAction 232;
+    CONID -> YYAction 234;
     _ -> (YYAction yyErr);
   };
 private yyaction116 t =   case yychar t of {
-  '(' -> YYAction 233;
-  '[' -> YYAction 234;
+  '(' -> YYAction 235;
+  '[' -> YYAction 236;
   _ ->   case yytoken t of {
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
+    QUALIFIER -> YYAction 198;
     _ -> (YYAction yyErr);
   };
 };
@@ -1481,15 +1503,15 @@ private yyaction117 t =   case yytoken t of {
     _ -> (YYAction yyErr);
   };
 private yyaction118 t =   case yytoken t of {
-    CONID -> YYAction 237;
+    CONID -> YYAction 239;
     _ -> (YYAction yyErr);
   };
 private yyaction119 t =   case yychar t of {
-  '(' -> YYAction 233;
-  '[' -> YYAction 234;
+  '(' -> YYAction 235;
+  '[' -> YYAction 236;
   _ ->   case yytoken t of {
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
+    QUALIFIER -> YYAction 198;
     _ -> (YYAction yyErr);
   };
 };
@@ -1505,7 +1527,7 @@ private yyaction120 t =   case yychar t of {
     VARID -> YYAction 107;
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
-    NATIVE -> YYAction 239;
+    NATIVE -> YYAction 241;
     DATA -> YYAction 114;
     CLASS -> YYAction 115;
     INSTANCE -> YYAction 116;
@@ -1541,7 +1563,7 @@ private yyaction121 t =   case yychar t of {
     VARID -> YYAction 107;
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
-    NATIVE -> YYAction 239;
+    NATIVE -> YYAction 241;
     DATA -> YYAction 114;
     CLASS -> YYAction 115;
     INSTANCE -> YYAction 116;
@@ -1577,7 +1599,7 @@ private yyaction122 t =   case yychar t of {
     VARID -> YYAction 107;
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
-    NATIVE -> YYAction 239;
+    NATIVE -> YYAction 241;
     DATA -> YYAction 114;
     CLASS -> YYAction 115;
     INSTANCE -> YYAction 116;
@@ -1602,11 +1624,11 @@ private yyaction122 t =   case yychar t of {
   };
 };
 private yyaction123 t =   case yytoken t of {
-    NATIVE -> YYAction 239;
+    NATIVE -> YYAction 241;
     _ -> (YYAction yyErr);
   };
 private yyaction124 t =   case yychar t of {
-  '-' -> YYAction 244;
+  '-' -> YYAction 246;
   '(' -> YYAction 42;
   ')' -> YYAction 86;
   ',' -> YYAction 87;
@@ -1708,25 +1730,25 @@ private yyaction142 t =   case yychar t of {
   ';' -> YYAction (-129);
   '}' -> YYAction (-129);
   _ ->   case yytoken t of {
-    WHERE -> YYAction 249;
+    WHERE -> YYAction 251;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction143 t = YYAction (-206);
 private yyaction144 t =   case yychar t of {
-  '-' -> YYAction 252;
+  '-' -> YYAction 254;
   _ ->   case yytoken t of {
-    VARID -> YYAction 251;
+    VARID -> YYAction 253;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction145 t =   case yytoken t of {
-    DCOLON -> YYAction 256;
+    DCOLON -> YYAction 258;
     _ -> (YYAction yyErr);
   };
 private yyaction146 t =   case yychar t of {
-  ',' -> YYAction 257;
+  ',' -> YYAction 259;
   _ ->   case yytoken t of {
     DCOLON -> YYAction (-210);
     _ -> (YYAction yyErr);
@@ -1737,11 +1759,11 @@ private yyaction148 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
-    VARID -> YYAction 258;
-    CONID -> YYAction 259;
-    QUALIFIER -> YYAction 260;
-    STRCONST -> YYAction 261;
-    DCOLON -> YYAction 262;
+    VARID -> YYAction 260;
+    CONID -> YYAction 261;
+    QUALIFIER -> YYAction 262;
+    STRCONST -> YYAction 263;
+    DCOLON -> YYAction 264;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
@@ -1750,13 +1772,13 @@ private yyaction149 t =   case yychar t of {
   ';' -> YYAction (-314);
   '}' -> YYAction (-314);
   _ ->   case yytoken t of {
-    WHERE -> YYAction 266;
+    WHERE -> YYAction 268;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction150 t =   case yychar t of {
-  '|' -> YYAction 268;
-  '=' -> YYAction 269;
+  '|' -> YYAction 270;
+  '=' -> YYAction 271;
   _ -> (YYAction yyErr);
 };
 private yyaction151 t =   case yychar t of {
@@ -1773,7 +1795,7 @@ private yyaction152 t =   case yychar t of {
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
     VARID -> YYAction 74;
-    QUALIFIER -> YYAction 272;
+    QUALIFIER -> YYAction 274;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
@@ -1795,9 +1817,9 @@ private yyaction155 t =   case yytoken t of {
 private yyaction156 t = YYAction (-11);
 private yyaction157 t = YYAction (-184);
 private yyaction158 t = YYAction (-181);
-private yyaction159 t = YYAction (-364);
+private yyaction159 t = YYAction (-365);
 private yyaction160 t =   case yytoken t of {
-    THEN -> YYAction 278;
+    THEN -> YYAction 280;
     _ -> (YYAction yyErr);
   };
 private yyaction161 t =   case yychar t of {
@@ -1830,7 +1852,7 @@ private yyaction161 t =   case yychar t of {
   };
 };
 private yyaction162 t =   case yychar t of {
-  '{' -> YYAction 280;
+  '{' -> YYAction 282;
   _ -> (YYAction yyErr);
 };
 private yyaction163 t = YYAction (-137);
@@ -1838,7 +1860,7 @@ private yyaction164 t =   case yychar t of {
   ';' -> YYAction (-138);
   '}' -> YYAction (-138);
   _ ->   case yytoken t of {
-    WHERE -> YYAction 249;
+    WHERE -> YYAction 251;
     _ -> (YYAction yyErr);
   };
 };
@@ -1848,21 +1870,21 @@ private yyaction165 t =   case yychar t of {
   _ -> (YYAction yyErr);
 };
 private yyaction166 t =   case yychar t of {
-  '}' -> YYAction 282;
+  '}' -> YYAction 284;
   _ -> (YYAction yyErr);
 };
 private yyaction167 t =   case yychar t of {
-  '{' -> YYAction 283;
+  '{' -> YYAction 285;
   _ -> (YYAction yyErr);
 };
 private yyaction168 t =   case yychar t of {
-  '=' -> YYAction 285;
+  '=' -> YYAction 287;
   ';' -> YYAction (-345);
   '}' -> YYAction (-345);
   ',' -> YYAction (-345);
   ']' -> YYAction (-345);
   _ ->   case yytoken t of {
-    GETS -> YYAction 284;
+    GETS -> YYAction 286;
     _ -> (YYAction yyErr);
   };
 };
@@ -1873,11 +1895,11 @@ private yyaction169 t =   case yychar t of {
 };
 private yyaction170 t = YYAction (-336);
 private yyaction171 t =   case yychar t of {
-  '}' -> YYAction 287;
+  '}' -> YYAction 289;
   _ -> (YYAction yyErr);
 };
-private yyaction172 t = YYAction (-406);
-private yyaction173 t = YYAction (-419);
+private yyaction172 t = YYAction (-409);
+private yyaction173 t = YYAction (-422);
 private yyaction174 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
@@ -1907,7 +1929,7 @@ private yyaction174 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction175 t = YYAction (-412);
+private yyaction175 t = YYAction (-415);
 private yyaction176 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
@@ -1937,13 +1959,13 @@ private yyaction176 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction177 t = YYAction (-405);
+private yyaction177 t = YYAction (-408);
 private yyaction178 t =   case yychar t of {
-  ')' -> YYAction 292;
+  ')' -> YYAction 294;
   _ -> (YYAction yyErr);
 };
-private yyaction179 t = YYAction (-404);
-private yyaction180 t = YYAction (-403);
+private yyaction179 t = YYAction (-407);
+private yyaction180 t = YYAction (-406);
 private yyaction181 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
@@ -1977,7 +1999,7 @@ private yyaction181 t =   case yychar t of {
 private yyaction182 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
-  ')' -> YYAction 293;
+  ')' -> YYAction 295;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
@@ -2005,7 +2027,7 @@ private yyaction182 t =   case yychar t of {
   };
 };
 private yyaction183 t =   case yychar t of {
-  ')' -> YYAction 294;
+  ')' -> YYAction 296;
   _ -> (YYAction yyErr);
 };
 private yyaction184 t =   case yychar t of {
@@ -2016,8 +2038,8 @@ private yyaction184 t =   case yychar t of {
   '!' -> YYAction 45;
   '\\' -> YYAction 46;
   '_' -> YYAction 47;
-  ')' -> YYAction (-433);
-  ']' -> YYAction (-433);
+  ')' -> YYAction (-436);
+  ']' -> YYAction (-436);
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
     CONID -> YYAction 25;
@@ -2036,7 +2058,7 @@ private yyaction184 t =   case yychar t of {
     CHRCONST -> YYAction 38;
     REGEXP -> YYAction 39;
     BIGCONST -> YYAction 40;
-    DOTDOT -> YYAction (-433);
+    DOTDOT -> YYAction (-436);
     _ -> (YYAction yyErr);
   };
 };
@@ -2073,7 +2095,7 @@ private yyaction186 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
-  ']' -> YYAction 298;
+  ']' -> YYAction 300;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   '\\' -> YYAction 46;
@@ -2099,7 +2121,7 @@ private yyaction186 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction187 t = YYAction (-414);
+private yyaction187 t = YYAction (-417);
 private yyaction188 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
@@ -2129,65 +2151,67 @@ private yyaction188 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction189 t = YYAction (-359);
-private yyaction190 t = YYAction (-171);
-private yyaction191 t = YYAction (-400);
-private yyaction192 t =   case yychar t of {
-  '=' -> YYAction 301;
-  '}' -> YYAction (-430);
-  ',' -> YYAction (-430);
-  _ -> (YYAction yyErr);
-};
-private yyaction193 t =   case yychar t of {
-  '}' -> YYAction 302;
-  _ -> (YYAction yyErr);
-};
+private yyaction189 t = YYAction (-360);
+private yyaction190 t = YYAction (-359);
+private yyaction191 t = YYAction (-382);
+private yyaction192 t = YYAction (-171);
+private yyaction193 t = YYAction (-403);
 private yyaction194 t =   case yychar t of {
-  ',' -> YYAction 303;
-  '}' -> YYAction (-420);
+  '=' -> YYAction 303;
+  '}' -> YYAction (-433);
+  ',' -> YYAction (-433);
   _ -> (YYAction yyErr);
 };
-private yyaction195 t = YYAction (-252);
-private yyaction196 t =   case yytoken t of {
+private yyaction195 t =   case yychar t of {
+  '}' -> YYAction 304;
+  _ -> (YYAction yyErr);
+};
+private yyaction196 t =   case yychar t of {
+  ',' -> YYAction 305;
+  '}' -> YYAction (-423);
+  _ -> (YYAction yyErr);
+};
+private yyaction197 t = YYAction (-252);
+private yyaction198 t =   case yytoken t of {
     CONID -> YYAction 75;
-    QUALIFIER -> YYAction 304;
+    QUALIFIER -> YYAction 306;
     _ -> (YYAction yyErr);
   };
-private yyaction197 t =   case yytoken t of {
-    VARID -> YYAction 305;
+private yyaction199 t =   case yytoken t of {
+    VARID -> YYAction 307;
     _ -> (YYAction yyErr);
   };
-private yyaction198 t =   case yychar t of {
-  '(' -> YYAction 198;
-  ')' -> YYAction 310;
+private yyaction200 t =   case yychar t of {
+  '(' -> YYAction 200;
+  ')' -> YYAction 312;
   ',' -> YYAction 87;
-  '[' -> YYAction 199;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 308;
+    VARID -> YYAction 310;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
-    ARROW -> YYAction 309;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    ARROW -> YYAction 311;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction199 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
-  ']' -> YYAction 315;
+private yyaction201 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  ']' -> YYAction 317;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction200 t = YYAction (-254);
-private yyaction201 t = YYAction (-361);
-private yyaction202 t = YYAction (-229);
-private yyaction203 t = YYAction (-230);
-private yyaction204 t =   case yychar t of {
+private yyaction202 t = YYAction (-254);
+private yyaction203 t = YYAction (-362);
+private yyaction204 t = YYAction (-229);
+private yyaction205 t = YYAction (-230);
+private yyaction206 t =   case yychar t of {
   '-' -> YYAction (-236);
   ';' -> YYAction (-236);
   '}' -> YYAction (-236);
@@ -2196,10 +2220,9 @@ private yyaction204 t =   case yychar t of {
   '|' -> YYAction (-236);
   ']' -> YYAction (-236);
   '=' -> YYAction (-236);
-  '\\' -> YYAction (-236);
   _ ->   case yytoken t of {
-    ARROW -> YYAction 317;
-    EARROW -> YYAction 318;
+    ARROW -> YYAction 319;
+    EARROW -> YYAction 320;
     DOCUMENTATION -> YYAction (-236);
     WHERE -> YYAction (-236);
     CLASS -> YYAction (-236);
@@ -2214,11 +2237,11 @@ private yyaction204 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction205 t = YYAction (-235);
-private yyaction206 t = YYAction (-245);
-private yyaction207 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction207 t = YYAction (-235);
+private yyaction208 t = YYAction (-245);
+private yyaction209 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   '-' -> YYAction (-294);
   ';' -> YYAction (-294);
   '}' -> YYAction (-294);
@@ -2227,11 +2250,10 @@ private yyaction207 t =   case yychar t of {
   '|' -> YYAction (-294);
   ']' -> YYAction (-294);
   '=' -> YYAction (-294);
-  '\\' -> YYAction (-294);
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
+    QUALIFIER -> YYAction 198;
     DOCUMENTATION -> YYAction (-294);
     WHERE -> YYAction (-294);
     CLASS -> YYAction (-294);
@@ -2248,32 +2270,9 @@ private yyaction207 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction208 t = YYAction (-246);
-private yyaction209 t = YYAction (-247);
-private yyaction210 t =   case yychar t of {
-  '-' -> YYAction 102;
-  ';' -> YYAction (-367);
-  '}' -> YYAction (-367);
-  ')' -> YYAction (-367);
-  ',' -> YYAction (-367);
-  '|' -> YYAction (-367);
-  ']' -> YYAction (-367);
-  '=' -> YYAction (-367);
-  '\\' -> YYAction (-367);
-  _ ->   case yytoken t of {
-    SOMEOP -> YYAction 101;
-    WHERE -> YYAction (-367);
-    THEN -> YYAction (-367);
-    ELSE -> YYAction (-367);
-    OF -> YYAction (-367);
-    ARROW -> YYAction (-367);
-    DCOLON -> YYAction (-367);
-    GETS -> YYAction (-367);
-    DOTDOT -> YYAction (-367);
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction211 t =   case yychar t of {
+private yyaction210 t = YYAction (-246);
+private yyaction211 t = YYAction (-247);
+private yyaction212 t =   case yychar t of {
   '-' -> YYAction 102;
   ';' -> YYAction (-368);
   '}' -> YYAction (-368);
@@ -2282,7 +2281,6 @@ private yyaction211 t =   case yychar t of {
   '|' -> YYAction (-368);
   ']' -> YYAction (-368);
   '=' -> YYAction (-368);
-  '\\' -> YYAction (-368);
   _ ->   case yytoken t of {
     SOMEOP -> YYAction 101;
     WHERE -> YYAction (-368);
@@ -2296,12 +2294,34 @@ private yyaction211 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction212 t = YYAction (-384);
-private yyaction213 t =   case yytoken t of {
-    VARID -> YYAction 320;
+private yyaction213 t =   case yychar t of {
+  '-' -> YYAction 102;
+  ';' -> YYAction (-369);
+  '}' -> YYAction (-369);
+  ')' -> YYAction (-369);
+  ',' -> YYAction (-369);
+  '|' -> YYAction (-369);
+  ']' -> YYAction (-369);
+  '=' -> YYAction (-369);
+  _ ->   case yytoken t of {
+    SOMEOP -> YYAction 101;
+    WHERE -> YYAction (-369);
+    THEN -> YYAction (-369);
+    ELSE -> YYAction (-369);
+    OF -> YYAction (-369);
+    ARROW -> YYAction (-369);
+    DCOLON -> YYAction (-369);
+    GETS -> YYAction (-369);
+    DOTDOT -> YYAction (-369);
     _ -> (YYAction yyErr);
   };
-private yyaction214 t =   case yychar t of {
+};
+private yyaction214 t = YYAction (-387);
+private yyaction215 t =   case yytoken t of {
+    VARID -> YYAction 322;
+    _ -> (YYAction yyErr);
+  };
+private yyaction216 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -2330,54 +2350,54 @@ private yyaction214 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction215 t = YYAction (-385);
-private yyaction216 t = YYAction (-386);
-private yyaction217 t =   case yychar t of {
-  '?' -> YYAction 324;
-  '=' -> YYAction 325;
-  '}' -> YYAction (-428);
-  ',' -> YYAction (-428);
+private yyaction217 t = YYAction (-388);
+private yyaction218 t = YYAction (-389);
+private yyaction219 t =   case yychar t of {
+  '?' -> YYAction 326;
+  '=' -> YYAction 327;
+  '}' -> YYAction (-431);
+  ',' -> YYAction (-431);
   _ ->   case yytoken t of {
-    GETS -> YYAction 323;
+    GETS -> YYAction 325;
     _ -> (YYAction yyErr);
   };
-};
-private yyaction218 t =   case yychar t of {
-  '}' -> YYAction 326;
-  _ -> (YYAction yyErr);
-};
-private yyaction219 t =   case yychar t of {
-  ',' -> YYAction 327;
-  '}' -> YYAction (-423);
-  _ -> (YYAction yyErr);
 };
 private yyaction220 t =   case yychar t of {
   '}' -> YYAction 328;
   _ -> (YYAction yyErr);
 };
 private yyaction221 t =   case yychar t of {
-  '(' -> YYAction 332;
+  ',' -> YYAction 329;
+  '}' -> YYAction (-426);
+  _ -> (YYAction yyErr);
+};
+private yyaction222 t =   case yychar t of {
+  '}' -> YYAction 330;
+  _ -> (YYAction yyErr);
+};
+private yyaction223 t =   case yychar t of {
+  '(' -> YYAction 334;
   ';' -> YYAction (-145);
   '}' -> YYAction (-145);
   _ ->   case yytoken t of {
-    VARID -> YYAction 329;
-    CONID -> YYAction 330;
-    PUBLIC -> YYAction 331;
+    VARID -> YYAction 331;
+    CONID -> YYAction 332;
+    PUBLIC -> YYAction 333;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction222 t = YYAction (-196);
-private yyaction223 t = YYAction (-198);
-private yyaction224 t = YYAction (-197);
-private yyaction225 t =   case yytoken t of {
-    TYPE -> YYAction 335;
+private yyaction224 t = YYAction (-196);
+private yyaction225 t = YYAction (-198);
+private yyaction226 t = YYAction (-197);
+private yyaction227 t =   case yytoken t of {
+    TYPE -> YYAction 337;
     WHERE -> YYAction (-43);
     CLASS -> YYAction (-43);
     _ -> (YYAction yyErr);
   };
-private yyaction226 t = YYAction (-217);
-private yyaction227 t =   case yychar t of {
-  '-' -> YYAction 337;
+private yyaction228 t = YYAction (-217);
+private yyaction229 t =   case yychar t of {
+  '-' -> YYAction 339;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
@@ -2385,151 +2405,93 @@ private yyaction227 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction228 t = YYAction (-215);
-private yyaction229 t = YYAction (-216);
-private yyaction230 t = YYAction (-214);
-private yyaction231 t =   case yychar t of {
-  '(' -> YYAction 340;
-  '=' -> YYAction 341;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 195;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction232 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 195;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
-    _ -> (YYAction yyErr);
-  };
-};
+private yyaction230 t = YYAction (-215);
+private yyaction231 t = YYAction (-216);
+private yyaction232 t = YYAction (-214);
 private yyaction233 t =   case yychar t of {
-  ')' -> YYAction 310;
-  ',' -> YYAction 87;
+  '(' -> YYAction 342;
+  '=' -> YYAction 343;
   _ ->   case yytoken t of {
-    ARROW -> YYAction 309;
+    VARID -> YYAction 197;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction234 t =   case yychar t of {
-  ']' -> YYAction 315;
-  _ -> (YYAction yyErr);
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
 };
 private yyaction235 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+  ')' -> YYAction 312;
+  ',' -> YYAction 87;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    ARROW -> YYAction 311;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction236 t = YYAction (-37);
+private yyaction236 t =   case yychar t of {
+  ']' -> YYAction 317;
+  _ -> (YYAction yyErr);
+};
 private yyaction237 t =   case yychar t of {
-  '(' -> YYAction 340;
-  '=' -> YYAction 347;
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction238 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
+private yyaction238 t = YYAction (-37);
 private yyaction239 t =   case yychar t of {
-  '-' -> YYAction 226;
-  '(' -> YYAction 227;
+  '(' -> YYAction 342;
+  '=' -> YYAction 349;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction240 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction241 t =   case yychar t of {
+  '-' -> YYAction 228;
+  '(' -> YYAction 229;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
-    VARID -> YYAction 190;
+    VARID -> YYAction 192;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction240 t = YYAction (-34);
-private yyaction241 t = YYAction (-35);
-private yyaction242 t = YYAction (-36);
-private yyaction243 t = YYAction (-212);
-private yyaction244 t =   case yychar t of {
-  '(' -> YYAction 42;
-  ')' -> YYAction 350;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction245 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 42;
-  ')' -> YYAction 351;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
+private yyaction242 t = YYAction (-34);
+private yyaction243 t = YYAction (-35);
+private yyaction244 t = YYAction (-36);
+private yyaction245 t = YYAction (-212);
 private yyaction246 t =   case yychar t of {
   '(' -> YYAction 42;
   ')' -> YYAction 352;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
+  '\\' -> YYAction 46;
   '_' -> YYAction 47;
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
@@ -2537,6 +2499,9 @@ private yyaction246 t =   case yychar t of {
     QUALIFIER -> YYAction 26;
     TRUE -> YYAction 27;
     FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
     DO -> YYAction 32;
     INTCONST -> YYAction 33;
     STRCONST -> YYAction 34;
@@ -2550,6 +2515,61 @@ private yyaction246 t =   case yychar t of {
   };
 };
 private yyaction247 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  ')' -> YYAction 353;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction248 t =   case yychar t of {
+  '(' -> YYAction 42;
+  ')' -> YYAction 354;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction249 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 124;
   '[' -> YYAction 43;
@@ -2595,46 +2615,46 @@ private yyaction247 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction248 t = YYAction (-31);
-private yyaction249 t =   case yychar t of {
-  '{' -> YYAction 354;
+private yyaction250 t = YYAction (-31);
+private yyaction251 t =   case yychar t of {
+  '{' -> YYAction 356;
   _ -> (YYAction yyErr);
 };
-private yyaction250 t = YYAction (-321);
-private yyaction251 t = YYAction (-200);
-private yyaction252 t = YYAction (-201);
-private yyaction253 t = YYAction (-199);
-private yyaction254 t =   case yychar t of {
-  '-' -> YYAction 252;
+private yyaction252 t = YYAction (-321);
+private yyaction253 t = YYAction (-200);
+private yyaction254 t = YYAction (-201);
+private yyaction255 t = YYAction (-199);
+private yyaction256 t =   case yychar t of {
+  '-' -> YYAction 254;
   ';' -> YYAction (-202);
   '}' -> YYAction (-202);
   _ ->   case yytoken t of {
-    VARID -> YYAction 251;
+    VARID -> YYAction 253;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction255 t = YYAction (-204);
-private yyaction256 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 195;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction257 t =   case yychar t of {
-  '(' -> YYAction 227;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 190;
-    _ -> (YYAction yyErr);
-  };
-};
+private yyaction257 t = YYAction (-204);
 private yyaction258 t =   case yychar t of {
-  '.' -> YYAction 358;
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction259 t =   case yychar t of {
+  '(' -> YYAction 229;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 192;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction260 t =   case yychar t of {
+  '.' -> YYAction 360;
   ';' -> YYAction (-5);
   '}' -> YYAction (-5);
   _ ->   case yytoken t of {
@@ -2643,44 +2663,44 @@ private yyaction258 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction259 t = YYAction (-6);
-private yyaction260 t =   case yytoken t of {
-    VARID -> YYAction 258;
-    CONID -> YYAction 259;
-    QUALIFIER -> YYAction 260;
-    STRCONST -> YYAction 261;
+private yyaction261 t = YYAction (-6);
+private yyaction262 t =   case yytoken t of {
+    VARID -> YYAction 260;
+    CONID -> YYAction 261;
+    QUALIFIER -> YYAction 262;
+    STRCONST -> YYAction 263;
     _ -> (YYAction yyErr);
   };
-private yyaction261 t = YYAction (-9);
-private yyaction262 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction263 t = YYAction (-9);
+private yyaction264 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction263 t =   case yytoken t of {
-    DCOLON -> YYAction 363;
-    _ -> (YYAction yyErr);
-  };
-private yyaction264 t =   case yytoken t of {
-    DCOLON -> YYAction 364;
-    _ -> (YYAction yyErr);
-  };
 private yyaction265 t =   case yytoken t of {
     DCOLON -> YYAction 365;
     _ -> (YYAction yyErr);
   };
-private yyaction266 t =   case yychar t of {
-  '{' -> YYAction 366;
+private yyaction266 t =   case yytoken t of {
+    DCOLON -> YYAction 366;
+    _ -> (YYAction yyErr);
+  };
+private yyaction267 t =   case yytoken t of {
+    DCOLON -> YYAction 367;
+    _ -> (YYAction yyErr);
+  };
+private yyaction268 t =   case yychar t of {
+  '{' -> YYAction 368;
   _ -> (YYAction yyErr);
 };
-private yyaction267 t = YYAction (-268);
-private yyaction268 t =   case yychar t of {
+private yyaction269 t = YYAction (-268);
+private yyaction270 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -2709,38 +2729,38 @@ private yyaction268 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction269 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction270 t = YYAction (-320);
 private yyaction271 t =   case yychar t of {
-  '|' -> YYAction 268;
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction272 t = YYAction (-320);
+private yyaction273 t =   case yychar t of {
+  '|' -> YYAction 270;
   ';' -> YYAction (-351);
   '}' -> YYAction (-351);
   _ ->   case yytoken t of {
@@ -2748,36 +2768,36 @@ private yyaction271 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction272 t =   case yychar t of {
+private yyaction274 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
     VARID -> YYAction 74;
-    QUALIFIER -> YYAction 372;
+    QUALIFIER -> YYAction 374;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction273 t =   case yychar t of {
-  ')' -> YYAction 374;
+private yyaction275 t =   case yychar t of {
+  ')' -> YYAction 376;
   _ -> (YYAction yyErr);
 };
-private yyaction274 t = YYAction (-192);
-private yyaction275 t =   case yychar t of {
-  ',' -> YYAction 375;
+private yyaction276 t = YYAction (-192);
+private yyaction277 t =   case yychar t of {
+  ',' -> YYAction 377;
   ')' -> YYAction (-179);
   _ -> (YYAction yyErr);
 };
-private yyaction276 t = YYAction (-191);
-private yyaction277 t = YYAction (-19);
-private yyaction278 t = YYAction (-363);
-private yyaction279 t =   case yychar t of {
-  ';' -> YYAction 377;
+private yyaction278 t = YYAction (-191);
+private yyaction279 t = YYAction (-19);
+private yyaction280 t = YYAction (-364);
+private yyaction281 t =   case yychar t of {
+  ';' -> YYAction 379;
   _ ->   case yytoken t of {
-    ELSE -> YYAction 376;
+    ELSE -> YYAction 378;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction280 t =   case yychar t of {
+private yyaction282 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -2806,7 +2826,7 @@ private yyaction280 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction281 t =   case yychar t of {
+private yyaction283 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 124;
   '[' -> YYAction 43;
@@ -2836,11 +2856,11 @@ private yyaction281 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction282 t =   case yytoken t of {
-    IN -> YYAction 383;
+private yyaction284 t =   case yytoken t of {
+    IN -> YYAction 386;
     _ -> (YYAction yyErr);
   };
-private yyaction283 t =   case yychar t of {
+private yyaction285 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 124;
   '[' -> YYAction 43;
@@ -2869,65 +2889,65 @@ private yyaction283 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction284 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction285 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
 private yyaction286 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction287 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction288 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -2957,49 +2977,49 @@ private yyaction286 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction287 t = YYAction (-383);
-private yyaction288 t =   case yychar t of {
-  ';' -> YYAction 388;
-  ')' -> YYAction (-434);
-  _ -> (YYAction yyErr);
-};
-private yyaction289 t =   case yychar t of {
-  ')' -> YYAction 389;
-  _ -> (YYAction yyErr);
-};
+private yyaction289 t = YYAction (-386);
 private yyaction290 t =   case yychar t of {
+  ';' -> YYAction 391;
+  ')' -> YYAction (-437);
+  _ -> (YYAction yyErr);
+};
+private yyaction291 t =   case yychar t of {
+  ')' -> YYAction 392;
+  _ -> (YYAction yyErr);
+};
+private yyaction292 t =   case yychar t of {
   ',' -> YYAction 184;
-  ')' -> YYAction (-431);
-  ']' -> YYAction (-431);
+  ')' -> YYAction (-434);
+  ']' -> YYAction (-434);
   _ ->   case yytoken t of {
-    DOTDOT -> YYAction (-431);
+    DOTDOT -> YYAction (-434);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction291 t =   case yychar t of {
-  ')' -> YYAction 390;
+private yyaction293 t =   case yychar t of {
+  ')' -> YYAction 393;
   _ -> (YYAction yyErr);
 };
-private yyaction292 t = YYAction (-407);
-private yyaction293 t = YYAction (-409);
-private yyaction294 t = YYAction (-408);
-private yyaction295 t = YYAction (-432);
-private yyaction296 t =   case yychar t of {
-  ',' -> YYAction 391;
+private yyaction294 t = YYAction (-410);
+private yyaction295 t = YYAction (-412);
+private yyaction296 t = YYAction (-411);
+private yyaction297 t = YYAction (-435);
+private yyaction298 t =   case yychar t of {
+  ',' -> YYAction 394;
   ']' -> YYAction (-339);
   _ -> (YYAction yyErr);
 };
-private yyaction297 t =   case yychar t of {
-  ']' -> YYAction 392;
-  _ -> (YYAction yyErr);
-};
-private yyaction298 t = YYAction (-415);
 private yyaction299 t =   case yychar t of {
-  ']' -> YYAction 393;
+  ']' -> YYAction 395;
   _ -> (YYAction yyErr);
 };
-private yyaction300 t = YYAction (-360);
+private yyaction300 t = YYAction (-418);
 private yyaction301 t =   case yychar t of {
+  ']' -> YYAction 396;
+  _ -> (YYAction yyErr);
+};
+private yyaction302 t = YYAction (-361);
+private yyaction303 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -3028,42 +3048,42 @@ private yyaction301 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction302 t = YYAction (-401);
-private yyaction303 t =   case yychar t of {
-  '}' -> YYAction (-422);
+private yyaction304 t = YYAction (-404);
+private yyaction305 t =   case yychar t of {
+  '}' -> YYAction (-425);
   _ ->   case yytoken t of {
-    VARID -> YYAction 190;
+    VARID -> YYAction 192;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction304 t =   case yytoken t of {
+private yyaction306 t =   case yytoken t of {
     CONID -> YYAction 157;
     _ -> (YYAction yyErr);
   };
-private yyaction305 t = YYAction (-228);
-private yyaction306 t =   case yychar t of {
-  '.' -> YYAction 397;
+private yyaction307 t = YYAction (-228);
+private yyaction308 t =   case yychar t of {
+  '.' -> YYAction 400;
   _ ->   case yytoken t of {
-    SOMEOP -> YYAction 396;
+    SOMEOP -> YYAction 399;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction307 t =   case yychar t of {
+private yyaction309 t =   case yychar t of {
   '.' -> YYAction (-226);
   _ ->   case yytoken t of {
-    VARID -> YYAction 305;
+    VARID -> YYAction 307;
     SOMEOP -> YYAction (-226);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction308 t =   case yychar t of {
+private yyaction310 t =   case yychar t of {
   '(' -> YYAction (-252);
   ')' -> YYAction (-252);
   ',' -> YYAction (-252);
   '|' -> YYAction (-252);
   '[' -> YYAction (-252);
   _ ->   case yytoken t of {
-    DCOLON -> YYAction 400;
+    DCOLON -> YYAction 403;
     VARID -> YYAction (-252);
     CONID -> YYAction (-252);
     QUALIFIER -> YYAction (-252);
@@ -3071,19 +3091,19 @@ private yyaction308 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction309 t =   case yychar t of {
-  ')' -> YYAction 401;
-  _ -> (YYAction yyErr);
-};
-private yyaction310 t = YYAction (-256);
 private yyaction311 t =   case yychar t of {
-  ')' -> YYAction 402;
-  ',' -> YYAction 403;
-  '|' -> YYAction 404;
+  ')' -> YYAction 404;
   _ -> (YYAction yyErr);
 };
-private yyaction312 t = YYAction (-239);
+private yyaction312 t = YYAction (-256);
 private yyaction313 t =   case yychar t of {
+  ')' -> YYAction 405;
+  ',' -> YYAction 406;
+  '|' -> YYAction 407;
+  _ -> (YYAction yyErr);
+};
+private yyaction314 t = YYAction (-239);
+private yyaction315 t =   case yychar t of {
   ';' -> YYAction (-238);
   '}' -> YYAction (-238);
   ')' -> YYAction (-238);
@@ -3091,93 +3111,59 @@ private yyaction313 t =   case yychar t of {
   '|' -> YYAction (-238);
   ']' -> YYAction (-238);
   _ ->   case yytoken t of {
-    ARROW -> YYAction 405;
+    ARROW -> YYAction 408;
     WHERE -> YYAction (-238);
     CLASS -> YYAction (-238);
     EARROW -> YYAction (-238);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction314 t =   case yychar t of {
-  ')' -> YYAction 406;
-  _ -> (YYAction yyErr);
-};
-private yyaction315 t = YYAction (-255);
 private yyaction316 t =   case yychar t of {
-  ']' -> YYAction 407;
+  ')' -> YYAction 409;
   _ -> (YYAction yyErr);
 };
-private yyaction317 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 195;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    _ -> (YYAction yyErr);
-  };
-};
+private yyaction317 t = YYAction (-255);
 private yyaction318 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+  ']' -> YYAction 410;
+  _ -> (YYAction yyErr);
+};
+private yyaction319 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
+    QUALIFIER -> YYAction 198;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction319 t = YYAction (-295);
 private yyaction320 t =   case yychar t of {
-  '?' -> YYAction 412;
-  '=' -> YYAction 413;
-  '}' -> YYAction (-428);
-  ',' -> YYAction (-428);
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    GETS -> YYAction 411;
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction321 t =   case yychar t of {
-  '}' -> YYAction 414;
-  _ -> (YYAction yyErr);
-};
+private yyaction321 t = YYAction (-295);
 private yyaction322 t =   case yychar t of {
-  ']' -> YYAction 415;
-  _ -> (YYAction yyErr);
+  '?' -> YYAction 415;
+  '=' -> YYAction 416;
+  '}' -> YYAction (-431);
+  ',' -> YYAction (-431);
+  _ ->   case yytoken t of {
+    GETS -> YYAction 414;
+    _ -> (YYAction yyErr);
+  };
 };
 private yyaction323 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '}' -> YYAction 416;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
+  '}' -> YYAction 417;
+  _ -> (YYAction yyErr);
 };
 private yyaction324 t =   case yychar t of {
-  '}' -> YYAction 418;
+  ']' -> YYAction 418;
   _ -> (YYAction yyErr);
 };
 private yyaction325 t =   case yychar t of {
@@ -3210,130 +3196,164 @@ private yyaction325 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction326 t = YYAction (-390);
+private yyaction326 t =   case yychar t of {
+  '}' -> YYAction 421;
+  _ -> (YYAction yyErr);
+};
 private yyaction327 t =   case yychar t of {
-  '}' -> YYAction (-425);
+  '-' -> YYAction 41;
+  '}' -> YYAction 422;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
   _ ->   case yytoken t of {
-    VARID -> YYAction 421;
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction328 t = YYAction (-2);
+private yyaction328 t = YYAction (-393);
 private yyaction329 t =   case yychar t of {
+  '}' -> YYAction (-428);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 424;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction330 t = YYAction (-2);
+private yyaction331 t =   case yychar t of {
   '(' -> YYAction (-171);
   _ ->   case yytoken t of {
-    CONID -> YYAction 423;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction330 t =   case yychar t of {
-  '(' -> YYAction 332;
-  ';' -> YYAction (-145);
-  '}' -> YYAction (-145);
-  _ ->   case yytoken t of {
-    VARID -> YYAction 190;
-    PUBLIC -> YYAction 331;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction331 t =   case yychar t of {
-  '(' -> YYAction 332;
-  ';' -> YYAction (-145);
-  '}' -> YYAction (-145);
-  _ ->   case yytoken t of {
-    VARID -> YYAction 190;
-    PUBLIC -> YYAction 331;
+    CONID -> YYAction 426;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction332 t =   case yychar t of {
-  ')' -> YYAction 429;
+  '(' -> YYAction 334;
+  ';' -> YYAction (-145);
+  '}' -> YYAction (-145);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 192;
+    PUBLIC -> YYAction 333;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction333 t =   case yychar t of {
+  '(' -> YYAction 334;
+  ';' -> YYAction (-145);
+  '}' -> YYAction (-145);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 192;
+    PUBLIC -> YYAction 333;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction334 t =   case yychar t of {
+  ')' -> YYAction 432;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
-    CONID -> YYAction 426;
-    QUALIFIER -> YYAction 427;
-    PUBLIC -> YYAction 428;
+    CONID -> YYAction 429;
+    QUALIFIER -> YYAction 430;
+    PUBLIC -> YYAction 431;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction333 t = YYAction (-142);
-private yyaction334 t =   case yychar t of {
-  '(' -> YYAction 437;
+private yyaction335 t = YYAction (-142);
+private yyaction336 t =   case yychar t of {
+  '(' -> YYAction 440;
   _ -> (YYAction yyErr);
 };
-private yyaction335 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction337 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction336 t =   case yytoken t of {
-    CLASS -> YYAction 439;
+private yyaction338 t =   case yytoken t of {
+    CLASS -> YYAction 442;
     WHERE -> YYAction (-45);
     _ -> (YYAction yyErr);
   };
-private yyaction337 t =   case yychar t of {
-  ')' -> YYAction 441;
-  _ -> (YYAction yyErr);
-};
-private yyaction338 t =   case yychar t of {
-  ')' -> YYAction 442;
-  _ -> (YYAction yyErr);
-};
 private yyaction339 t =   case yychar t of {
-  ')' -> YYAction 443;
+  ')' -> YYAction 444;
   _ -> (YYAction yyErr);
 };
-private yyaction340 t =   case yytoken t of {
-    VARID -> YYAction 444;
+private yyaction340 t =   case yychar t of {
+  ')' -> YYAction 445;
+  _ -> (YYAction yyErr);
+};
+private yyaction341 t =   case yychar t of {
+  ')' -> YYAction 446;
+  _ -> (YYAction yyErr);
+};
+private yyaction342 t =   case yytoken t of {
+    VARID -> YYAction 447;
     _ -> (YYAction yyErr);
   };
-private yyaction341 t =   case yychar t of {
-  '?' -> YYAction 453;
-  '!' -> YYAction 454;
+private yyaction343 t =   case yychar t of {
+  '?' -> YYAction 456;
+  '!' -> YYAction 457;
   _ ->   case yytoken t of {
-    CONID -> YYAction 445;
-    DOCUMENTATION -> YYAction 446;
-    NATIVE -> YYAction 447;
-    PRIVATE -> YYAction 448;
-    PROTECTED -> YYAction 449;
-    PUBLIC -> YYAction 450;
-    PURE -> YYAction 451;
-    MUTABLE -> YYAction 452;
+    CONID -> YYAction 448;
+    DOCUMENTATION -> YYAction 449;
+    NATIVE -> YYAction 450;
+    PRIVATE -> YYAction 451;
+    PROTECTED -> YYAction 452;
+    PUBLIC -> YYAction 453;
+    PURE -> YYAction 454;
+    MUTABLE -> YYAction 455;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction342 t =   case yychar t of {
-  '(' -> YYAction 340;
+private yyaction344 t =   case yychar t of {
+  '(' -> YYAction 342;
   '=' -> YYAction (-276);
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction343 t =   case yychar t of {
-  '=' -> YYAction 462;
+private yyaction345 t =   case yychar t of {
+  '=' -> YYAction 465;
   _ -> (YYAction yyErr);
 };
-private yyaction344 t =   case yytoken t of {
-    EARROW -> YYAction 463;
+private yyaction346 t =   case yytoken t of {
+    EARROW -> YYAction 466;
     _ -> (YYAction yyErr);
   };
-private yyaction345 t =   case yychar t of {
+private yyaction347 t =   case yychar t of {
   ';' -> YYAction (-314);
   '}' -> YYAction (-314);
   '(' -> YYAction (-246);
   '[' -> YYAction (-246);
   _ ->   case yytoken t of {
-    WHERE -> YYAction 266;
+    WHERE -> YYAction 268;
     VARID -> YYAction (-246);
     CONID -> YYAction (-246);
     QUALIFIER -> YYAction (-246);
@@ -3342,127 +3362,127 @@ private yyaction345 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction346 t =   case yychar t of {
+private yyaction348 t =   case yychar t of {
   ';' -> YYAction (-314);
   '}' -> YYAction (-314);
   _ ->   case yytoken t of {
-    WHERE -> YYAction 266;
+    WHERE -> YYAction 268;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction347 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction349 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction348 t =   case yychar t of {
-  '=' -> YYAction 467;
+private yyaction350 t =   case yychar t of {
+  '=' -> YYAction 470;
   _ -> (YYAction yyErr);
 };
-private yyaction349 t = YYAction (-267);
-private yyaction350 t =   case yychar t of {
-  '-' -> YYAction (-406);
-  '.' -> YYAction (-406);
-  '(' -> YYAction (-406);
-  ',' -> YYAction (-209);
-  '|' -> YYAction (-406);
-  '[' -> YYAction (-406);
-  '?' -> YYAction (-406);
-  '!' -> YYAction (-406);
-  '=' -> YYAction (-406);
-  '_' -> YYAction (-406);
-  _ ->   case yytoken t of {
-    VARID -> YYAction (-406);
-    CONID -> YYAction (-406);
-    QUALIFIER -> YYAction (-406);
-    TRUE -> YYAction (-406);
-    FALSE -> YYAction (-406);
-    DO -> YYAction (-406);
-    INTCONST -> YYAction (-406);
-    STRCONST -> YYAction (-406);
-    LONGCONST -> YYAction (-406);
-    FLTCONST -> YYAction (-406);
-    DBLCONST -> YYAction (-406);
-    CHRCONST -> YYAction (-406);
-    REGEXP -> YYAction (-406);
-    BIGCONST -> YYAction (-406);
-    DCOLON -> YYAction (-209);
-    SOMEOP -> YYAction (-406);
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction351 t =   case yychar t of {
-  '-' -> YYAction (-405);
-  '.' -> YYAction (-405);
-  '(' -> YYAction (-405);
-  ',' -> YYAction (-207);
-  '|' -> YYAction (-405);
-  '[' -> YYAction (-405);
-  '?' -> YYAction (-405);
-  '!' -> YYAction (-405);
-  '=' -> YYAction (-405);
-  '_' -> YYAction (-405);
-  _ ->   case yytoken t of {
-    VARID -> YYAction (-405);
-    CONID -> YYAction (-405);
-    QUALIFIER -> YYAction (-405);
-    TRUE -> YYAction (-405);
-    FALSE -> YYAction (-405);
-    DO -> YYAction (-405);
-    INTCONST -> YYAction (-405);
-    STRCONST -> YYAction (-405);
-    LONGCONST -> YYAction (-405);
-    FLTCONST -> YYAction (-405);
-    DBLCONST -> YYAction (-405);
-    CHRCONST -> YYAction (-405);
-    REGEXP -> YYAction (-405);
-    BIGCONST -> YYAction (-405);
-    DCOLON -> YYAction (-207);
-    SOMEOP -> YYAction (-405);
-    _ -> (YYAction yyErr);
-  };
-};
+private yyaction351 t = YYAction (-267);
 private yyaction352 t =   case yychar t of {
-  '-' -> YYAction (-404);
-  '.' -> YYAction (-404);
-  '(' -> YYAction (-404);
-  ',' -> YYAction (-208);
-  '|' -> YYAction (-404);
-  '[' -> YYAction (-404);
-  '?' -> YYAction (-404);
-  '!' -> YYAction (-404);
-  '=' -> YYAction (-404);
-  '_' -> YYAction (-404);
+  '-' -> YYAction (-409);
+  '.' -> YYAction (-409);
+  '(' -> YYAction (-409);
+  ',' -> YYAction (-209);
+  '|' -> YYAction (-409);
+  '[' -> YYAction (-409);
+  '?' -> YYAction (-409);
+  '!' -> YYAction (-409);
+  '=' -> YYAction (-409);
+  '_' -> YYAction (-409);
   _ ->   case yytoken t of {
-    VARID -> YYAction (-404);
-    CONID -> YYAction (-404);
-    QUALIFIER -> YYAction (-404);
-    TRUE -> YYAction (-404);
-    FALSE -> YYAction (-404);
-    DO -> YYAction (-404);
-    INTCONST -> YYAction (-404);
-    STRCONST -> YYAction (-404);
-    LONGCONST -> YYAction (-404);
-    FLTCONST -> YYAction (-404);
-    DBLCONST -> YYAction (-404);
-    CHRCONST -> YYAction (-404);
-    REGEXP -> YYAction (-404);
-    BIGCONST -> YYAction (-404);
-    DCOLON -> YYAction (-208);
-    SOMEOP -> YYAction (-404);
+    VARID -> YYAction (-409);
+    CONID -> YYAction (-409);
+    QUALIFIER -> YYAction (-409);
+    TRUE -> YYAction (-409);
+    FALSE -> YYAction (-409);
+    DO -> YYAction (-409);
+    INTCONST -> YYAction (-409);
+    STRCONST -> YYAction (-409);
+    LONGCONST -> YYAction (-409);
+    FLTCONST -> YYAction (-409);
+    DBLCONST -> YYAction (-409);
+    CHRCONST -> YYAction (-409);
+    REGEXP -> YYAction (-409);
+    BIGCONST -> YYAction (-409);
+    DCOLON -> YYAction (-209);
+    SOMEOP -> YYAction (-409);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction353 t = YYAction (-29);
+private yyaction353 t =   case yychar t of {
+  '-' -> YYAction (-408);
+  '.' -> YYAction (-408);
+  '(' -> YYAction (-408);
+  ',' -> YYAction (-207);
+  '|' -> YYAction (-408);
+  '[' -> YYAction (-408);
+  '?' -> YYAction (-408);
+  '!' -> YYAction (-408);
+  '=' -> YYAction (-408);
+  '_' -> YYAction (-408);
+  _ ->   case yytoken t of {
+    VARID -> YYAction (-408);
+    CONID -> YYAction (-408);
+    QUALIFIER -> YYAction (-408);
+    TRUE -> YYAction (-408);
+    FALSE -> YYAction (-408);
+    DO -> YYAction (-408);
+    INTCONST -> YYAction (-408);
+    STRCONST -> YYAction (-408);
+    LONGCONST -> YYAction (-408);
+    FLTCONST -> YYAction (-408);
+    DBLCONST -> YYAction (-408);
+    CHRCONST -> YYAction (-408);
+    REGEXP -> YYAction (-408);
+    BIGCONST -> YYAction (-408);
+    DCOLON -> YYAction (-207);
+    SOMEOP -> YYAction (-408);
+    _ -> (YYAction yyErr);
+  };
+};
 private yyaction354 t =   case yychar t of {
+  '-' -> YYAction (-407);
+  '.' -> YYAction (-407);
+  '(' -> YYAction (-407);
+  ',' -> YYAction (-208);
+  '|' -> YYAction (-407);
+  '[' -> YYAction (-407);
+  '?' -> YYAction (-407);
+  '!' -> YYAction (-407);
+  '=' -> YYAction (-407);
+  '_' -> YYAction (-407);
+  _ ->   case yytoken t of {
+    VARID -> YYAction (-407);
+    CONID -> YYAction (-407);
+    QUALIFIER -> YYAction (-407);
+    TRUE -> YYAction (-407);
+    FALSE -> YYAction (-407);
+    DO -> YYAction (-407);
+    INTCONST -> YYAction (-407);
+    STRCONST -> YYAction (-407);
+    LONGCONST -> YYAction (-407);
+    FLTCONST -> YYAction (-407);
+    DBLCONST -> YYAction (-407);
+    CHRCONST -> YYAction (-407);
+    REGEXP -> YYAction (-407);
+    BIGCONST -> YYAction (-407);
+    DCOLON -> YYAction (-208);
+    SOMEOP -> YYAction (-407);
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction355 t = YYAction (-29);
+private yyaction356 t =   case yychar t of {
   '-' -> YYAction 41;
-  '}' -> YYAction 468;
+  '}' -> YYAction 471;
   '(' -> YYAction 124;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
@@ -3490,69 +3510,69 @@ private yyaction354 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction355 t = YYAction (-203);
-private yyaction356 t = YYAction (-205);
-private yyaction357 t = YYAction (-211);
-private yyaction358 t =   case yytoken t of {
-    VARID -> YYAction 258;
-    CONID -> YYAction 259;
-    QUALIFIER -> YYAction 260;
-    STRCONST -> YYAction 261;
+private yyaction357 t = YYAction (-203);
+private yyaction358 t = YYAction (-205);
+private yyaction359 t = YYAction (-211);
+private yyaction360 t =   case yytoken t of {
+    VARID -> YYAction 260;
+    CONID -> YYAction 261;
+    QUALIFIER -> YYAction 262;
+    STRCONST -> YYAction 263;
     _ -> (YYAction yyErr);
   };
-private yyaction359 t = YYAction (-8);
-private yyaction360 t =   case yychar t of {
+private yyaction361 t = YYAction (-8);
+private yyaction362 t =   case yychar t of {
   ';' -> YYAction (-219);
   '}' -> YYAction (-219);
   '|' -> YYAction (-219);
   _ ->   case yytoken t of {
-    THROWS -> YYAction 471;
+    THROWS -> YYAction 474;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction361 t =   case yychar t of {
-  '|' -> YYAction 472;
+private yyaction363 t =   case yychar t of {
+  '|' -> YYAction 475;
   ';' -> YYAction (-220);
   '}' -> YYAction (-220);
   _ -> (YYAction yyErr);
 };
-private yyaction362 t = YYAction (-222);
-private yyaction363 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 195;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction364 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 195;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
-    _ -> (YYAction yyErr);
-  };
-};
+private yyaction364 t = YYAction (-222);
 private yyaction365 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction366 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction367 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction368 t =   case yychar t of {
   '-' -> YYAction 41;
-  '}' -> YYAction 479;
+  '}' -> YYAction 482;
   '(' -> YYAction 124;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
@@ -3564,16 +3584,16 @@ private yyaction366 t =   case yychar t of {
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
     DOCUMENTATION -> YYAction 108;
-    NATIVE -> YYAction 239;
+    NATIVE -> YYAction 241;
     TRUE -> YYAction 27;
     FALSE -> YYAction 28;
     IF -> YYAction 29;
     CASE -> YYAction 30;
     LET -> YYAction 31;
     DO -> YYAction 32;
-    PRIVATE -> YYAction 476;
-    PROTECTED -> YYAction 477;
-    PUBLIC -> YYAction 478;
+    PRIVATE -> YYAction 479;
+    PROTECTED -> YYAction 480;
+    PUBLIC -> YYAction 481;
     PURE -> YYAction 123;
     INTCONST -> YYAction 33;
     STRCONST -> YYAction 34;
@@ -3586,33 +3606,33 @@ private yyaction366 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction367 t =   case yychar t of {
+private yyaction369 t =   case yychar t of {
   ',' -> YYAction (-345);
   '=' -> YYAction (-345);
   _ ->   case yytoken t of {
-    GETS -> YYAction 284;
+    GETS -> YYAction 286;
     ARROW -> YYAction (-345);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction368 t =   case yychar t of {
-  ',' -> YYAction 485;
+private yyaction370 t =   case yychar t of {
+  ',' -> YYAction 488;
   '=' -> YYAction (-347);
   _ ->   case yytoken t of {
     ARROW -> YYAction (-347);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction369 t =   case yychar t of {
-  '=' -> YYAction 487;
+private yyaction371 t =   case yychar t of {
+  '=' -> YYAction 490;
   _ ->   case yytoken t of {
-    ARROW -> YYAction 486;
+    ARROW -> YYAction 489;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction370 t = YYAction (-319);
-private yyaction371 t = YYAction (-352);
-private yyaction372 t =   case yychar t of {
+private yyaction372 t = YYAction (-319);
+private yyaction373 t = YYAction (-352);
+private yyaction374 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
@@ -3620,24 +3640,24 @@ private yyaction372 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction373 t = YYAction (-190);
-private yyaction374 t = YYAction (-21);
-private yyaction375 t =   case yychar t of {
+private yyaction375 t = YYAction (-190);
+private yyaction376 t = YYAction (-21);
+private yyaction377 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
     VARID -> YYAction 74;
-    QUALIFIER -> YYAction 272;
+    QUALIFIER -> YYAction 274;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction376 t = YYAction (-366);
-private yyaction377 t =   case yytoken t of {
-    ELSE -> YYAction 491;
+private yyaction378 t = YYAction (-367);
+private yyaction379 t =   case yytoken t of {
+    ELSE -> YYAction 494;
     _ -> (YYAction yyErr);
   };
-private yyaction378 t =   case yychar t of {
+private yyaction380 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -3666,64 +3686,29 @@ private yyaction378 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction379 t =   case yychar t of {
-  '|' -> YYAction 268;
-  '=' -> YYAction 487;
+private yyaction381 t = YYAction (-333);
+private yyaction382 t =   case yychar t of {
+  '|' -> YYAction 270;
+  '=' -> YYAction 490;
   _ ->   case yytoken t of {
-    ARROW -> YYAction 486;
+    ARROW -> YYAction 489;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction380 t =   case yychar t of {
-  ';' -> YYAction 495;
+private yyaction383 t =   case yychar t of {
+  ';' -> YYAction 498;
   '}' -> YYAction (-356);
   _ ->   case yytoken t of {
-    WHERE -> YYAction 249;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction381 t =   case yychar t of {
-  '}' -> YYAction 497;
-  _ -> (YYAction yyErr);
-};
-private yyaction382 t = YYAction (-141);
-private yyaction383 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
+    WHERE -> YYAction 251;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction384 t =   case yychar t of {
-  '}' -> YYAction 499;
+  '}' -> YYAction 500;
   _ -> (YYAction yyErr);
 };
-private yyaction385 t = YYAction (-346);
-private yyaction386 t = YYAction (-337);
-private yyaction387 t = YYAction (-344);
-private yyaction388 t =   case yychar t of {
+private yyaction385 t = YYAction (-141);
+private yyaction386 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -3731,7 +3716,6 @@ private yyaction388 t =   case yychar t of {
   '!' -> YYAction 45;
   '\\' -> YYAction 46;
   '_' -> YYAction 47;
-  ')' -> YYAction (-436);
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
     CONID -> YYAction 25;
@@ -3753,9 +3737,46 @@ private yyaction388 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction389 t = YYAction (-411);
-private yyaction390 t = YYAction (-410);
+private yyaction387 t =   case yychar t of {
+  '}' -> YYAction 502;
+  _ -> (YYAction yyErr);
+};
+private yyaction388 t = YYAction (-346);
+private yyaction389 t = YYAction (-337);
+private yyaction390 t = YYAction (-344);
 private yyaction391 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  ')' -> YYAction (-439);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction392 t = YYAction (-414);
+private yyaction393 t = YYAction (-413);
+private yyaction394 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -3785,69 +3806,69 @@ private yyaction391 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction392 t = YYAction (-417);
-private yyaction393 t = YYAction (-416);
-private yyaction394 t = YYAction (-429);
-private yyaction395 t = YYAction (-421);
-private yyaction396 t = YYAction (-233);
-private yyaction397 t = YYAction (-232);
-private yyaction398 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction395 t = YYAction (-420);
+private yyaction396 t = YYAction (-419);
+private yyaction397 t = YYAction (-432);
+private yyaction398 t = YYAction (-424);
+private yyaction399 t = YYAction (-233);
+private yyaction400 t = YYAction (-232);
+private yyaction401 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
+    QUALIFIER -> YYAction 198;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction399 t = YYAction (-227);
-private yyaction400 t =   case yychar t of {
-  '(' -> YYAction 505;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 503;
-    SOMEOP -> YYAction 504;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction401 t = YYAction (-258);
-private yyaction402 t = YYAction (-248);
+private yyaction402 t = YYAction (-227);
 private yyaction403 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+  '(' -> YYAction 508;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    VARID -> YYAction 506;
+    SOMEOP -> YYAction 507;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction404 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction404 t = YYAction (-258);
+private yyaction405 t = YYAction (-248);
+private yyaction406 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction405 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction407 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction406 t = YYAction (-257);
-private yyaction407 t = YYAction (-251);
 private yyaction408 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction409 t = YYAction (-257);
+private yyaction410 t = YYAction (-251);
+private yyaction411 t =   case yychar t of {
   '-' -> YYAction (-236);
   ';' -> YYAction (-236);
   '}' -> YYAction (-236);
@@ -3856,9 +3877,8 @@ private yyaction408 t =   case yychar t of {
   '|' -> YYAction (-236);
   ']' -> YYAction (-236);
   '=' -> YYAction (-236);
-  '\\' -> YYAction (-236);
   _ ->   case yytoken t of {
-    ARROW -> YYAction 317;
+    ARROW -> YYAction 319;
     DOCUMENTATION -> YYAction (-236);
     WHERE -> YYAction (-236);
     CLASS -> YYAction (-236);
@@ -3874,11 +3894,11 @@ private yyaction408 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction409 t = YYAction (-237);
-private yyaction410 t = YYAction (-234);
-private yyaction411 t =   case yychar t of {
+private yyaction412 t = YYAction (-237);
+private yyaction413 t = YYAction (-234);
+private yyaction414 t =   case yychar t of {
   '-' -> YYAction 41;
-  '}' -> YYAction 513;
+  '}' -> YYAction 516;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
@@ -3906,13 +3926,13 @@ private yyaction411 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction412 t =   case yychar t of {
-  '}' -> YYAction 514;
+private yyaction415 t =   case yychar t of {
+  '}' -> YYAction 517;
   _ -> (YYAction yyErr);
 };
-private yyaction413 t =   case yychar t of {
+private yyaction416 t =   case yychar t of {
   '-' -> YYAction 41;
-  '}' -> YYAction 515;
+  '}' -> YYAction 518;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
@@ -3940,37 +3960,37 @@ private yyaction413 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction414 t = YYAction (-394);
-private yyaction415 t = YYAction (-395);
-private yyaction416 t = YYAction (-389);
-private yyaction417 t = YYAction (-426);
-private yyaction418 t = YYAction (-387);
-private yyaction419 t = YYAction (-388);
-private yyaction420 t = YYAction (-427);
-private yyaction421 t =   case yychar t of {
-  '=' -> YYAction 517;
-  '}' -> YYAction (-428);
-  ',' -> YYAction (-428);
+private yyaction417 t = YYAction (-397);
+private yyaction418 t = YYAction (-398);
+private yyaction419 t = YYAction (-392);
+private yyaction420 t = YYAction (-429);
+private yyaction421 t = YYAction (-390);
+private yyaction422 t = YYAction (-391);
+private yyaction423 t = YYAction (-430);
+private yyaction424 t =   case yychar t of {
+  '=' -> YYAction 520;
+  '}' -> YYAction (-431);
+  ',' -> YYAction (-431);
   _ ->   case yytoken t of {
-    GETS -> YYAction 516;
+    GETS -> YYAction 519;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction422 t = YYAction (-424);
-private yyaction423 t =   case yychar t of {
-  '(' -> YYAction 332;
+private yyaction425 t = YYAction (-427);
+private yyaction426 t =   case yychar t of {
+  '(' -> YYAction 334;
   ';' -> YYAction (-145);
   '}' -> YYAction (-145);
   _ ->   case yytoken t of {
-    VARID -> YYAction 190;
-    PUBLIC -> YYAction 331;
+    VARID -> YYAction 192;
+    PUBLIC -> YYAction 333;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction424 t = YYAction (-144);
-private yyaction425 t = YYAction (-149);
-private yyaction426 t =   case yychar t of {
-  '(' -> YYAction 519;
+private yyaction427 t = YYAction (-144);
+private yyaction428 t = YYAction (-149);
+private yyaction429 t =   case yychar t of {
+  '(' -> YYAction 522;
   ')' -> YYAction (-186);
   ',' -> YYAction (-186);
   _ ->   case yytoken t of {
@@ -3980,165 +4000,165 @@ private yyaction426 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction427 t =   case yychar t of {
+private yyaction430 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
     VARID -> YYAction 74;
     CONID -> YYAction 75;
-    QUALIFIER -> YYAction 520;
+    QUALIFIER -> YYAction 523;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction428 t =   case yychar t of {
+private yyaction431 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
-    CONID -> YYAction 426;
-    QUALIFIER -> YYAction 427;
-    PUBLIC -> YYAction 428;
+    CONID -> YYAction 429;
+    QUALIFIER -> YYAction 430;
+    PUBLIC -> YYAction 431;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction429 t = YYAction (-147);
-private yyaction430 t =   case yychar t of {
-  ')' -> YYAction 522;
+private yyaction432 t = YYAction (-147);
+private yyaction433 t =   case yychar t of {
+  ')' -> YYAction 525;
   _ -> (YYAction yyErr);
 };
-private yyaction431 t =   case yychar t of {
-  ',' -> YYAction 523;
+private yyaction434 t =   case yychar t of {
+  ',' -> YYAction 526;
   ')' -> YYAction (-150);
   _ -> (YYAction yyErr);
 };
-private yyaction432 t =   case yychar t of {
+private yyaction435 t =   case yychar t of {
   ')' -> YYAction (-159);
   ',' -> YYAction (-159);
   _ ->   case yytoken t of {
-    VARID -> YYAction 524;
-    CONID -> YYAction 525;
+    VARID -> YYAction 527;
+    CONID -> YYAction 528;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction433 t = YYAction (-153);
-private yyaction434 t = YYAction (-156);
-private yyaction435 t = YYAction (-157);
-private yyaction436 t = YYAction (-158);
-private yyaction437 t =   case yychar t of {
+private yyaction436 t = YYAction (-153);
+private yyaction437 t = YYAction (-156);
+private yyaction438 t = YYAction (-157);
+private yyaction439 t = YYAction (-158);
+private yyaction440 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
-    CONID -> YYAction 426;
-    QUALIFIER -> YYAction 427;
-    PUBLIC -> YYAction 428;
+    CONID -> YYAction 429;
+    QUALIFIER -> YYAction 430;
+    PUBLIC -> YYAction 431;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction438 t = YYAction (-44);
-private yyaction439 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction441 t = YYAction (-44);
+private yyaction442 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction440 t =   case yytoken t of {
-    WHERE -> YYAction 530;
+private yyaction443 t =   case yytoken t of {
+    WHERE -> YYAction 533;
     _ -> (YYAction yyErr);
   };
-private yyaction441 t = YYAction (-209);
-private yyaction442 t = YYAction (-207);
-private yyaction443 t = YYAction (-208);
-private yyaction444 t =   case yytoken t of {
-    DCOLON -> YYAction 400;
+private yyaction444 t = YYAction (-209);
+private yyaction445 t = YYAction (-207);
+private yyaction446 t = YYAction (-208);
+private yyaction447 t =   case yytoken t of {
+    DCOLON -> YYAction 403;
     _ -> (YYAction yyErr);
   };
-private yyaction445 t =   case yychar t of {
-  '{' -> YYAction 532;
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction448 t =   case yychar t of {
+  '{' -> YYAction 535;
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   ';' -> YYAction (-290);
   '}' -> YYAction (-290);
   '|' -> YYAction (-290);
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
+    QUALIFIER -> YYAction 198;
     DOCUMENTATION -> YYAction (-290);
     WHERE -> YYAction (-290);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction446 t =   case yychar t of {
-  '?' -> YYAction 453;
-  '!' -> YYAction 454;
-  _ ->   case yytoken t of {
-    CONID -> YYAction 445;
-    PRIVATE -> YYAction 448;
-    PROTECTED -> YYAction 449;
-    PUBLIC -> YYAction 450;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction447 t = YYAction (-271);
-private yyaction448 t =   case yychar t of {
-  '?' -> YYAction 453;
-  '!' -> YYAction 454;
-  _ ->   case yytoken t of {
-    CONID -> YYAction 445;
-    _ -> (YYAction yyErr);
-  };
-};
 private yyaction449 t =   case yychar t of {
-  '?' -> YYAction 453;
-  '!' -> YYAction 454;
+  '?' -> YYAction 456;
+  '!' -> YYAction 457;
   _ ->   case yytoken t of {
-    CONID -> YYAction 445;
+    CONID -> YYAction 448;
+    PRIVATE -> YYAction 451;
+    PROTECTED -> YYAction 452;
+    PUBLIC -> YYAction 453;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction450 t =   case yychar t of {
-  '?' -> YYAction 453;
-  '!' -> YYAction 454;
+private yyaction450 t = YYAction (-271);
+private yyaction451 t =   case yychar t of {
+  '?' -> YYAction 456;
+  '!' -> YYAction 457;
   _ ->   case yytoken t of {
-    CONID -> YYAction 445;
+    CONID -> YYAction 448;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction451 t =   case yytoken t of {
-    NATIVE -> YYAction 539;
+private yyaction452 t =   case yychar t of {
+  '?' -> YYAction 456;
+  '!' -> YYAction 457;
+  _ ->   case yytoken t of {
+    CONID -> YYAction 448;
     _ -> (YYAction yyErr);
   };
-private yyaction452 t =   case yytoken t of {
-    NATIVE -> YYAction 540;
+};
+private yyaction453 t =   case yychar t of {
+  '?' -> YYAction 456;
+  '!' -> YYAction 457;
+  _ ->   case yytoken t of {
+    CONID -> YYAction 448;
     _ -> (YYAction yyErr);
   };
-private yyaction453 t =   case yytoken t of {
-    CONID -> YYAction 445;
-    _ -> (YYAction yyErr);
-  };
+};
 private yyaction454 t =   case yytoken t of {
-    CONID -> YYAction 445;
+    NATIVE -> YYAction 542;
     _ -> (YYAction yyErr);
   };
 private yyaction455 t =   case yytoken t of {
-    VARID -> YYAction 258;
-    CONID -> YYAction 259;
-    QUALIFIER -> YYAction 260;
-    STRCONST -> YYAction 261;
+    NATIVE -> YYAction 543;
     _ -> (YYAction yyErr);
   };
-private yyaction456 t = YYAction (-275);
-private yyaction457 t =   case yychar t of {
-  '|' -> YYAction 544;
+private yyaction456 t =   case yytoken t of {
+    CONID -> YYAction 448;
+    _ -> (YYAction yyErr);
+  };
+private yyaction457 t =   case yytoken t of {
+    CONID -> YYAction 448;
+    _ -> (YYAction yyErr);
+  };
+private yyaction458 t =   case yytoken t of {
+    VARID -> YYAction 260;
+    CONID -> YYAction 261;
+    QUALIFIER -> YYAction 262;
+    STRCONST -> YYAction 263;
+    _ -> (YYAction yyErr);
+  };
+private yyaction459 t = YYAction (-275);
+private yyaction460 t =   case yychar t of {
+  '|' -> YYAction 547;
   ';' -> YYAction (-278);
   '}' -> YYAction (-278);
   _ ->   case yytoken t of {
@@ -4146,84 +4166,84 @@ private yyaction457 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction458 t =   case yychar t of {
+private yyaction461 t =   case yychar t of {
   ';' -> YYAction (-280);
   '}' -> YYAction (-280);
   '|' -> YYAction (-280);
   _ ->   case yytoken t of {
-    DOCUMENTATION -> YYAction 545;
+    DOCUMENTATION -> YYAction 548;
     WHERE -> YYAction (-280);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction459 t = YYAction (-283);
-private yyaction460 t = YYAction (-289);
-private yyaction461 t = YYAction (-277);
-private yyaction462 t =   case yychar t of {
-  '?' -> YYAction 453;
-  '!' -> YYAction 454;
+private yyaction462 t = YYAction (-283);
+private yyaction463 t = YYAction (-289);
+private yyaction464 t = YYAction (-277);
+private yyaction465 t =   case yychar t of {
+  '?' -> YYAction 456;
+  '!' -> YYAction 457;
   _ ->   case yytoken t of {
-    CONID -> YYAction 445;
-    DOCUMENTATION -> YYAction 446;
-    NATIVE -> YYAction 447;
-    PRIVATE -> YYAction 448;
-    PROTECTED -> YYAction 449;
-    PUBLIC -> YYAction 450;
-    PURE -> YYAction 451;
-    MUTABLE -> YYAction 452;
+    CONID -> YYAction 448;
+    DOCUMENTATION -> YYAction 449;
+    NATIVE -> YYAction 450;
+    PRIVATE -> YYAction 451;
+    PROTECTED -> YYAction 452;
+    PUBLIC -> YYAction 453;
+    PURE -> YYAction 454;
+    MUTABLE -> YYAction 455;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction463 t =   case yytoken t of {
-    VARID -> YYAction 190;
+private yyaction466 t =   case yytoken t of {
+    VARID -> YYAction 192;
     _ -> (YYAction yyErr);
   };
-private yyaction464 t = YYAction (-264);
-private yyaction465 t = YYAction (-266);
-private yyaction466 t = YYAction (-312);
-private yyaction467 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction467 t = YYAction (-264);
+private yyaction468 t = YYAction (-266);
+private yyaction469 t = YYAction (-312);
+private yyaction470 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction468 t = YYAction (-317);
-private yyaction469 t =   case yychar t of {
-  '}' -> YYAction 550;
+private yyaction471 t = YYAction (-317);
+private yyaction472 t =   case yychar t of {
+  '}' -> YYAction 553;
   _ -> (YYAction yyErr);
 };
-private yyaction470 t = YYAction (-7);
-private yyaction471 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction473 t = YYAction (-7);
+private yyaction474 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction472 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction475 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction473 t = YYAction (-223);
-private yyaction474 t = YYAction (-224);
-private yyaction475 t = YYAction (-225);
-private yyaction476 t =   case yychar t of {
+private yyaction476 t = YYAction (-223);
+private yyaction477 t = YYAction (-224);
+private yyaction478 t = YYAction (-225);
+private yyaction479 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 124;
   '[' -> YYAction 43;
@@ -4235,7 +4255,7 @@ private yyaction476 t =   case yychar t of {
     VARID -> YYAction 107;
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
-    NATIVE -> YYAction 239;
+    NATIVE -> YYAction 241;
     TRUE -> YYAction 27;
     FALSE -> YYAction 28;
     IF -> YYAction 29;
@@ -4254,70 +4274,70 @@ private yyaction476 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction477 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 124;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 107;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    NATIVE -> YYAction 239;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    PURE -> YYAction 123;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction478 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 124;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 107;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    NATIVE -> YYAction 239;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    PURE -> YYAction 123;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction479 t = YYAction (-315);
 private yyaction480 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 124;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 107;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    NATIVE -> YYAction 241;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    PURE -> YYAction 123;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction481 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 124;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 107;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    NATIVE -> YYAction 241;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    PURE -> YYAction 123;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction482 t = YYAction (-315);
+private yyaction483 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 124;
   '[' -> YYAction 43;
@@ -4332,16 +4352,16 @@ private yyaction480 t =   case yychar t of {
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
     DOCUMENTATION -> YYAction 108;
-    NATIVE -> YYAction 239;
+    NATIVE -> YYAction 241;
     TRUE -> YYAction 27;
     FALSE -> YYAction 28;
     IF -> YYAction 29;
     CASE -> YYAction 30;
     LET -> YYAction 31;
     DO -> YYAction 32;
-    PRIVATE -> YYAction 476;
-    PROTECTED -> YYAction 477;
-    PUBLIC -> YYAction 478;
+    PRIVATE -> YYAction 479;
+    PROTECTED -> YYAction 480;
+    PUBLIC -> YYAction 481;
     PURE -> YYAction 123;
     INTCONST -> YYAction 33;
     STRCONST -> YYAction 34;
@@ -4354,18 +4374,18 @@ private yyaction480 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction481 t = YYAction (-130);
-private yyaction482 t =   case yychar t of {
-  '}' -> YYAction 557;
+private yyaction484 t = YYAction (-130);
+private yyaction485 t =   case yychar t of {
+  '}' -> YYAction 560;
   _ -> (YYAction yyErr);
 };
-private yyaction483 t =   case yychar t of {
+private yyaction486 t =   case yychar t of {
   ';' -> YYAction 8;
   '}' -> YYAction (-124);
   _ -> (YYAction yyErr);
 };
-private yyaction484 t = YYAction (-136);
-private yyaction485 t =   case yychar t of {
+private yyaction487 t = YYAction (-136);
+private yyaction488 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -4396,9 +4416,9 @@ private yyaction485 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction486 t = YYAction (-334);
-private yyaction487 t = YYAction (-335);
-private yyaction488 t =   case yychar t of {
+private yyaction489 t = YYAction (-334);
+private yyaction490 t = YYAction (-335);
+private yyaction491 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -4427,12 +4447,12 @@ private yyaction488 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction489 t = YYAction (-189);
-private yyaction490 t = YYAction (-180);
-private yyaction491 t = YYAction (-365);
-private yyaction492 t = YYAction (-371);
-private yyaction493 t = YYAction (-354);
-private yyaction494 t =   case yychar t of {
+private yyaction492 t = YYAction (-189);
+private yyaction493 t = YYAction (-180);
+private yyaction494 t = YYAction (-366);
+private yyaction495 t = YYAction (-372);
+private yyaction496 t = YYAction (-354);
+private yyaction497 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -4461,7 +4481,7 @@ private yyaction494 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction495 t =   case yychar t of {
+private yyaction498 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -4491,45 +4511,45 @@ private yyaction495 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction496 t = YYAction (-355);
-private yyaction497 t = YYAction (-372);
-private yyaction498 t = YYAction (-373);
-private yyaction499 t =   case yychar t of {
+private yyaction499 t = YYAction (-355);
+private yyaction500 t = YYAction (-373);
+private yyaction501 t = YYAction (-374);
+private yyaction502 t =   case yychar t of {
   ';' -> YYAction (-338);
   '}' -> YYAction (-338);
   ',' -> YYAction (-338);
   ']' -> YYAction (-338);
   _ ->   case yytoken t of {
-    IN -> YYAction 383;
+    IN -> YYAction 386;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction500 t = YYAction (-435);
-private yyaction501 t = YYAction (-340);
-private yyaction502 t = YYAction (-231);
-private yyaction503 t = YYAction (-262);
-private yyaction504 t = YYAction (-261);
-private yyaction505 t =   case yychar t of {
-  '(' -> YYAction 505;
+private yyaction503 t = YYAction (-438);
+private yyaction504 t = YYAction (-340);
+private yyaction505 t = YYAction (-231);
+private yyaction506 t = YYAction (-262);
+private yyaction507 t = YYAction (-261);
+private yyaction508 t =   case yychar t of {
+  '(' -> YYAction 508;
   _ ->   case yytoken t of {
-    VARID -> YYAction 503;
-    SOMEOP -> YYAction 504;
+    VARID -> YYAction 506;
+    SOMEOP -> YYAction 507;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction506 t =   case yychar t of {
-  ')' -> YYAction 564;
+private yyaction509 t =   case yychar t of {
+  ')' -> YYAction 567;
   _ -> (YYAction yyErr);
 };
-private yyaction507 t =   case yychar t of {
+private yyaction510 t =   case yychar t of {
   ')' -> YYAction (-260);
   _ ->   case yytoken t of {
-    ARROW -> YYAction 565;
+    ARROW -> YYAction 568;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction508 t =   case yychar t of {
-  ',' -> YYAction 566;
+private yyaction511 t =   case yychar t of {
+  ',' -> YYAction 569;
   ';' -> YYAction (-241);
   '}' -> YYAction (-241);
   ')' -> YYAction (-241);
@@ -4539,93 +4559,93 @@ private yyaction508 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction509 t =   case yychar t of {
-  ')' -> YYAction 567;
+private yyaction512 t =   case yychar t of {
+  ')' -> YYAction 570;
   _ -> (YYAction yyErr);
 };
-private yyaction510 t =   case yychar t of {
-  '|' -> YYAction 568;
+private yyaction513 t =   case yychar t of {
+  '|' -> YYAction 571;
   ')' -> YYAction (-243);
   _ -> (YYAction yyErr);
 };
-private yyaction511 t =   case yychar t of {
-  ')' -> YYAction 569;
+private yyaction514 t =   case yychar t of {
+  ')' -> YYAction 572;
   _ -> (YYAction yyErr);
 };
-private yyaction512 t = YYAction (-240);
-private yyaction513 t = YYAction (-393);
-private yyaction514 t = YYAction (-391);
-private yyaction515 t = YYAction (-392);
-private yyaction516 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction517 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction518 t = YYAction (-143);
+private yyaction515 t = YYAction (-240);
+private yyaction516 t = YYAction (-396);
+private yyaction517 t = YYAction (-394);
+private yyaction518 t = YYAction (-395);
 private yyaction519 t =   case yychar t of {
-  ')' -> YYAction 571;
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
   _ ->   case yytoken t of {
-    VARID -> YYAction 524;
-    CONID -> YYAction 525;
-    PUBLIC -> YYAction 570;
-    SOMEOP -> YYAction 84;
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction520 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction521 t = YYAction (-143);
+private yyaction522 t =   case yychar t of {
+  ')' -> YYAction 574;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 527;
+    CONID -> YYAction 528;
+    PUBLIC -> YYAction 573;
+    SOMEOP -> YYAction 84;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction523 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
@@ -4634,96 +4654,96 @@ private yyaction520 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction521 t = YYAction (-161);
-private yyaction522 t = YYAction (-148);
-private yyaction523 t =   case yychar t of {
+private yyaction524 t = YYAction (-161);
+private yyaction525 t = YYAction (-148);
+private yyaction526 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   ')' -> YYAction (-151);
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
-    CONID -> YYAction 426;
-    QUALIFIER -> YYAction 427;
-    PUBLIC -> YYAction 428;
+    CONID -> YYAction 429;
+    QUALIFIER -> YYAction 430;
+    PUBLIC -> YYAction 431;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction524 t = YYAction (-168);
-private yyaction525 t = YYAction (-169);
-private yyaction526 t = YYAction (-170);
-private yyaction527 t = YYAction (-160);
-private yyaction528 t =   case yychar t of {
-  ')' -> YYAction 576;
+private yyaction527 t = YYAction (-168);
+private yyaction528 t = YYAction (-169);
+private yyaction529 t = YYAction (-170);
+private yyaction530 t = YYAction (-160);
+private yyaction531 t =   case yychar t of {
+  ')' -> YYAction 579;
   _ -> (YYAction yyErr);
 };
-private yyaction529 t = YYAction (-46);
-private yyaction530 t =   case yychar t of {
-  '{' -> YYAction 577;
+private yyaction532 t = YYAction (-46);
+private yyaction533 t =   case yychar t of {
+  '{' -> YYAction 580;
   _ -> (YYAction yyErr);
 };
-private yyaction531 t = YYAction (-42);
-private yyaction532 t =   case yychar t of {
-  '?' -> YYAction 580;
-  '!' -> YYAction 581;
+private yyaction534 t = YYAction (-42);
+private yyaction535 t =   case yychar t of {
+  '?' -> YYAction 583;
+  '!' -> YYAction 584;
   _ ->   case yytoken t of {
-    VARID -> YYAction 190;
+    VARID -> YYAction 192;
     DOCUMENTATION -> YYAction 1;
-    PRIVATE -> YYAction 578;
-    PUBLIC -> YYAction 579;
+    PRIVATE -> YYAction 581;
+    PUBLIC -> YYAction 582;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction533 t = YYAction (-293);
-private yyaction534 t = YYAction (-292);
-private yyaction535 t = YYAction (-282);
-private yyaction536 t = YYAction (-285);
-private yyaction537 t = YYAction (-286);
-private yyaction538 t = YYAction (-284);
-private yyaction539 t = YYAction (-269);
-private yyaction540 t = YYAction (-270);
-private yyaction541 t = YYAction (-288);
-private yyaction542 t = YYAction (-287);
-private yyaction543 t = YYAction (-272);
-private yyaction544 t =   case yychar t of {
-  '?' -> YYAction 453;
-  '!' -> YYAction 454;
+private yyaction536 t = YYAction (-293);
+private yyaction537 t = YYAction (-292);
+private yyaction538 t = YYAction (-282);
+private yyaction539 t = YYAction (-285);
+private yyaction540 t = YYAction (-286);
+private yyaction541 t = YYAction (-284);
+private yyaction542 t = YYAction (-269);
+private yyaction543 t = YYAction (-270);
+private yyaction544 t = YYAction (-288);
+private yyaction545 t = YYAction (-287);
+private yyaction546 t = YYAction (-272);
+private yyaction547 t =   case yychar t of {
+  '?' -> YYAction 456;
+  '!' -> YYAction 457;
   _ ->   case yytoken t of {
-    CONID -> YYAction 445;
-    DOCUMENTATION -> YYAction 446;
-    PRIVATE -> YYAction 448;
-    PROTECTED -> YYAction 449;
-    PUBLIC -> YYAction 450;
+    CONID -> YYAction 448;
+    DOCUMENTATION -> YYAction 449;
+    PRIVATE -> YYAction 451;
+    PROTECTED -> YYAction 452;
+    PUBLIC -> YYAction 453;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction545 t = YYAction (-281);
-private yyaction546 t =   case yytoken t of {
-    VARID -> YYAction 258;
-    CONID -> YYAction 259;
-    QUALIFIER -> YYAction 260;
-    STRCONST -> YYAction 261;
+private yyaction548 t = YYAction (-281);
+private yyaction549 t =   case yytoken t of {
+    VARID -> YYAction 260;
+    CONID -> YYAction 261;
+    QUALIFIER -> YYAction 262;
+    STRCONST -> YYAction 263;
     _ -> (YYAction yyErr);
   };
-private yyaction547 t = YYAction (-274);
-private yyaction548 t =   case yychar t of {
+private yyaction550 t = YYAction (-274);
+private yyaction551 t =   case yychar t of {
   ';' -> YYAction (-314);
   '}' -> YYAction (-314);
   _ ->   case yytoken t of {
-    WHERE -> YYAction 266;
+    WHERE -> YYAction 268;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction549 t = YYAction (-313);
-private yyaction550 t = YYAction (-318);
-private yyaction551 t = YYAction (-218);
-private yyaction552 t = YYAction (-221);
-private yyaction553 t = YYAction (-131);
-private yyaction554 t = YYAction (-132);
-private yyaction555 t = YYAction (-133);
-private yyaction556 t = YYAction (-135);
-private yyaction557 t = YYAction (-316);
-private yyaction558 t =   case yychar t of {
+private yyaction552 t = YYAction (-313);
+private yyaction553 t = YYAction (-318);
+private yyaction554 t = YYAction (-218);
+private yyaction555 t = YYAction (-221);
+private yyaction556 t = YYAction (-131);
+private yyaction557 t = YYAction (-132);
+private yyaction558 t = YYAction (-133);
+private yyaction559 t = YYAction (-135);
+private yyaction560 t = YYAction (-316);
+private yyaction561 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 124;
   '[' -> YYAction 43;
@@ -4737,16 +4757,16 @@ private yyaction558 t =   case yychar t of {
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
     DOCUMENTATION -> YYAction 108;
-    NATIVE -> YYAction 239;
+    NATIVE -> YYAction 241;
     TRUE -> YYAction 27;
     FALSE -> YYAction 28;
     IF -> YYAction 29;
     CASE -> YYAction 30;
     LET -> YYAction 31;
     DO -> YYAction 32;
-    PRIVATE -> YYAction 476;
-    PROTECTED -> YYAction 477;
-    PUBLIC -> YYAction 478;
+    PRIVATE -> YYAction 479;
+    PROTECTED -> YYAction 480;
+    PUBLIC -> YYAction 481;
     PURE -> YYAction 123;
     INTCONST -> YYAction 33;
     STRCONST -> YYAction 34;
@@ -4759,648 +4779,648 @@ private yyaction558 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction559 t = YYAction (-348);
-private yyaction560 t = YYAction (-350);
-private yyaction561 t = YYAction (-353);
-private yyaction562 t = YYAction (-357);
-private yyaction563 t =   case yychar t of {
-  ')' -> YYAction 594;
+private yyaction562 t = YYAction (-348);
+private yyaction563 t = YYAction (-350);
+private yyaction564 t = YYAction (-353);
+private yyaction565 t = YYAction (-357);
+private yyaction566 t =   case yychar t of {
+  ')' -> YYAction 597;
   _ -> (YYAction yyErr);
 };
-private yyaction564 t = YYAction (-253);
-private yyaction565 t =   case yychar t of {
-  '(' -> YYAction 505;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 503;
-    SOMEOP -> YYAction 504;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction566 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 195;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction567 t = YYAction (-249);
+private yyaction567 t = YYAction (-253);
 private yyaction568 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+  '(' -> YYAction 508;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    VARID -> YYAction 506;
+    SOMEOP -> YYAction 507;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction569 t = YYAction (-250);
-private yyaction570 t =   case yytoken t of {
-    VARID -> YYAction 524;
-    CONID -> YYAction 525;
-    PUBLIC -> YYAction 570;
+private yyaction569 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction570 t = YYAction (-249);
+private yyaction571 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction572 t = YYAction (-250);
+private yyaction573 t =   case yytoken t of {
+    VARID -> YYAction 527;
+    CONID -> YYAction 528;
+    PUBLIC -> YYAction 573;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
-private yyaction571 t = YYAction (-155);
-private yyaction572 t =   case yychar t of {
-  ')' -> YYAction 599;
+private yyaction574 t = YYAction (-155);
+private yyaction575 t =   case yychar t of {
+  ')' -> YYAction 602;
   _ -> (YYAction yyErr);
 };
-private yyaction573 t =   case yychar t of {
+private yyaction576 t =   case yychar t of {
   ')' -> YYAction (-162);
   ',' -> YYAction (-162);
   _ ->   case yytoken t of {
-    VARID -> YYAction 524;
-    CONID -> YYAction 525;
+    VARID -> YYAction 527;
+    CONID -> YYAction 528;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction574 t =   case yychar t of {
-  ',' -> YYAction 601;
+private yyaction577 t =   case yychar t of {
+  ',' -> YYAction 604;
   ')' -> YYAction (-165);
   _ -> (YYAction yyErr);
 };
-private yyaction575 t = YYAction (-152);
-private yyaction576 t = YYAction (-146);
-private yyaction577 t =   case yychar t of {
-  '-' -> YYAction 651;
-  ';' -> YYAction 652;
-  '{' -> YYAction 653;
-  '}' -> YYAction 654;
-  '.' -> YYAction 655;
-  '(' -> YYAction 656;
-  ')' -> YYAction 657;
-  ',' -> YYAction 658;
-  '|' -> YYAction 659;
-  '[' -> YYAction 660;
-  ']' -> YYAction 661;
-  '?' -> YYAction 662;
-  '!' -> YYAction 663;
-  '=' -> YYAction 664;
-  '\\' -> YYAction 665;
+private yyaction578 t = YYAction (-152);
+private yyaction579 t = YYAction (-146);
+private yyaction580 t =   case yychar t of {
+  '-' -> YYAction 654;
+  ';' -> YYAction 655;
+  '{' -> YYAction 656;
+  '}' -> YYAction 657;
+  '.' -> YYAction 658;
+  '(' -> YYAction 659;
+  ')' -> YYAction 660;
+  ',' -> YYAction 661;
+  '|' -> YYAction 662;
+  '[' -> YYAction 663;
+  ']' -> YYAction 664;
+  '?' -> YYAction 665;
+  '!' -> YYAction 666;
+  '=' -> YYAction 667;
+  '\\' -> YYAction 668;
   _ ->   case yytoken t of {
-    VARID -> YYAction 602;
-    CONID -> YYAction 603;
-    QVARID -> YYAction 604;
-    QCONID -> YYAction 605;
-    QUALIFIER -> YYAction 606;
-    DOCUMENTATION -> YYAction 607;
-    PACKAGE -> YYAction 608;
-    IMPORT -> YYAction 609;
-    INFIX -> YYAction 610;
-    INFIXR -> YYAction 611;
-    INFIXL -> YYAction 612;
-    NATIVE -> YYAction 613;
-    DATA -> YYAction 614;
-    WHERE -> YYAction 615;
-    CLASS -> YYAction 616;
-    INSTANCE -> YYAction 617;
-    ABSTRACT -> YYAction 618;
-    TYPE -> YYAction 619;
-    TRUE -> YYAction 620;
-    FALSE -> YYAction 621;
-    IF -> YYAction 622;
-    THEN -> YYAction 623;
-    ELSE -> YYAction 624;
-    CASE -> YYAction 625;
-    OF -> YYAction 626;
-    DERIVE -> YYAction 627;
-    LET -> YYAction 628;
-    IN -> YYAction 629;
-    DO -> YYAction 630;
-    FORALL -> YYAction 631;
-    PRIVATE -> YYAction 632;
-    PROTECTED -> YYAction 633;
-    PUBLIC -> YYAction 634;
-    PURE -> YYAction 635;
-    THROWS -> YYAction 636;
-    MUTABLE -> YYAction 637;
-    INTCONST -> YYAction 638;
-    STRCONST -> YYAction 639;
-    LONGCONST -> YYAction 640;
-    FLTCONST -> YYAction 641;
-    DBLCONST -> YYAction 642;
-    CHRCONST -> YYAction 643;
-    ARROW -> YYAction 644;
-    DCOLON -> YYAction 645;
-    GETS -> YYAction 646;
-    EARROW -> YYAction 647;
-    DOTDOT -> YYAction 648;
-    SOMEOP -> YYAction 649;
-    INTERPRET -> YYAction 650;
+    VARID -> YYAction 605;
+    CONID -> YYAction 606;
+    QVARID -> YYAction 607;
+    QCONID -> YYAction 608;
+    QUALIFIER -> YYAction 609;
+    DOCUMENTATION -> YYAction 610;
+    PACKAGE -> YYAction 611;
+    IMPORT -> YYAction 612;
+    INFIX -> YYAction 613;
+    INFIXR -> YYAction 614;
+    INFIXL -> YYAction 615;
+    NATIVE -> YYAction 616;
+    DATA -> YYAction 617;
+    WHERE -> YYAction 618;
+    CLASS -> YYAction 619;
+    INSTANCE -> YYAction 620;
+    ABSTRACT -> YYAction 621;
+    TYPE -> YYAction 622;
+    TRUE -> YYAction 623;
+    FALSE -> YYAction 624;
+    IF -> YYAction 625;
+    THEN -> YYAction 626;
+    ELSE -> YYAction 627;
+    CASE -> YYAction 628;
+    OF -> YYAction 629;
+    DERIVE -> YYAction 630;
+    LET -> YYAction 631;
+    IN -> YYAction 632;
+    DO -> YYAction 633;
+    FORALL -> YYAction 634;
+    PRIVATE -> YYAction 635;
+    PROTECTED -> YYAction 636;
+    PUBLIC -> YYAction 637;
+    PURE -> YYAction 638;
+    THROWS -> YYAction 639;
+    MUTABLE -> YYAction 640;
+    INTCONST -> YYAction 641;
+    STRCONST -> YYAction 642;
+    LONGCONST -> YYAction 643;
+    FLTCONST -> YYAction 644;
+    DBLCONST -> YYAction 645;
+    CHRCONST -> YYAction 646;
+    ARROW -> YYAction 647;
+    DCOLON -> YYAction 648;
+    GETS -> YYAction 649;
+    EARROW -> YYAction 650;
+    DOTDOT -> YYAction 651;
+    SOMEOP -> YYAction 652;
+    INTERPRET -> YYAction 653;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction578 t =   case yychar t of {
-  '?' -> YYAction 580;
-  '!' -> YYAction 581;
+private yyaction581 t =   case yychar t of {
+  '?' -> YYAction 583;
+  '!' -> YYAction 584;
   _ ->   case yytoken t of {
-    VARID -> YYAction 190;
+    VARID -> YYAction 192;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction579 t =   case yychar t of {
-  '?' -> YYAction 580;
-  '!' -> YYAction 581;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 190;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction580 t =   case yytoken t of {
-    VARID -> YYAction 190;
-    _ -> (YYAction yyErr);
-  };
-private yyaction581 t =   case yytoken t of {
-    VARID -> YYAction 190;
-    _ -> (YYAction yyErr);
-  };
 private yyaction582 t =   case yychar t of {
-  '?' -> YYAction 580;
-  '!' -> YYAction 581;
+  '?' -> YYAction 583;
+  '!' -> YYAction 584;
   _ ->   case yytoken t of {
-    VARID -> YYAction 190;
-    PRIVATE -> YYAction 578;
-    PUBLIC -> YYAction 579;
+    VARID -> YYAction 192;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction583 t = YYAction (-311);
-private yyaction584 t =   case yychar t of {
-  '}' -> YYAction 673;
+private yyaction583 t =   case yytoken t of {
+    VARID -> YYAction 192;
+    _ -> (YYAction yyErr);
+  };
+private yyaction584 t =   case yytoken t of {
+    VARID -> YYAction 192;
+    _ -> (YYAction yyErr);
+  };
+private yyaction585 t =   case yychar t of {
+  '?' -> YYAction 583;
+  '!' -> YYAction 584;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 192;
+    PRIVATE -> YYAction 581;
+    PUBLIC -> YYAction 582;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction586 t = YYAction (-311);
+private yyaction587 t =   case yychar t of {
+  '}' -> YYAction 676;
   _ -> (YYAction yyErr);
 };
-private yyaction585 t =   case yychar t of {
-  ',' -> YYAction 675;
+private yyaction588 t =   case yychar t of {
+  ',' -> YYAction 678;
   '}' -> YYAction (-296);
   _ ->   case yytoken t of {
-    DOCUMENTATION -> YYAction 674;
+    DOCUMENTATION -> YYAction 677;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction586 t =   case yytoken t of {
-    DCOLON -> YYAction 676;
+private yyaction589 t =   case yytoken t of {
+    DCOLON -> YYAction 679;
     _ -> (YYAction yyErr);
   };
-private yyaction587 t =   case yychar t of {
-  ',' -> YYAction 677;
+private yyaction590 t =   case yychar t of {
+  ',' -> YYAction 680;
   _ ->   case yytoken t of {
     DCOLON -> YYAction (-303);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction588 t = YYAction (-305);
-private yyaction589 t = YYAction (-308);
-private yyaction590 t = YYAction (-279);
-private yyaction591 t = YYAction (-273);
-private yyaction592 t = YYAction (-265);
-private yyaction593 t = YYAction (-126);
-private yyaction594 t = YYAction (-263);
-private yyaction595 t = YYAction (-259);
-private yyaction596 t = YYAction (-242);
-private yyaction597 t = YYAction (-244);
-private yyaction598 t = YYAction (-164);
-private yyaction599 t = YYAction (-154);
-private yyaction600 t = YYAction (-163);
-private yyaction601 t =   case yychar t of {
+private yyaction591 t = YYAction (-305);
+private yyaction592 t = YYAction (-308);
+private yyaction593 t = YYAction (-279);
+private yyaction594 t = YYAction (-273);
+private yyaction595 t = YYAction (-265);
+private yyaction596 t = YYAction (-126);
+private yyaction597 t = YYAction (-263);
+private yyaction598 t = YYAction (-259);
+private yyaction599 t = YYAction (-242);
+private yyaction600 t = YYAction (-244);
+private yyaction601 t = YYAction (-164);
+private yyaction602 t = YYAction (-154);
+private yyaction603 t = YYAction (-163);
+private yyaction604 t =   case yychar t of {
   ')' -> YYAction (-166);
   _ ->   case yytoken t of {
-    VARID -> YYAction 524;
-    CONID -> YYAction 525;
-    PUBLIC -> YYAction 570;
+    VARID -> YYAction 527;
+    CONID -> YYAction 528;
+    PUBLIC -> YYAction 573;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction602 t = YYAction (-49);
-private yyaction603 t = YYAction (-50);
-private yyaction604 t = YYAction (-51);
-private yyaction605 t = YYAction (-52);
-private yyaction606 t = YYAction (-53);
-private yyaction607 t = YYAction (-54);
-private yyaction608 t = YYAction (-55);
-private yyaction609 t = YYAction (-56);
-private yyaction610 t = YYAction (-57);
-private yyaction611 t = YYAction (-58);
-private yyaction612 t = YYAction (-59);
-private yyaction613 t = YYAction (-60);
-private yyaction614 t = YYAction (-61);
-private yyaction615 t = YYAction (-62);
-private yyaction616 t = YYAction (-63);
-private yyaction617 t = YYAction (-64);
-private yyaction618 t = YYAction (-65);
-private yyaction619 t = YYAction (-66);
-private yyaction620 t = YYAction (-67);
-private yyaction621 t = YYAction (-68);
-private yyaction622 t = YYAction (-69);
-private yyaction623 t = YYAction (-70);
-private yyaction624 t = YYAction (-71);
-private yyaction625 t = YYAction (-72);
-private yyaction626 t = YYAction (-73);
-private yyaction627 t = YYAction (-74);
-private yyaction628 t = YYAction (-75);
-private yyaction629 t = YYAction (-76);
-private yyaction630 t = YYAction (-77);
-private yyaction631 t = YYAction (-78);
-private yyaction632 t = YYAction (-79);
-private yyaction633 t = YYAction (-80);
-private yyaction634 t = YYAction (-81);
-private yyaction635 t = YYAction (-82);
-private yyaction636 t = YYAction (-83);
-private yyaction637 t = YYAction (-84);
-private yyaction638 t = YYAction (-85);
-private yyaction639 t = YYAction (-86);
-private yyaction640 t = YYAction (-87);
-private yyaction641 t = YYAction (-88);
-private yyaction642 t = YYAction (-89);
-private yyaction643 t = YYAction (-90);
-private yyaction644 t = YYAction (-91);
-private yyaction645 t = YYAction (-92);
-private yyaction646 t = YYAction (-93);
-private yyaction647 t = YYAction (-94);
-private yyaction648 t = YYAction (-95);
-private yyaction649 t = YYAction (-96);
-private yyaction650 t = YYAction (-97);
-private yyaction651 t = YYAction (-106);
-private yyaction652 t = YYAction (-107);
-private yyaction653 t =   case yychar t of {
-  '-' -> YYAction 651;
-  ';' -> YYAction 652;
-  '{' -> YYAction 653;
-  '}' -> YYAction 679;
-  '.' -> YYAction 655;
-  '(' -> YYAction 656;
-  ')' -> YYAction 657;
-  ',' -> YYAction 658;
-  '|' -> YYAction 659;
-  '[' -> YYAction 660;
-  ']' -> YYAction 661;
-  '?' -> YYAction 662;
-  '!' -> YYAction 663;
-  '=' -> YYAction 664;
-  '\\' -> YYAction 665;
+private yyaction605 t = YYAction (-49);
+private yyaction606 t = YYAction (-50);
+private yyaction607 t = YYAction (-51);
+private yyaction608 t = YYAction (-52);
+private yyaction609 t = YYAction (-53);
+private yyaction610 t = YYAction (-54);
+private yyaction611 t = YYAction (-55);
+private yyaction612 t = YYAction (-56);
+private yyaction613 t = YYAction (-57);
+private yyaction614 t = YYAction (-58);
+private yyaction615 t = YYAction (-59);
+private yyaction616 t = YYAction (-60);
+private yyaction617 t = YYAction (-61);
+private yyaction618 t = YYAction (-62);
+private yyaction619 t = YYAction (-63);
+private yyaction620 t = YYAction (-64);
+private yyaction621 t = YYAction (-65);
+private yyaction622 t = YYAction (-66);
+private yyaction623 t = YYAction (-67);
+private yyaction624 t = YYAction (-68);
+private yyaction625 t = YYAction (-69);
+private yyaction626 t = YYAction (-70);
+private yyaction627 t = YYAction (-71);
+private yyaction628 t = YYAction (-72);
+private yyaction629 t = YYAction (-73);
+private yyaction630 t = YYAction (-74);
+private yyaction631 t = YYAction (-75);
+private yyaction632 t = YYAction (-76);
+private yyaction633 t = YYAction (-77);
+private yyaction634 t = YYAction (-78);
+private yyaction635 t = YYAction (-79);
+private yyaction636 t = YYAction (-80);
+private yyaction637 t = YYAction (-81);
+private yyaction638 t = YYAction (-82);
+private yyaction639 t = YYAction (-83);
+private yyaction640 t = YYAction (-84);
+private yyaction641 t = YYAction (-85);
+private yyaction642 t = YYAction (-86);
+private yyaction643 t = YYAction (-87);
+private yyaction644 t = YYAction (-88);
+private yyaction645 t = YYAction (-89);
+private yyaction646 t = YYAction (-90);
+private yyaction647 t = YYAction (-91);
+private yyaction648 t = YYAction (-92);
+private yyaction649 t = YYAction (-93);
+private yyaction650 t = YYAction (-94);
+private yyaction651 t = YYAction (-95);
+private yyaction652 t = YYAction (-96);
+private yyaction653 t = YYAction (-97);
+private yyaction654 t = YYAction (-106);
+private yyaction655 t = YYAction (-107);
+private yyaction656 t =   case yychar t of {
+  '-' -> YYAction 654;
+  ';' -> YYAction 655;
+  '{' -> YYAction 656;
+  '}' -> YYAction 682;
+  '.' -> YYAction 658;
+  '(' -> YYAction 659;
+  ')' -> YYAction 660;
+  ',' -> YYAction 661;
+  '|' -> YYAction 662;
+  '[' -> YYAction 663;
+  ']' -> YYAction 664;
+  '?' -> YYAction 665;
+  '!' -> YYAction 666;
+  '=' -> YYAction 667;
+  '\\' -> YYAction 668;
   _ ->   case yytoken t of {
-    VARID -> YYAction 602;
-    CONID -> YYAction 603;
-    QVARID -> YYAction 604;
-    QCONID -> YYAction 605;
-    QUALIFIER -> YYAction 606;
-    DOCUMENTATION -> YYAction 607;
-    PACKAGE -> YYAction 608;
-    IMPORT -> YYAction 609;
-    INFIX -> YYAction 610;
-    INFIXR -> YYAction 611;
-    INFIXL -> YYAction 612;
-    NATIVE -> YYAction 613;
-    DATA -> YYAction 614;
-    WHERE -> YYAction 615;
-    CLASS -> YYAction 616;
-    INSTANCE -> YYAction 617;
-    ABSTRACT -> YYAction 618;
-    TYPE -> YYAction 619;
-    TRUE -> YYAction 620;
-    FALSE -> YYAction 621;
-    IF -> YYAction 622;
-    THEN -> YYAction 623;
-    ELSE -> YYAction 624;
-    CASE -> YYAction 625;
-    OF -> YYAction 626;
-    DERIVE -> YYAction 627;
-    LET -> YYAction 628;
-    IN -> YYAction 629;
-    DO -> YYAction 630;
-    FORALL -> YYAction 631;
-    PRIVATE -> YYAction 632;
-    PROTECTED -> YYAction 633;
-    PUBLIC -> YYAction 634;
-    PURE -> YYAction 635;
-    THROWS -> YYAction 636;
-    MUTABLE -> YYAction 637;
-    INTCONST -> YYAction 638;
-    STRCONST -> YYAction 639;
-    LONGCONST -> YYAction 640;
-    FLTCONST -> YYAction 641;
-    DBLCONST -> YYAction 642;
-    CHRCONST -> YYAction 643;
-    ARROW -> YYAction 644;
-    DCOLON -> YYAction 645;
-    GETS -> YYAction 646;
-    EARROW -> YYAction 647;
-    DOTDOT -> YYAction 648;
-    SOMEOP -> YYAction 649;
-    INTERPRET -> YYAction 650;
+    VARID -> YYAction 605;
+    CONID -> YYAction 606;
+    QVARID -> YYAction 607;
+    QCONID -> YYAction 608;
+    QUALIFIER -> YYAction 609;
+    DOCUMENTATION -> YYAction 610;
+    PACKAGE -> YYAction 611;
+    IMPORT -> YYAction 612;
+    INFIX -> YYAction 613;
+    INFIXR -> YYAction 614;
+    INFIXL -> YYAction 615;
+    NATIVE -> YYAction 616;
+    DATA -> YYAction 617;
+    WHERE -> YYAction 618;
+    CLASS -> YYAction 619;
+    INSTANCE -> YYAction 620;
+    ABSTRACT -> YYAction 621;
+    TYPE -> YYAction 622;
+    TRUE -> YYAction 623;
+    FALSE -> YYAction 624;
+    IF -> YYAction 625;
+    THEN -> YYAction 626;
+    ELSE -> YYAction 627;
+    CASE -> YYAction 628;
+    OF -> YYAction 629;
+    DERIVE -> YYAction 630;
+    LET -> YYAction 631;
+    IN -> YYAction 632;
+    DO -> YYAction 633;
+    FORALL -> YYAction 634;
+    PRIVATE -> YYAction 635;
+    PROTECTED -> YYAction 636;
+    PUBLIC -> YYAction 637;
+    PURE -> YYAction 638;
+    THROWS -> YYAction 639;
+    MUTABLE -> YYAction 640;
+    INTCONST -> YYAction 641;
+    STRCONST -> YYAction 642;
+    LONGCONST -> YYAction 643;
+    FLTCONST -> YYAction 644;
+    DBLCONST -> YYAction 645;
+    CHRCONST -> YYAction 646;
+    ARROW -> YYAction 647;
+    DCOLON -> YYAction 648;
+    GETS -> YYAction 649;
+    EARROW -> YYAction 650;
+    DOTDOT -> YYAction 651;
+    SOMEOP -> YYAction 652;
+    INTERPRET -> YYAction 653;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction654 t = YYAction (-48);
-private yyaction655 t = YYAction (-104);
-private yyaction656 t = YYAction (-102);
-private yyaction657 t = YYAction (-103);
-private yyaction658 t = YYAction (-98);
-private yyaction659 t = YYAction (-99);
-private yyaction660 t = YYAction (-100);
-private yyaction661 t = YYAction (-101);
-private yyaction662 t = YYAction (-105);
-private yyaction663 t = YYAction (-108);
-private yyaction664 t = YYAction (-109);
-private yyaction665 t = YYAction (-110);
-private yyaction666 t =   case yychar t of {
-  '}' -> YYAction 681;
+private yyaction657 t = YYAction (-48);
+private yyaction658 t = YYAction (-104);
+private yyaction659 t = YYAction (-102);
+private yyaction660 t = YYAction (-103);
+private yyaction661 t = YYAction (-98);
+private yyaction662 t = YYAction (-99);
+private yyaction663 t = YYAction (-100);
+private yyaction664 t = YYAction (-101);
+private yyaction665 t = YYAction (-105);
+private yyaction666 t = YYAction (-108);
+private yyaction667 t = YYAction (-109);
+private yyaction668 t = YYAction (-110);
+private yyaction669 t =   case yychar t of {
+  '}' -> YYAction 684;
   _ -> (YYAction yyErr);
 };
-private yyaction667 t =   case yychar t of {
-  '-' -> YYAction 651;
-  ';' -> YYAction 652;
-  '{' -> YYAction 653;
-  '.' -> YYAction 655;
-  '(' -> YYAction 656;
-  ')' -> YYAction 657;
-  ',' -> YYAction 658;
-  '|' -> YYAction 659;
-  '[' -> YYAction 660;
-  ']' -> YYAction 661;
-  '?' -> YYAction 662;
-  '!' -> YYAction 663;
-  '=' -> YYAction 664;
-  '\\' -> YYAction 665;
+private yyaction670 t =   case yychar t of {
+  '-' -> YYAction 654;
+  ';' -> YYAction 655;
+  '{' -> YYAction 656;
+  '.' -> YYAction 658;
+  '(' -> YYAction 659;
+  ')' -> YYAction 660;
+  ',' -> YYAction 661;
+  '|' -> YYAction 662;
+  '[' -> YYAction 663;
+  ']' -> YYAction 664;
+  '?' -> YYAction 665;
+  '!' -> YYAction 666;
+  '=' -> YYAction 667;
+  '\\' -> YYAction 668;
   '}' -> YYAction (-111);
   _ ->   case yytoken t of {
-    VARID -> YYAction 602;
-    CONID -> YYAction 603;
-    QVARID -> YYAction 604;
-    QCONID -> YYAction 605;
-    QUALIFIER -> YYAction 606;
-    DOCUMENTATION -> YYAction 607;
-    PACKAGE -> YYAction 608;
-    IMPORT -> YYAction 609;
-    INFIX -> YYAction 610;
-    INFIXR -> YYAction 611;
-    INFIXL -> YYAction 612;
-    NATIVE -> YYAction 613;
-    DATA -> YYAction 614;
-    WHERE -> YYAction 615;
-    CLASS -> YYAction 616;
-    INSTANCE -> YYAction 617;
-    ABSTRACT -> YYAction 618;
-    TYPE -> YYAction 619;
-    TRUE -> YYAction 620;
-    FALSE -> YYAction 621;
-    IF -> YYAction 622;
-    THEN -> YYAction 623;
-    ELSE -> YYAction 624;
-    CASE -> YYAction 625;
-    OF -> YYAction 626;
-    DERIVE -> YYAction 627;
-    LET -> YYAction 628;
-    IN -> YYAction 629;
-    DO -> YYAction 630;
-    FORALL -> YYAction 631;
-    PRIVATE -> YYAction 632;
-    PROTECTED -> YYAction 633;
-    PUBLIC -> YYAction 634;
-    PURE -> YYAction 635;
-    THROWS -> YYAction 636;
-    MUTABLE -> YYAction 637;
-    INTCONST -> YYAction 638;
-    STRCONST -> YYAction 639;
-    LONGCONST -> YYAction 640;
-    FLTCONST -> YYAction 641;
-    DBLCONST -> YYAction 642;
-    CHRCONST -> YYAction 643;
-    ARROW -> YYAction 644;
-    DCOLON -> YYAction 645;
-    GETS -> YYAction 646;
-    EARROW -> YYAction 647;
-    DOTDOT -> YYAction 648;
-    SOMEOP -> YYAction 649;
-    INTERPRET -> YYAction 650;
+    VARID -> YYAction 605;
+    CONID -> YYAction 606;
+    QVARID -> YYAction 607;
+    QCONID -> YYAction 608;
+    QUALIFIER -> YYAction 609;
+    DOCUMENTATION -> YYAction 610;
+    PACKAGE -> YYAction 611;
+    IMPORT -> YYAction 612;
+    INFIX -> YYAction 613;
+    INFIXR -> YYAction 614;
+    INFIXL -> YYAction 615;
+    NATIVE -> YYAction 616;
+    DATA -> YYAction 617;
+    WHERE -> YYAction 618;
+    CLASS -> YYAction 619;
+    INSTANCE -> YYAction 620;
+    ABSTRACT -> YYAction 621;
+    TYPE -> YYAction 622;
+    TRUE -> YYAction 623;
+    FALSE -> YYAction 624;
+    IF -> YYAction 625;
+    THEN -> YYAction 626;
+    ELSE -> YYAction 627;
+    CASE -> YYAction 628;
+    OF -> YYAction 629;
+    DERIVE -> YYAction 630;
+    LET -> YYAction 631;
+    IN -> YYAction 632;
+    DO -> YYAction 633;
+    FORALL -> YYAction 634;
+    PRIVATE -> YYAction 635;
+    PROTECTED -> YYAction 636;
+    PUBLIC -> YYAction 637;
+    PURE -> YYAction 638;
+    THROWS -> YYAction 639;
+    MUTABLE -> YYAction 640;
+    INTCONST -> YYAction 641;
+    STRCONST -> YYAction 642;
+    LONGCONST -> YYAction 643;
+    FLTCONST -> YYAction 644;
+    DBLCONST -> YYAction 645;
+    CHRCONST -> YYAction 646;
+    ARROW -> YYAction 647;
+    DCOLON -> YYAction 648;
+    GETS -> YYAction 649;
+    EARROW -> YYAction 650;
+    DOTDOT -> YYAction 651;
+    SOMEOP -> YYAction 652;
+    INTERPRET -> YYAction 653;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction668 t = YYAction (-307);
-private yyaction669 t = YYAction (-306);
-private yyaction670 t = YYAction (-310);
-private yyaction671 t = YYAction (-309);
-private yyaction672 t =   case yytoken t of {
-    DCOLON -> YYAction 683;
+private yyaction671 t = YYAction (-307);
+private yyaction672 t = YYAction (-306);
+private yyaction673 t = YYAction (-310);
+private yyaction674 t = YYAction (-309);
+private yyaction675 t =   case yytoken t of {
+    DCOLON -> YYAction 686;
     _ -> (YYAction yyErr);
   };
-private yyaction673 t = YYAction (-291);
-private yyaction674 t =   case yychar t of {
-  '?' -> YYAction 580;
-  '!' -> YYAction 581;
+private yyaction676 t = YYAction (-291);
+private yyaction677 t =   case yychar t of {
+  '?' -> YYAction 583;
+  '!' -> YYAction 584;
   '}' -> YYAction (-298);
   _ ->   case yytoken t of {
-    VARID -> YYAction 190;
+    VARID -> YYAction 192;
     DOCUMENTATION -> YYAction 1;
-    PRIVATE -> YYAction 578;
-    PUBLIC -> YYAction 579;
+    PRIVATE -> YYAction 581;
+    PUBLIC -> YYAction 582;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction675 t =   case yychar t of {
-  '?' -> YYAction 580;
-  '!' -> YYAction 581;
+private yyaction678 t =   case yychar t of {
+  '?' -> YYAction 583;
+  '!' -> YYAction 584;
   '}' -> YYAction (-297);
   _ ->   case yytoken t of {
-    VARID -> YYAction 190;
+    VARID -> YYAction 192;
     DOCUMENTATION -> YYAction 1;
-    PRIVATE -> YYAction 578;
-    PUBLIC -> YYAction 579;
+    PRIVATE -> YYAction 581;
+    PUBLIC -> YYAction 582;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction676 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 195;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction677 t =   case yychar t of {
-  '?' -> YYAction 580;
-  '!' -> YYAction 581;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 190;
-    PRIVATE -> YYAction 578;
-    PUBLIC -> YYAction 579;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction678 t = YYAction (-167);
 private yyaction679 t =   case yychar t of {
-  '-' -> YYAction 651;
-  ';' -> YYAction 652;
-  '{' -> YYAction 653;
-  '.' -> YYAction 655;
-  '(' -> YYAction 656;
-  ')' -> YYAction 657;
-  ',' -> YYAction 658;
-  '|' -> YYAction 659;
-  '[' -> YYAction 660;
-  ']' -> YYAction 661;
-  '?' -> YYAction 662;
-  '!' -> YYAction 663;
-  '=' -> YYAction 664;
-  '\\' -> YYAction 665;
-  '}' -> YYAction (-115);
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 602;
-    CONID -> YYAction 603;
-    QVARID -> YYAction 604;
-    QCONID -> YYAction 605;
-    QUALIFIER -> YYAction 606;
-    DOCUMENTATION -> YYAction 607;
-    PACKAGE -> YYAction 608;
-    IMPORT -> YYAction 609;
-    INFIX -> YYAction 610;
-    INFIXR -> YYAction 611;
-    INFIXL -> YYAction 612;
-    NATIVE -> YYAction 613;
-    DATA -> YYAction 614;
-    WHERE -> YYAction 615;
-    CLASS -> YYAction 616;
-    INSTANCE -> YYAction 617;
-    ABSTRACT -> YYAction 618;
-    TYPE -> YYAction 619;
-    TRUE -> YYAction 620;
-    FALSE -> YYAction 621;
-    IF -> YYAction 622;
-    THEN -> YYAction 623;
-    ELSE -> YYAction 624;
-    CASE -> YYAction 625;
-    OF -> YYAction 626;
-    DERIVE -> YYAction 627;
-    LET -> YYAction 628;
-    IN -> YYAction 629;
-    DO -> YYAction 630;
-    FORALL -> YYAction 631;
-    PRIVATE -> YYAction 632;
-    PROTECTED -> YYAction 633;
-    PUBLIC -> YYAction 634;
-    PURE -> YYAction 635;
-    THROWS -> YYAction 636;
-    MUTABLE -> YYAction 637;
-    INTCONST -> YYAction 638;
-    STRCONST -> YYAction 639;
-    LONGCONST -> YYAction 640;
-    FLTCONST -> YYAction 641;
-    DBLCONST -> YYAction 642;
-    CHRCONST -> YYAction 643;
-    ARROW -> YYAction 644;
-    DCOLON -> YYAction 645;
-    GETS -> YYAction 646;
-    EARROW -> YYAction 647;
-    DOTDOT -> YYAction 648;
-    SOMEOP -> YYAction 649;
-    INTERPRET -> YYAction 650;
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction680 t =   case yychar t of {
-  '}' -> YYAction 689;
+  '?' -> YYAction 583;
+  '!' -> YYAction 584;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 192;
+    PRIVATE -> YYAction 581;
+    PUBLIC -> YYAction 582;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction681 t = YYAction (-167);
+private yyaction682 t =   case yychar t of {
+  '-' -> YYAction 654;
+  ';' -> YYAction 655;
+  '{' -> YYAction 656;
+  '.' -> YYAction 658;
+  '(' -> YYAction 659;
+  ')' -> YYAction 660;
+  ',' -> YYAction 661;
+  '|' -> YYAction 662;
+  '[' -> YYAction 663;
+  ']' -> YYAction 664;
+  '?' -> YYAction 665;
+  '!' -> YYAction 666;
+  '=' -> YYAction 667;
+  '\\' -> YYAction 668;
+  '}' -> YYAction (-115);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 605;
+    CONID -> YYAction 606;
+    QVARID -> YYAction 607;
+    QCONID -> YYAction 608;
+    QUALIFIER -> YYAction 609;
+    DOCUMENTATION -> YYAction 610;
+    PACKAGE -> YYAction 611;
+    IMPORT -> YYAction 612;
+    INFIX -> YYAction 613;
+    INFIXR -> YYAction 614;
+    INFIXL -> YYAction 615;
+    NATIVE -> YYAction 616;
+    DATA -> YYAction 617;
+    WHERE -> YYAction 618;
+    CLASS -> YYAction 619;
+    INSTANCE -> YYAction 620;
+    ABSTRACT -> YYAction 621;
+    TYPE -> YYAction 622;
+    TRUE -> YYAction 623;
+    FALSE -> YYAction 624;
+    IF -> YYAction 625;
+    THEN -> YYAction 626;
+    ELSE -> YYAction 627;
+    CASE -> YYAction 628;
+    OF -> YYAction 629;
+    DERIVE -> YYAction 630;
+    LET -> YYAction 631;
+    IN -> YYAction 632;
+    DO -> YYAction 633;
+    FORALL -> YYAction 634;
+    PRIVATE -> YYAction 635;
+    PROTECTED -> YYAction 636;
+    PUBLIC -> YYAction 637;
+    PURE -> YYAction 638;
+    THROWS -> YYAction 639;
+    MUTABLE -> YYAction 640;
+    INTCONST -> YYAction 641;
+    STRCONST -> YYAction 642;
+    LONGCONST -> YYAction 643;
+    FLTCONST -> YYAction 644;
+    DBLCONST -> YYAction 645;
+    CHRCONST -> YYAction 646;
+    ARROW -> YYAction 647;
+    DCOLON -> YYAction 648;
+    GETS -> YYAction 649;
+    EARROW -> YYAction 650;
+    DOTDOT -> YYAction 651;
+    SOMEOP -> YYAction 652;
+    INTERPRET -> YYAction 653;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction683 t =   case yychar t of {
+  '}' -> YYAction 692;
   _ -> (YYAction yyErr);
 };
-private yyaction681 t = YYAction (-47);
-private yyaction682 t = YYAction (-112);
-private yyaction683 t =   case yychar t of {
-  '(' -> YYAction 198;
-  '[' -> YYAction 199;
+private yyaction684 t = YYAction (-47);
+private yyaction685 t = YYAction (-112);
+private yyaction686 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 195;
+    VARID -> YYAction 197;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 196;
-    FORALL -> YYAction 197;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction684 t = YYAction (-300);
-private yyaction685 t = YYAction (-299);
-private yyaction686 t = YYAction (-301);
-private yyaction687 t = YYAction (-304);
-private yyaction688 t = YYAction (-116);
-private yyaction689 t =   case yychar t of {
-  '-' -> YYAction 651;
-  ';' -> YYAction 652;
-  '{' -> YYAction 653;
-  '.' -> YYAction 655;
-  '(' -> YYAction 656;
-  ')' -> YYAction 657;
-  ',' -> YYAction 658;
-  '|' -> YYAction 659;
-  '[' -> YYAction 660;
-  ']' -> YYAction 661;
-  '?' -> YYAction 662;
-  '!' -> YYAction 663;
-  '=' -> YYAction 664;
-  '\\' -> YYAction 665;
+private yyaction687 t = YYAction (-300);
+private yyaction688 t = YYAction (-299);
+private yyaction689 t = YYAction (-301);
+private yyaction690 t = YYAction (-304);
+private yyaction691 t = YYAction (-116);
+private yyaction692 t =   case yychar t of {
+  '-' -> YYAction 654;
+  ';' -> YYAction 655;
+  '{' -> YYAction 656;
+  '.' -> YYAction 658;
+  '(' -> YYAction 659;
+  ')' -> YYAction 660;
+  ',' -> YYAction 661;
+  '|' -> YYAction 662;
+  '[' -> YYAction 663;
+  ']' -> YYAction 664;
+  '?' -> YYAction 665;
+  '!' -> YYAction 666;
+  '=' -> YYAction 667;
+  '\\' -> YYAction 668;
   '}' -> YYAction (-113);
   _ ->   case yytoken t of {
-    VARID -> YYAction 602;
-    CONID -> YYAction 603;
-    QVARID -> YYAction 604;
-    QCONID -> YYAction 605;
-    QUALIFIER -> YYAction 606;
-    DOCUMENTATION -> YYAction 607;
-    PACKAGE -> YYAction 608;
-    IMPORT -> YYAction 609;
-    INFIX -> YYAction 610;
-    INFIXR -> YYAction 611;
-    INFIXL -> YYAction 612;
-    NATIVE -> YYAction 613;
-    DATA -> YYAction 614;
-    WHERE -> YYAction 615;
-    CLASS -> YYAction 616;
-    INSTANCE -> YYAction 617;
-    ABSTRACT -> YYAction 618;
-    TYPE -> YYAction 619;
-    TRUE -> YYAction 620;
-    FALSE -> YYAction 621;
-    IF -> YYAction 622;
-    THEN -> YYAction 623;
-    ELSE -> YYAction 624;
-    CASE -> YYAction 625;
-    OF -> YYAction 626;
-    DERIVE -> YYAction 627;
-    LET -> YYAction 628;
-    IN -> YYAction 629;
-    DO -> YYAction 630;
-    FORALL -> YYAction 631;
-    PRIVATE -> YYAction 632;
-    PROTECTED -> YYAction 633;
-    PUBLIC -> YYAction 634;
-    PURE -> YYAction 635;
-    THROWS -> YYAction 636;
-    MUTABLE -> YYAction 637;
-    INTCONST -> YYAction 638;
-    STRCONST -> YYAction 639;
-    LONGCONST -> YYAction 640;
-    FLTCONST -> YYAction 641;
-    DBLCONST -> YYAction 642;
-    CHRCONST -> YYAction 643;
-    ARROW -> YYAction 644;
-    DCOLON -> YYAction 645;
-    GETS -> YYAction 646;
-    EARROW -> YYAction 647;
-    DOTDOT -> YYAction 648;
-    SOMEOP -> YYAction 649;
-    INTERPRET -> YYAction 650;
+    VARID -> YYAction 605;
+    CONID -> YYAction 606;
+    QVARID -> YYAction 607;
+    QCONID -> YYAction 608;
+    QUALIFIER -> YYAction 609;
+    DOCUMENTATION -> YYAction 610;
+    PACKAGE -> YYAction 611;
+    IMPORT -> YYAction 612;
+    INFIX -> YYAction 613;
+    INFIXR -> YYAction 614;
+    INFIXL -> YYAction 615;
+    NATIVE -> YYAction 616;
+    DATA -> YYAction 617;
+    WHERE -> YYAction 618;
+    CLASS -> YYAction 619;
+    INSTANCE -> YYAction 620;
+    ABSTRACT -> YYAction 621;
+    TYPE -> YYAction 622;
+    TRUE -> YYAction 623;
+    FALSE -> YYAction 624;
+    IF -> YYAction 625;
+    THEN -> YYAction 626;
+    ELSE -> YYAction 627;
+    CASE -> YYAction 628;
+    OF -> YYAction 629;
+    DERIVE -> YYAction 630;
+    LET -> YYAction 631;
+    IN -> YYAction 632;
+    DO -> YYAction 633;
+    FORALL -> YYAction 634;
+    PRIVATE -> YYAction 635;
+    PROTECTED -> YYAction 636;
+    PUBLIC -> YYAction 637;
+    PURE -> YYAction 638;
+    THROWS -> YYAction 639;
+    MUTABLE -> YYAction 640;
+    INTCONST -> YYAction 641;
+    STRCONST -> YYAction 642;
+    LONGCONST -> YYAction 643;
+    FLTCONST -> YYAction 644;
+    DBLCONST -> YYAction 645;
+    CHRCONST -> YYAction 646;
+    ARROW -> YYAction 647;
+    DCOLON -> YYAction 648;
+    GETS -> YYAction 649;
+    EARROW -> YYAction 650;
+    DOTDOT -> YYAction 651;
+    SOMEOP -> YYAction 652;
+    INTERPRET -> YYAction 653;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction690 t = YYAction (-302);
-private yyaction691 t = YYAction (-114);
+private yyaction693 t = YYAction (-302);
+private yyaction694 t = YYAction (-114);
 private reduce1 =  \(a,d,p)\w\b     -> do {
                                                         changeST Global.{sub <- SubSt.{
                                                             thisPos = p}};
@@ -6078,57 +6098,61 @@ private reduce357 =  liste
 ;
 private reduce358 =  \a\_    ->  [a] 
 ;
-private reduce359 =  \_\p\l   -> Lam p l false
+private reduce359 =  \_\ps\b  -> foldr (\p\x -> Lam p x false) b ps 
 ;
-private reduce360 =  \_\p\_\x -> Lam p x false
+private reduce361 =  \_\x -> x 
 ;
-private reduce361 =  \x\_\t  -> Ann {ex = x, typ=t} 
+private reduce362 =  \x\_\t  -> Ann {ex = x, typ=t} 
 ;
-private reduce363 =  flip const 
+private reduce364 =  flip const 
 ;
-private reduce365 =  flip const 
-;
-private reduce367 =  mkapp 
+private reduce366 =  flip const 
 ;
 private reduce368 =  mkapp 
 ;
-private reduce369 =  \m\x -> nApp (Vbl (contextName m "negate")) x
+private reduce369 =  mkapp 
 ;
-private reduce371 =  \_\c\_\t\_\e  -> Ifte c t e
+private reduce370 =  \m\x -> nApp (Vbl (contextName m "negate")) x
 ;
-private reduce372 =  \_\e\_\_\as\_ -> Case CNormal e as
+private reduce372 =  \_\c\_\t\_\e  -> Ifte c t e
 ;
-private reduce373 =  \_\_\ds\_\_\e -> Let ds e
+private reduce373 =  \_\e\_\_\as\_ -> Case CNormal e as
 ;
-private reduce375 =  underscore 
+private reduce374 =  \_\_\ds\_\_\e -> Let ds e
 ;
-private reduce377 =  nApp 
+private reduce376 =  underscore 
 ;
-private reduce379 =  \u\p -> nApp (Vbl {name=Simple u}) p
+private reduce378 =  nApp 
 ;
-private reduce380 =  With1 
+private reduce380 =  \u\p -> nApp (Vbl {name=Simple u}) p
 ;
-private reduce381 =  With2 
+private reduce381 =  single 
 ;
-private reduce383 =  \d\_\defs\_   -> do mkMonad (yyline d) defs 
+private reduce382 =  (:) 
 ;
-private reduce384 =  \p\_\(v::Token) -> umem p v id
+private reduce383 =  With1 
 ;
-private reduce385 =  \p\_\v -> do {v <- unqualified v;
+private reduce384 =  With2 
+;
+private reduce386 =  \d\_\defs\_   -> do mkMonad (yyline d) defs 
+;
+private reduce387 =  \p\_\(v::Token) -> umem p v id
+;
+private reduce388 =  \p\_\v -> do {v <- unqualified v;
                                                     YYM.return (umem p v id)}
 ;
-private reduce386 =  \p\_\v -> umem p v id
+private reduce389 =  \p\_\v -> umem p v id
 ;
-private reduce387 =  \q\_\(v::Token)\_\_ ->
+private reduce390 =  \q\_\(v::Token)\_\_ ->
                                             Vbl  (q v.{value <- ("has$" ++)}) 
 ;
-private reduce388 =  \q\_\(v::Token)\_\_ ->
+private reduce391 =  \q\_\(v::Token)\_\_ ->
                                             Vbl  (q v.{value <- ("upd$" ++)}) 
 ;
-private reduce389 =  \q\_\(v::Token)\_\_ ->
+private reduce392 =  \q\_\(v::Token)\_\_ ->
                                             Vbl  (q v.{value <- ("chg$" ++)}) 
 ;
-private reduce390 =  \q\(p::Token)\fs\_ -> let {
+private reduce393 =  \q\(p::Token)\fs\_ -> let {
                         -- n   = Simple q;
                         flp = Vbl (wellKnown p "flip");
                         bul = Vbl (contextName p "•");
@@ -6140,93 +6164,93 @@ private reduce390 =  \q\(p::Token)\fs\_ -> let {
                             chup (r, false, e) = flp `nApp` Vbl  (q r.{value <- ("upd$"++)}) `nApp` e;
                                       }} in c fs 
 ;
-private reduce391 =  \p\_\_\(v::Token)\_\_ -> umem p v.{value <- ("has$"++)} id
+private reduce394 =  \p\_\_\(v::Token)\_\_ -> umem p v.{value <- ("has$"++)} id
 ;
-private reduce392 =  \p\_\_\(v::Token)\_\_ -> umem p v.{value <- ("upd$"++)} id
+private reduce395 =  \p\_\_\(v::Token)\_\_ -> umem p v.{value <- ("upd$"++)} id
 ;
-private reduce393 = \p\_\_\(v::Token)\_\_ -> umem p v.{value <- ("chg$"++)} id
+private reduce396 = \p\_\_\(v::Token)\_\_ -> umem p v.{value <- ("chg$"++)} id
 ;
-private reduce394 =  \x\(p::Token)\_\fs\_ ->
+private reduce397 =  \x\(p::Token)\_\fs\_ ->
                                 let {
                         u x [] = x;
                         u x ((r::Token, true , e):xs) = u (umem x r.{value <- ("chg$" ++)} (`nApp` e))  xs;
                         u x ((r::Token, false, e):xs) = u (umem x r.{value <- ("upd$" ++)} (`nApp` e))  xs;
                                 } in u x fs
 ;
-private reduce395 =  \p\t\_\v\_  ->
+private reduce398 =  \p\t\_\v\_  ->
                                         let elem = t.{tokid = VARID, value = "elemAt"}
                                         in Vbl {name=Simple elem}
                                             `nApp` p
                                             `nApp` v
 ;
-private reduce396 =  \x   -> Vbl {name=x} 
+private reduce399 =  \x   -> Vbl {name=x} 
 ;
-private reduce398 =  \t   -> Vbl {name = Simple t.{tokid=VARID, value="_"}} 
+private reduce401 =  \t   -> Vbl {name = Simple t.{tokid=VARID, value="_"}} 
 ;
-private reduce399 =  \qc  -> Con {name=qc} 
+private reduce402 =  \qc  -> Con {name=qc} 
 ;
-private reduce400 =  \qc\_\z    -> ConFS {name=qc, fields=[]}
+private reduce403 =  \qc\_\z    -> ConFS {name=qc, fields=[]}
 ;
-private reduce401 =  \qc\_\fs\z -> ConFS {name=qc, fields=fs}
+private reduce404 =  \qc\_\fs\z -> ConFS {name=qc, fields=fs}
 ;
-private reduce402 =  \z\_   -> Con (With1 baseToken z.{tokid=CONID, value="()"})
+private reduce405 =  \z\_   -> Con (With1 baseToken z.{tokid=CONID, value="()"})
 ;
-private reduce403 =  \z\n\_ -> Con (With1 baseToken z.{tokid=CONID, value=tuple (n+1)})
+private reduce406 =  \z\n\_ -> Con (With1 baseToken z.{tokid=CONID, value=tuple (n+1)})
 ;
-private reduce404 =  \_\x\_ -> Vbl {name=Simple x} 
+private reduce407 =  \_\x\_ -> Vbl {name=Simple x} 
 ;
-private reduce405 =  \_\o\_ -> (varcon o) (opSname o)
+private reduce408 =  \_\o\_ -> (varcon o) (opSname o)
 ;
-private reduce406 =  \_\m\_ -> (Vbl (With1 baseToken m)) 
+private reduce409 =  \_\m\_ -> (Vbl (With1 baseToken m)) 
 ;
-private reduce407 =  \z\o\x\_ ->  let -- (+1) --> flip (+) 1
+private reduce410 =  \z\o\x\_ ->  let -- (+1) --> flip (+) 1
                                         flp = Vbl (contextName z "flip") 
                                         op  = (varcon o) (opSname o)
                                         ex = nApp (nApp flp op) x
                                     in ex
 ;
-private reduce408 =  \_\x\o\_ ->  -- (1+) --> (+) 1
+private reduce411 =  \_\x\o\_ ->  -- (1+) --> (+) 1
                                         nApp ((varcon o) (opSname o)) x
 ;
-private reduce409 =  \_\x\o\_ ->  -- (1+) --> (+) 1
+private reduce412 =  \_\x\o\_ ->  -- (1+) --> (+) 1
                                         nApp ((varcon o) (Simple o)) x
 ;
-private reduce410 =  \a\e\x\es\_ -> fold nApp (Con 
+private reduce413 =  \a\e\x\es\_ -> fold nApp (Con 
                                                                    (With1 baseToken x.{tokid=CONID, value=tuple (1+length es)})
                                                                    )
                                                               (e:es)
 ;
-private reduce411 =  \a\e\(x::Token)\es\_ -> fold nApp (Vbl 
+private reduce414 =  \a\e\(x::Token)\es\_ -> fold nApp (Vbl 
                                                                    (With1 baseToken x.{tokid=VARID, value="strictTuple" ++ show (1+length es)})
                                                                     )
                                                               (e:es)
 ;
-private reduce412 =  \_\x\_ -> Term x 
+private reduce415 =  \_\x\_ -> Term x 
 ;
-private reduce413 =  \a\z ->  Con (With1 baseToken z.{tokid=CONID, value="[]"})
+private reduce416 =  \a\z ->  Con (With1 baseToken z.{tokid=CONID, value="[]"})
 ;
-private reduce414 =  \b\es\z -> 
+private reduce417 =  \b\es\z -> 
                                                 foldr (\a\as -> nApp (nApp (Con (With1 baseToken b.{tokid=CONID, value=":"})) a) as)
                                                        (Con (With1 baseToken z.{tokid=CONID, value="[]"}))
                                                        es
 ;
-private reduce415 =  \a\b\c\d   -> do mkEnumFrom   a b c d
+private reduce418 =  \a\b\c\d   -> do mkEnumFrom   a b c d
 ;
-private reduce416 =  \a\b\c\d\e -> do mkEnumFromTo a b c d e
+private reduce419 =  \a\b\c\d\e -> do mkEnumFromTo a b c d e
 ;
-private reduce417 =  \(a::Token)\e\b\qs\(z::Token) -> do {
+private reduce420 =  \(a::Token)\e\b\qs\(z::Token) -> do {
                 let {nil = z.{tokid=CONID, value="[]"}};
                 listComprehension (yyline b) e qs
                                             (Con {name = With1 baseToken nil})
                                     }
 ;
-private reduce418 =  const 1 
+private reduce421 =  const 1 
 ;
-private reduce419 =  ((+) . const 1) 
+private reduce422 =  ((+) . const 1) 
 ;
-private reduce420 =  single 
+private reduce423 =  single 
 ;
-private reduce421 =  \a\c\ls ->
+private reduce424 =  \a\c\ls ->
                                         if elemBy (using fst) a ls then do {
                                                 E.warn (yyline c) (msgdoc ("field `" ++ fst a
                                                     ++ "` should appear only once."));
@@ -6235,35 +6259,35 @@ private reduce421 =  \a\c\ls ->
                                                 YYM.return (a:ls)
                                     
 ;
-private reduce422 =  (const . single) 
-;
-private reduce423 =  single 
-;
-private reduce424 =  liste  
-;
 private reduce425 =  (const . single) 
 ;
-private reduce426 =  \s\_\x ->  (s, true,  x) 
+private reduce426 =  single 
 ;
-private reduce427 =  \s\_\x ->  (s, false, x) 
+private reduce427 =  liste  
 ;
-private reduce428 =  \s     ->  (s, false, Vbl (Simple s)) 
+private reduce428 =  (const . single) 
 ;
-private reduce429 =  \s\_\x ->  (Token.value s, x) 
+private reduce429 =  \s\_\x ->  (s, true,  x) 
 ;
-private reduce430 =  \s     ->  (s.value, Vbl (Simple s)) 
+private reduce430 =  \s\_\x ->  (s, false, x) 
 ;
-private reduce431 =  single 
+private reduce431 =  \s     ->  (s, false, Vbl (Simple s)) 
 ;
-private reduce432 =  liste  
+private reduce432 =  \s\_\x ->  (Token.value s, x) 
 ;
-private reduce433 =  (const . single) 
+private reduce433 =  \s     ->  (s.value, Vbl (Simple s)) 
 ;
 private reduce434 =  single 
 ;
-private reduce435 =  liste 
+private reduce435 =  liste  
 ;
 private reduce436 =  (const . single) 
+;
+private reduce437 =  single 
+;
+private reduce438 =  liste 
+;
+private reduce439 =  (const . single) 
 ;
 yyrule 1 = "package: packageclause ';' definitions";
 yyrule 2 = "package: packageclause WHERE '{' definitions '}'";
@@ -6623,84 +6647,87 @@ yyrule 355 = "calt: calt wherelet";
 yyrule 356 = "calts: calt";
 yyrule 357 = "calts: calt ';' calts";
 yyrule 358 = "calts: calt ';'";
-yyrule 359 = "lambda: '\\' pattern lambda";
-yyrule 360 = "lambda: '\\' pattern ARROW expr";
-yyrule 361 = "expr: binex DCOLON sigma";
-yyrule 362 = "expr: binex";
-yyrule 363 = "thenx: ';' THEN";
-yyrule 364 = "thenx: THEN";
-yyrule 365 = "elsex: ';' ELSE";
-yyrule 366 = "elsex: ELSE";
-yyrule 367 = "binex: binex SOMEOP binex";
-yyrule 368 = "binex: binex '-' binex";
-yyrule 369 = "binex: '-' topex";
-yyrule 370 = "binex: topex";
-yyrule 371 = "topex: IF expr thenx expr elsex expr";
-yyrule 372 = "topex: CASE expr OF '{' calts '}'";
-yyrule 373 = "topex: LET '{' letdefs '}' IN expr";
-yyrule 374 = "topex: lambda";
-yyrule 375 = "topex: appex";
-yyrule 376 = "appex: unex";
-yyrule 377 = "appex: appex unex";
-yyrule 378 = "unex: primary";
-yyrule 379 = "unex: unop unex";
-yyrule 380 = "qualifiers: QUALIFIER";
-yyrule 381 = "qualifiers: QUALIFIER QUALIFIER";
-yyrule 382 = "primary: term";
-yyrule 383 = "primary: DO '{' dodefs '}'";
-yyrule 384 = "primary: primary '.' VARID";
-yyrule 385 = "primary: primary '.' operator";
-yyrule 386 = "primary: primary '.' unop";
-yyrule 387 = "primary: qualifiers '{' VARID '?' '}'";
-yyrule 388 = "primary: qualifiers '{' VARID '=' '}'";
-yyrule 389 = "primary: qualifiers '{' VARID GETS '}'";
-yyrule 390 = "primary: qualifiers '{' getfields '}'";
-yyrule 391 = "primary: primary '.' '{' VARID '?' '}'";
-yyrule 392 = "primary: primary '.' '{' VARID '=' '}'";
-yyrule 393 = "primary: primary '.' '{' VARID GETS '}'";
-yyrule 394 = "primary: primary '.' '{' getfields '}'";
-yyrule 395 = "primary: primary '.' '[' expr ']'";
-yyrule 396 = "term: qvarid";
-yyrule 397 = "term: literal";
-yyrule 398 = "term: '_'";
-yyrule 399 = "term: qconid";
-yyrule 400 = "term: qconid '{' '}'";
-yyrule 401 = "term: qconid '{' fields '}'";
-yyrule 402 = "term: '(' ')'";
-yyrule 403 = "term: '(' commata ')'";
-yyrule 404 = "term: '(' unop ')'";
-yyrule 405 = "term: '(' operator ')'";
-yyrule 406 = "term: '(' '-' ')'";
-yyrule 407 = "term: '(' operator expr ')'";
-yyrule 408 = "term: '(' binex operator ')'";
-yyrule 409 = "term: '(' binex '-' ')'";
-yyrule 410 = "term: '(' expr ',' exprSC ')'";
-yyrule 411 = "term: '(' expr ';' exprSS ')'";
-yyrule 412 = "term: '(' expr ')'";
-yyrule 413 = "term: '[' ']'";
-yyrule 414 = "term: '[' exprSC ']'";
-yyrule 415 = "term: '[' exprSC DOTDOT ']'";
-yyrule 416 = "term: '[' exprSC DOTDOT expr ']'";
-yyrule 417 = "term: '[' expr '|' lcquals ']'";
-yyrule 418 = "commata: ','";
-yyrule 419 = "commata: ',' commata";
-yyrule 420 = "fields: field";
-yyrule 421 = "fields: field ',' fields";
-yyrule 422 = "fields: field ','";
-yyrule 423 = "getfields: getfield";
-yyrule 424 = "getfields: getfield ',' getfields";
-yyrule 425 = "getfields: getfield ','";
-yyrule 426 = "getfield: VARID GETS expr";
-yyrule 427 = "getfield: VARID '=' expr";
-yyrule 428 = "getfield: VARID";
-yyrule 429 = "field: varid '=' expr";
-yyrule 430 = "field: varid";
-yyrule 431 = "exprSC: expr";
-yyrule 432 = "exprSC: expr ',' exprSC";
-yyrule 433 = "exprSC: expr ','";
-yyrule 434 = "exprSS: expr";
-yyrule 435 = "exprSS: expr ';' exprSS";
-yyrule 436 = "exprSS: expr ';'";
+yyrule 359 = "lambda: '\\' apats lambdabody";
+yyrule 360 = "lambdabody: lambda";
+yyrule 361 = "lambdabody: ARROW expr";
+yyrule 362 = "expr: binex DCOLON sigma";
+yyrule 363 = "expr: binex";
+yyrule 364 = "thenx: ';' THEN";
+yyrule 365 = "thenx: THEN";
+yyrule 366 = "elsex: ';' ELSE";
+yyrule 367 = "elsex: ELSE";
+yyrule 368 = "binex: binex SOMEOP binex";
+yyrule 369 = "binex: binex '-' binex";
+yyrule 370 = "binex: '-' topex";
+yyrule 371 = "binex: topex";
+yyrule 372 = "topex: IF expr thenx expr elsex expr";
+yyrule 373 = "topex: CASE expr OF '{' calts '}'";
+yyrule 374 = "topex: LET '{' letdefs '}' IN expr";
+yyrule 375 = "topex: lambda";
+yyrule 376 = "topex: appex";
+yyrule 377 = "appex: unex";
+yyrule 378 = "appex: appex unex";
+yyrule 379 = "unex: primary";
+yyrule 380 = "unex: unop unex";
+yyrule 381 = "apats: unex";
+yyrule 382 = "apats: unex apats";
+yyrule 383 = "qualifiers: QUALIFIER";
+yyrule 384 = "qualifiers: QUALIFIER QUALIFIER";
+yyrule 385 = "primary: term";
+yyrule 386 = "primary: DO '{' dodefs '}'";
+yyrule 387 = "primary: primary '.' VARID";
+yyrule 388 = "primary: primary '.' operator";
+yyrule 389 = "primary: primary '.' unop";
+yyrule 390 = "primary: qualifiers '{' VARID '?' '}'";
+yyrule 391 = "primary: qualifiers '{' VARID '=' '}'";
+yyrule 392 = "primary: qualifiers '{' VARID GETS '}'";
+yyrule 393 = "primary: qualifiers '{' getfields '}'";
+yyrule 394 = "primary: primary '.' '{' VARID '?' '}'";
+yyrule 395 = "primary: primary '.' '{' VARID '=' '}'";
+yyrule 396 = "primary: primary '.' '{' VARID GETS '}'";
+yyrule 397 = "primary: primary '.' '{' getfields '}'";
+yyrule 398 = "primary: primary '.' '[' expr ']'";
+yyrule 399 = "term: qvarid";
+yyrule 400 = "term: literal";
+yyrule 401 = "term: '_'";
+yyrule 402 = "term: qconid";
+yyrule 403 = "term: qconid '{' '}'";
+yyrule 404 = "term: qconid '{' fields '}'";
+yyrule 405 = "term: '(' ')'";
+yyrule 406 = "term: '(' commata ')'";
+yyrule 407 = "term: '(' unop ')'";
+yyrule 408 = "term: '(' operator ')'";
+yyrule 409 = "term: '(' '-' ')'";
+yyrule 410 = "term: '(' operator expr ')'";
+yyrule 411 = "term: '(' binex operator ')'";
+yyrule 412 = "term: '(' binex '-' ')'";
+yyrule 413 = "term: '(' expr ',' exprSC ')'";
+yyrule 414 = "term: '(' expr ';' exprSS ')'";
+yyrule 415 = "term: '(' expr ')'";
+yyrule 416 = "term: '[' ']'";
+yyrule 417 = "term: '[' exprSC ']'";
+yyrule 418 = "term: '[' exprSC DOTDOT ']'";
+yyrule 419 = "term: '[' exprSC DOTDOT expr ']'";
+yyrule 420 = "term: '[' expr '|' lcquals ']'";
+yyrule 421 = "commata: ','";
+yyrule 422 = "commata: ',' commata";
+yyrule 423 = "fields: field";
+yyrule 424 = "fields: field ',' fields";
+yyrule 425 = "fields: field ','";
+yyrule 426 = "getfields: getfield";
+yyrule 427 = "getfields: getfield ',' getfields";
+yyrule 428 = "getfields: getfield ','";
+yyrule 429 = "getfield: VARID GETS expr";
+yyrule 430 = "getfield: VARID '=' expr";
+yyrule 431 = "getfield: VARID";
+yyrule 432 = "field: varid '=' expr";
+yyrule 433 = "field: varid";
+yyrule 434 = "exprSC: expr";
+yyrule 435 = "exprSC: expr ',' exprSC";
+yyrule 436 = "exprSC: expr ','";
+yyrule 437 = "exprSS: expr";
+yyrule 438 = "exprSS: expr ';' exprSS";
+yyrule 439 = "exprSS: expr ';'";
 yyrule _ = "<unknown rule>";
 
 private yyprod1 ((_, (YYNTdefinitions yy3)):(_, (YYTok yy2)):(_, (YYNTpackageclause yy1)):yyvs) =  do { yyr <- reduce1 yy1 yy2 yy3 ;YYM.return (YYNTpackage yyr, yyvs)};
@@ -7415,164 +7442,170 @@ private yyprod357 ((_, (YYNTcalts yy3)):(_, (YYTok yy2)):(_, (YYNTcalt yy1)):yyv
 private yyprod357 yyvals = yybadprod 357 yyvals;
 private yyprod358 ((_, (YYTok yy2)):(_, (YYNTcalt yy1)):yyvs) =  do { let {!yyr = reduce358 yy1 yy2}; YYM.return (YYNTcalts yyr, yyvs)};
 private yyprod358 yyvals = yybadprod 358 yyvals;
-private yyprod359 ((_, (YYNTlambda yy3)):(_, (YYNTpattern yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce359 yy1 yy2 yy3}; YYM.return (YYNTlambda yyr, yyvs)};
+private yyprod359 ((_, (YYNTlambdabody yy3)):(_, (YYNTapats yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce359 yy1 yy2 yy3}; YYM.return (YYNTlambda yyr, yyvs)};
 private yyprod359 yyvals = yybadprod 359 yyvals;
-private yyprod360 ((_, (YYNTexpr yy4)):(_, (YYTok yy3)):(_, (YYNTpattern yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce360 yy1 yy2 yy3 yy4}; YYM.return (YYNTlambda yyr, yyvs)};
+private yyprod360 ((_, (YYNTlambda yy1)):yyvs) = YYM.return (YYNTlambdabody (yy1), yyvs);
 private yyprod360 yyvals = yybadprod 360 yyvals;
-private yyprod361 ((_, (YYNTsigma yy3)):(_, (YYTok yy2)):(_, (YYNTbinex yy1)):yyvs) =  do { let {!yyr = reduce361 yy1 yy2 yy3}; YYM.return (YYNTexpr yyr, yyvs)};
+private yyprod361 ((_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce361 yy1 yy2}; YYM.return (YYNTlambdabody yyr, yyvs)};
 private yyprod361 yyvals = yybadprod 361 yyvals;
-private yyprod362 ((_, (YYNTbinex yy1)):yyvs) = YYM.return (YYNTexpr (yy1), yyvs);
+private yyprod362 ((_, (YYNTsigma yy3)):(_, (YYTok yy2)):(_, (YYNTbinex yy1)):yyvs) =  do { let {!yyr = reduce362 yy1 yy2 yy3}; YYM.return (YYNTexpr yyr, yyvs)};
 private yyprod362 yyvals = yybadprod 362 yyvals;
-private yyprod363 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce363 yy1 yy2}; YYM.return (YYNTthenx yyr, yyvs)};
+private yyprod363 ((_, (YYNTbinex yy1)):yyvs) = YYM.return (YYNTexpr (yy1), yyvs);
 private yyprod363 yyvals = yybadprod 363 yyvals;
-private yyprod364 ((_, (YYTok yy1)):yyvs) = YYM.return (YYNTthenx (yy1), yyvs);
+private yyprod364 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce364 yy1 yy2}; YYM.return (YYNTthenx yyr, yyvs)};
 private yyprod364 yyvals = yybadprod 364 yyvals;
-private yyprod365 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce365 yy1 yy2}; YYM.return (YYNTelsex yyr, yyvs)};
+private yyprod365 ((_, (YYTok yy1)):yyvs) = YYM.return (YYNTthenx (yy1), yyvs);
 private yyprod365 yyvals = yybadprod 365 yyvals;
-private yyprod366 ((_, (YYTok yy1)):yyvs) = YYM.return (YYNTelsex (yy1), yyvs);
+private yyprod366 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce366 yy1 yy2}; YYM.return (YYNTelsex yyr, yyvs)};
 private yyprod366 yyvals = yybadprod 366 yyvals;
-private yyprod367 ((_, (YYNTbinex yy3)):(_, (YYTok yy2)):(_, (YYNTbinex yy1)):yyvs) =  do { let {!yyr = reduce367 yy1 yy2 yy3}; YYM.return (YYNTbinex yyr, yyvs)};
-private yyprod367 ((_, (YYNTbinex yy1)):yyvs) = YYM.return (YYNTbinex (yy1), yyvs);
+private yyprod367 ((_, (YYTok yy1)):yyvs) = YYM.return (YYNTelsex (yy1), yyvs);
 private yyprod367 yyvals = yybadprod 367 yyvals;
 private yyprod368 ((_, (YYNTbinex yy3)):(_, (YYTok yy2)):(_, (YYNTbinex yy1)):yyvs) =  do { let {!yyr = reduce368 yy1 yy2 yy3}; YYM.return (YYNTbinex yyr, yyvs)};
 private yyprod368 ((_, (YYNTbinex yy1)):yyvs) = YYM.return (YYNTbinex (yy1), yyvs);
 private yyprod368 yyvals = yybadprod 368 yyvals;
-private yyprod369 ((_, (YYNTtopex yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce369 yy1 yy2}; YYM.return (YYNTbinex yyr, yyvs)};
+private yyprod369 ((_, (YYNTbinex yy3)):(_, (YYTok yy2)):(_, (YYNTbinex yy1)):yyvs) =  do { let {!yyr = reduce369 yy1 yy2 yy3}; YYM.return (YYNTbinex yyr, yyvs)};
+private yyprod369 ((_, (YYNTbinex yy1)):yyvs) = YYM.return (YYNTbinex (yy1), yyvs);
 private yyprod369 yyvals = yybadprod 369 yyvals;
-private yyprod370 ((_, (YYNTtopex yy1)):yyvs) = YYM.return (YYNTbinex (yy1), yyvs);
+private yyprod370 ((_, (YYNTtopex yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce370 yy1 yy2}; YYM.return (YYNTbinex yyr, yyvs)};
 private yyprod370 yyvals = yybadprod 370 yyvals;
-private yyprod371 ((_, (YYNTexpr yy6)):(_, (YYNTelsex yy5)):(_, (YYNTexpr yy4)):(_, (YYNTthenx yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce371 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTtopex yyr, yyvs)};
+private yyprod371 ((_, (YYNTtopex yy1)):yyvs) = YYM.return (YYNTbinex (yy1), yyvs);
 private yyprod371 yyvals = yybadprod 371 yyvals;
-private yyprod372 ((_, (YYTok yy6)):(_, (YYNTcalts yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce372 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTtopex yyr, yyvs)};
+private yyprod372 ((_, (YYNTexpr yy6)):(_, (YYNTelsex yy5)):(_, (YYNTexpr yy4)):(_, (YYNTthenx yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce372 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTtopex yyr, yyvs)};
 private yyprod372 yyvals = yybadprod 372 yyvals;
-private yyprod373 ((_, (YYNTexpr yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYNTletdefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce373 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTtopex yyr, yyvs)};
+private yyprod373 ((_, (YYTok yy6)):(_, (YYNTcalts yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce373 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTtopex yyr, yyvs)};
 private yyprod373 yyvals = yybadprod 373 yyvals;
-private yyprod374 ((_, (YYNTlambda yy1)):yyvs) = YYM.return (YYNTtopex (yy1), yyvs);
+private yyprod374 ((_, (YYNTexpr yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYNTletdefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce374 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTtopex yyr, yyvs)};
 private yyprod374 yyvals = yybadprod 374 yyvals;
-private yyprod375 ((_, (YYNTappex yy1)):yyvs) =  do { let {!yyr = reduce375 yy1}; YYM.return (YYNTtopex yyr, yyvs)};
+private yyprod375 ((_, (YYNTlambda yy1)):yyvs) = YYM.return (YYNTtopex (yy1), yyvs);
 private yyprod375 yyvals = yybadprod 375 yyvals;
-private yyprod376 ((_, (YYNTunex yy1)):yyvs) = YYM.return (YYNTappex (yy1), yyvs);
+private yyprod376 ((_, (YYNTappex yy1)):yyvs) =  do { let {!yyr = reduce376 yy1}; YYM.return (YYNTtopex yyr, yyvs)};
 private yyprod376 yyvals = yybadprod 376 yyvals;
-private yyprod377 ((_, (YYNTunex yy2)):(_, (YYNTappex yy1)):yyvs) =  do { let {!yyr = reduce377 yy1 yy2}; YYM.return (YYNTappex yyr, yyvs)};
+private yyprod377 ((_, (YYNTunex yy1)):yyvs) = YYM.return (YYNTappex (yy1), yyvs);
 private yyprod377 yyvals = yybadprod 377 yyvals;
-private yyprod378 ((_, (YYNTprimary yy1)):yyvs) = YYM.return (YYNTunex (yy1), yyvs);
+private yyprod378 ((_, (YYNTunex yy2)):(_, (YYNTappex yy1)):yyvs) =  do { let {!yyr = reduce378 yy1 yy2}; YYM.return (YYNTappex yyr, yyvs)};
 private yyprod378 yyvals = yybadprod 378 yyvals;
-private yyprod379 ((_, (YYNTunex yy2)):(_, (YYNTunop yy1)):yyvs) =  do { let {!yyr = reduce379 yy1 yy2}; YYM.return (YYNTunex yyr, yyvs)};
+private yyprod379 ((_, (YYNTprimary yy1)):yyvs) = YYM.return (YYNTunex (yy1), yyvs);
 private yyprod379 yyvals = yybadprod 379 yyvals;
-private yyprod380 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce380 yy1}; YYM.return (YYNTqualifiers yyr, yyvs)};
+private yyprod380 ((_, (YYNTunex yy2)):(_, (YYNTunop yy1)):yyvs) =  do { let {!yyr = reduce380 yy1 yy2}; YYM.return (YYNTunex yyr, yyvs)};
 private yyprod380 yyvals = yybadprod 380 yyvals;
-private yyprod381 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce381 yy1 yy2}; YYM.return (YYNTqualifiers yyr, yyvs)};
+private yyprod381 ((_, (YYNTunex yy1)):yyvs) =  do { let {!yyr = reduce381 yy1}; YYM.return (YYNTapats yyr, yyvs)};
 private yyprod381 yyvals = yybadprod 381 yyvals;
-private yyprod382 ((_, (YYNTterm yy1)):yyvs) = YYM.return (YYNTprimary (yy1), yyvs);
+private yyprod382 ((_, (YYNTapats yy2)):(_, (YYNTunex yy1)):yyvs) =  do { let {!yyr = reduce382 yy1 yy2}; YYM.return (YYNTapats yyr, yyvs)};
 private yyprod382 yyvals = yybadprod 382 yyvals;
-private yyprod383 ((_, (YYTok yy4)):(_, (YYNTdodefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce383 yy1 yy2 yy3 yy4 ;YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod383 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce383 yy1}; YYM.return (YYNTqualifiers yyr, yyvs)};
 private yyprod383 yyvals = yybadprod 383 yyvals;
-private yyprod384 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce384 yy1 yy2 yy3}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod384 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce384 yy1 yy2}; YYM.return (YYNTqualifiers yyr, yyvs)};
 private yyprod384 yyvals = yybadprod 384 yyvals;
-private yyprod385 ((_, (YYNToperator yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { yyr <- reduce385 yy1 yy2 yy3 ;YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod385 ((_, (YYNTterm yy1)):yyvs) = YYM.return (YYNTprimary (yy1), yyvs);
 private yyprod385 yyvals = yybadprod 385 yyvals;
-private yyprod386 ((_, (YYNTunop yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce386 yy1 yy2 yy3}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod386 ((_, (YYTok yy4)):(_, (YYNTdodefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce386 yy1 yy2 yy3 yy4 ;YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod386 yyvals = yybadprod 386 yyvals;
-private yyprod387 ((_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce387 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod387 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce387 yy1 yy2 yy3}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod387 yyvals = yybadprod 387 yyvals;
-private yyprod388 ((_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce388 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod388 ((_, (YYNToperator yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { yyr <- reduce388 yy1 yy2 yy3 ;YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod388 yyvals = yybadprod 388 yyvals;
-private yyprod389 ((_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce389 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod389 ((_, (YYNTunop yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce389 yy1 yy2 yy3}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod389 yyvals = yybadprod 389 yyvals;
-private yyprod390 ((_, (YYTok yy4)):(_, (YYNTgetfields yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce390 yy1 yy2 yy3 yy4}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod390 ((_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce390 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod390 yyvals = yybadprod 390 yyvals;
-private yyprod391 ((_, (YYTok yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce391 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod391 ((_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce391 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod391 yyvals = yybadprod 391 yyvals;
-private yyprod392 ((_, (YYTok yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce392 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod392 ((_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce392 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod392 yyvals = yybadprod 392 yyvals;
-private yyprod393 ((_, (YYTok yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce393 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod393 ((_, (YYTok yy4)):(_, (YYNTgetfields yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce393 yy1 yy2 yy3 yy4}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod393 yyvals = yybadprod 393 yyvals;
-private yyprod394 ((_, (YYTok yy5)):(_, (YYNTgetfields yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce394 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod394 ((_, (YYTok yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce394 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod394 yyvals = yybadprod 394 yyvals;
-private yyprod395 ((_, (YYTok yy5)):(_, (YYNTexpr yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce395 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod395 ((_, (YYTok yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce395 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod395 yyvals = yybadprod 395 yyvals;
-private yyprod396 ((_, (YYNTqvarid yy1)):yyvs) =  do { let {!yyr = reduce396 yy1}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod396 ((_, (YYTok yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce396 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod396 yyvals = yybadprod 396 yyvals;
-private yyprod397 ((_, (YYNTliteral yy1)):yyvs) = YYM.return (YYNTterm (yy1), yyvs);
+private yyprod397 ((_, (YYTok yy5)):(_, (YYNTgetfields yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce397 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod397 yyvals = yybadprod 397 yyvals;
-private yyprod398 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce398 yy1}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod398 ((_, (YYTok yy5)):(_, (YYNTexpr yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce398 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod398 yyvals = yybadprod 398 yyvals;
-private yyprod399 ((_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce399 yy1}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod399 ((_, (YYNTqvarid yy1)):yyvs) =  do { let {!yyr = reduce399 yy1}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod399 yyvals = yybadprod 399 yyvals;
-private yyprod400 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce400 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod400 ((_, (YYNTliteral yy1)):yyvs) = YYM.return (YYNTterm (yy1), yyvs);
 private yyprod400 yyvals = yybadprod 400 yyvals;
-private yyprod401 ((_, (YYTok yy4)):(_, (YYNTfields yy3)):(_, (YYTok yy2)):(_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce401 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod401 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce401 yy1}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod401 yyvals = yybadprod 401 yyvals;
-private yyprod402 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce402 yy1 yy2}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod402 ((_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce402 yy1}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod402 yyvals = yybadprod 402 yyvals;
-private yyprod403 ((_, (YYTok yy3)):(_, (YYNTcommata yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce403 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod403 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce403 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod403 yyvals = yybadprod 403 yyvals;
-private yyprod404 ((_, (YYTok yy3)):(_, (YYNTunop yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce404 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod404 ((_, (YYTok yy4)):(_, (YYNTfields yy3)):(_, (YYTok yy2)):(_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce404 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod404 yyvals = yybadprod 404 yyvals;
-private yyprod405 ((_, (YYTok yy3)):(_, (YYNToperator yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce405 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod405 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce405 yy1 yy2}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod405 yyvals = yybadprod 405 yyvals;
-private yyprod406 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce406 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod406 ((_, (YYTok yy3)):(_, (YYNTcommata yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce406 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod406 yyvals = yybadprod 406 yyvals;
-private yyprod407 ((_, (YYTok yy4)):(_, (YYNTexpr yy3)):(_, (YYNToperator yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce407 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod407 ((_, (YYTok yy3)):(_, (YYNTunop yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce407 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod407 yyvals = yybadprod 407 yyvals;
-private yyprod408 ((_, (YYTok yy4)):(_, (YYNToperator yy3)):(_, (YYNTbinex yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce408 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod408 ((_, (YYTok yy3)):(_, (YYNToperator yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce408 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod408 yyvals = yybadprod 408 yyvals;
-private yyprod409 ((_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYNTbinex yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce409 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod409 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce409 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod409 yyvals = yybadprod 409 yyvals;
-private yyprod410 ((_, (YYTok yy5)):(_, (YYNTexprSC yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce410 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod410 ((_, (YYTok yy4)):(_, (YYNTexpr yy3)):(_, (YYNToperator yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce410 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod410 yyvals = yybadprod 410 yyvals;
-private yyprod411 ((_, (YYTok yy5)):(_, (YYNTexprSS yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce411 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod411 ((_, (YYTok yy4)):(_, (YYNToperator yy3)):(_, (YYNTbinex yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce411 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod411 yyvals = yybadprod 411 yyvals;
-private yyprod412 ((_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce412 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod412 ((_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYNTbinex yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce412 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod412 yyvals = yybadprod 412 yyvals;
-private yyprod413 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce413 yy1 yy2}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod413 ((_, (YYTok yy5)):(_, (YYNTexprSC yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce413 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod413 yyvals = yybadprod 413 yyvals;
-private yyprod414 ((_, (YYTok yy3)):(_, (YYNTexprSC yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce414 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod414 ((_, (YYTok yy5)):(_, (YYNTexprSS yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce414 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod414 yyvals = yybadprod 414 yyvals;
-private yyprod415 ((_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYNTexprSC yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce415 yy1 yy2 yy3 yy4 ;YYM.return (YYNTterm yyr, yyvs)};
+private yyprod415 ((_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce415 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod415 yyvals = yybadprod 415 yyvals;
-private yyprod416 ((_, (YYTok yy5)):(_, (YYNTexpr yy4)):(_, (YYTok yy3)):(_, (YYNTexprSC yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce416 yy1 yy2 yy3 yy4 yy5 ;YYM.return (YYNTterm yyr, yyvs)};
+private yyprod416 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce416 yy1 yy2}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod416 yyvals = yybadprod 416 yyvals;
-private yyprod417 ((_, (YYTok yy5)):(_, (YYNTlcquals yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce417 yy1 yy2 yy3 yy4 yy5 ;YYM.return (YYNTterm yyr, yyvs)};
+private yyprod417 ((_, (YYTok yy3)):(_, (YYNTexprSC yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce417 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod417 yyvals = yybadprod 417 yyvals;
-private yyprod418 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce418 yy1}; YYM.return (YYNTcommata yyr, yyvs)};
+private yyprod418 ((_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYNTexprSC yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce418 yy1 yy2 yy3 yy4 ;YYM.return (YYNTterm yyr, yyvs)};
 private yyprod418 yyvals = yybadprod 418 yyvals;
-private yyprod419 ((_, (YYNTcommata yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce419 yy1 yy2}; YYM.return (YYNTcommata yyr, yyvs)};
+private yyprod419 ((_, (YYTok yy5)):(_, (YYNTexpr yy4)):(_, (YYTok yy3)):(_, (YYNTexprSC yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce419 yy1 yy2 yy3 yy4 yy5 ;YYM.return (YYNTterm yyr, yyvs)};
 private yyprod419 yyvals = yybadprod 419 yyvals;
-private yyprod420 ((_, (YYNTfield yy1)):yyvs) =  do { let {!yyr = reduce420 yy1}; YYM.return (YYNTfields yyr, yyvs)};
+private yyprod420 ((_, (YYTok yy5)):(_, (YYNTlcquals yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce420 yy1 yy2 yy3 yy4 yy5 ;YYM.return (YYNTterm yyr, yyvs)};
 private yyprod420 yyvals = yybadprod 420 yyvals;
-private yyprod421 ((_, (YYNTfields yy3)):(_, (YYTok yy2)):(_, (YYNTfield yy1)):yyvs) =  do { yyr <- reduce421 yy1 yy2 yy3 ;YYM.return (YYNTfields yyr, yyvs)};
+private yyprod421 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce421 yy1}; YYM.return (YYNTcommata yyr, yyvs)};
 private yyprod421 yyvals = yybadprod 421 yyvals;
-private yyprod422 ((_, (YYTok yy2)):(_, (YYNTfield yy1)):yyvs) =  do { let {!yyr = reduce422 yy1 yy2}; YYM.return (YYNTfields yyr, yyvs)};
+private yyprod422 ((_, (YYNTcommata yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce422 yy1 yy2}; YYM.return (YYNTcommata yyr, yyvs)};
 private yyprod422 yyvals = yybadprod 422 yyvals;
-private yyprod423 ((_, (YYNTgetfield yy1)):yyvs) =  do { let {!yyr = reduce423 yy1}; YYM.return (YYNTgetfields yyr, yyvs)};
+private yyprod423 ((_, (YYNTfield yy1)):yyvs) =  do { let {!yyr = reduce423 yy1}; YYM.return (YYNTfields yyr, yyvs)};
 private yyprod423 yyvals = yybadprod 423 yyvals;
-private yyprod424 ((_, (YYNTgetfields yy3)):(_, (YYTok yy2)):(_, (YYNTgetfield yy1)):yyvs) =  do { let {!yyr = reduce424 yy1 yy2 yy3}; YYM.return (YYNTgetfields yyr, yyvs)};
+private yyprod424 ((_, (YYNTfields yy3)):(_, (YYTok yy2)):(_, (YYNTfield yy1)):yyvs) =  do { yyr <- reduce424 yy1 yy2 yy3 ;YYM.return (YYNTfields yyr, yyvs)};
 private yyprod424 yyvals = yybadprod 424 yyvals;
-private yyprod425 ((_, (YYTok yy2)):(_, (YYNTgetfield yy1)):yyvs) =  do { let {!yyr = reduce425 yy1 yy2}; YYM.return (YYNTgetfields yyr, yyvs)};
+private yyprod425 ((_, (YYTok yy2)):(_, (YYNTfield yy1)):yyvs) =  do { let {!yyr = reduce425 yy1 yy2}; YYM.return (YYNTfields yyr, yyvs)};
 private yyprod425 yyvals = yybadprod 425 yyvals;
-private yyprod426 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce426 yy1 yy2 yy3}; YYM.return (YYNTgetfield yyr, yyvs)};
+private yyprod426 ((_, (YYNTgetfield yy1)):yyvs) =  do { let {!yyr = reduce426 yy1}; YYM.return (YYNTgetfields yyr, yyvs)};
 private yyprod426 yyvals = yybadprod 426 yyvals;
-private yyprod427 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce427 yy1 yy2 yy3}; YYM.return (YYNTgetfield yyr, yyvs)};
+private yyprod427 ((_, (YYNTgetfields yy3)):(_, (YYTok yy2)):(_, (YYNTgetfield yy1)):yyvs) =  do { let {!yyr = reduce427 yy1 yy2 yy3}; YYM.return (YYNTgetfields yyr, yyvs)};
 private yyprod427 yyvals = yybadprod 427 yyvals;
-private yyprod428 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce428 yy1}; YYM.return (YYNTgetfield yyr, yyvs)};
+private yyprod428 ((_, (YYTok yy2)):(_, (YYNTgetfield yy1)):yyvs) =  do { let {!yyr = reduce428 yy1 yy2}; YYM.return (YYNTgetfields yyr, yyvs)};
 private yyprod428 yyvals = yybadprod 428 yyvals;
-private yyprod429 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYNTvarid yy1)):yyvs) =  do { let {!yyr = reduce429 yy1 yy2 yy3}; YYM.return (YYNTfield yyr, yyvs)};
+private yyprod429 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce429 yy1 yy2 yy3}; YYM.return (YYNTgetfield yyr, yyvs)};
 private yyprod429 yyvals = yybadprod 429 yyvals;
-private yyprod430 ((_, (YYNTvarid yy1)):yyvs) =  do { let {!yyr = reduce430 yy1}; YYM.return (YYNTfield yyr, yyvs)};
+private yyprod430 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce430 yy1 yy2 yy3}; YYM.return (YYNTgetfield yyr, yyvs)};
 private yyprod430 yyvals = yybadprod 430 yyvals;
-private yyprod431 ((_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce431 yy1}; YYM.return (YYNTexprSC yyr, yyvs)};
+private yyprod431 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce431 yy1}; YYM.return (YYNTgetfield yyr, yyvs)};
 private yyprod431 yyvals = yybadprod 431 yyvals;
-private yyprod432 ((_, (YYNTexprSC yy3)):(_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce432 yy1 yy2 yy3}; YYM.return (YYNTexprSC yyr, yyvs)};
+private yyprod432 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYNTvarid yy1)):yyvs) =  do { let {!yyr = reduce432 yy1 yy2 yy3}; YYM.return (YYNTfield yyr, yyvs)};
 private yyprod432 yyvals = yybadprod 432 yyvals;
-private yyprod433 ((_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce433 yy1 yy2}; YYM.return (YYNTexprSC yyr, yyvs)};
+private yyprod433 ((_, (YYNTvarid yy1)):yyvs) =  do { let {!yyr = reduce433 yy1}; YYM.return (YYNTfield yyr, yyvs)};
 private yyprod433 yyvals = yybadprod 433 yyvals;
-private yyprod434 ((_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce434 yy1}; YYM.return (YYNTexprSS yyr, yyvs)};
+private yyprod434 ((_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce434 yy1}; YYM.return (YYNTexprSC yyr, yyvs)};
 private yyprod434 yyvals = yybadprod 434 yyvals;
-private yyprod435 ((_, (YYNTexprSS yy3)):(_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce435 yy1 yy2 yy3}; YYM.return (YYNTexprSS yyr, yyvs)};
+private yyprod435 ((_, (YYNTexprSC yy3)):(_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce435 yy1 yy2 yy3}; YYM.return (YYNTexprSC yyr, yyvs)};
 private yyprod435 yyvals = yybadprod 435 yyvals;
-private yyprod436 ((_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce436 yy1 yy2}; YYM.return (YYNTexprSS yyr, yyvs)};
+private yyprod436 ((_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce436 yy1 yy2}; YYM.return (YYNTexprSC yyr, yyvs)};
 private yyprod436 yyvals = yybadprod 436 yyvals;
+private yyprod437 ((_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce437 yy1}; YYM.return (YYNTexprSS yyr, yyvs)};
+private yyprod437 yyvals = yybadprod 437 yyvals;
+private yyprod438 ((_, (YYNTexprSS yy3)):(_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce438 yy1 yy2 yy3}; YYM.return (YYNTexprSS yyr, yyvs)};
+private yyprod438 yyvals = yybadprod 438 yyvals;
+private yyprod439 ((_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce439 yy1 yy2}; YYM.return (YYNTexprSS yyr, yyvs)};
+private yyprod439 yyvals = yybadprod 439 yyvals;
 ;
 
 private yyprods = let 
@@ -8011,7 +8044,10 @@ private yyprods = let
       (433, yyprod433),
       (434, yyprod434),
       (435, yyprod435),
-      (436, yyprod436)];
+      (436, yyprod436),
+      (437, yyprod437),
+      (438, yyprod438),
+      (439, yyprod439)];
       in sub1 `seq` sub2 `seq` sub3 `seq` sub4 `seq` sub5 `seq` sub6 `seq` sub7 `seq` arrayFromIndexList (sub1 ++ sub2 ++ sub3 ++ sub4 ++ sub5 ++ sub6 ++ sub7);
 private yyacts  = let 
     sub1 = [      (0, yyaction0),
@@ -8705,7 +8741,10 @@ private yyacts  = let
       (688, yyaction688),
       (689, yyaction689),
       (690, yyaction690),
-      (691, yyaction691)];
+      (691, yyaction691),
+      (692, yyaction692),
+      (693, yyaction693),
+      (694, yyaction694)];
       in sub1 `seq` sub2 `seq` sub3 `seq` sub4 `seq` sub5 `seq` sub6 `seq` sub7 `seq` sub8 `seq` sub9 `seq` sub10 `seq` sub11 `seq` arrayFromIndexList (sub1 ++ sub2 ++ sub3 ++ sub4 ++ sub5 ++ sub6 ++ sub7 ++ sub8 ++ sub9 ++ sub10 ++ sub11);
 private yyrecs  = let 
     sub1 = [      (0, yybadstart 0 "a module"),
@@ -8804,8 +8843,8 @@ private yyrecs  = let
       (93, yyparsing  93 "a term"),
       (94, yyparsing  94 "a term"),
       (95, yyparsing  95 "a term"),
-      (96, yyparsing  96 "a pattern"),
-      (97, yybadstart 97 "a lambda abstraction"),
+      (96, yyparsing  96 "a lambda abstraction"),
+      (97, yyparsing  97 "lambda patterns"),
       (98, yyparsing  98 "a term"),
       (99, yyparsing  99 "unary expression"),
       (100, yyparsing  100 "an expression"),
@@ -8896,423 +8935,423 @@ private yyrecs  = let
       (185, yyparsing  185 "a term"),
       (186, yyparsing  186 "a term"),
       (187, yyparsing  187 "a term"),
-      (188, yyparsing  188 "a lambda abstraction"),
-      (189, yyparsing  189 "a lambda abstraction"),
-      (190, yyparsing  190 "a variable name"),
-      (191, yyparsing  191 "a term")];
-    sub4 = [      (192, yyparsing  192 "field"),
-      (193, yyexpect 193(yyfromCh '}')),
-      (194, yyparsing  194 "field list"),
-      (195, yyparsing  195 "a type variable"),
-      (196, yyparsing  196 "a qualified constructor or type name"),
-      (197, yyexpect 197(yyfromId VARID)),
-      (198, yyparsing  198 "a non function type"),
-      (199, yyparsing  199 "a non function type"),
-      (200, yyparsing  200 "a type constructor"),
-      (201, yyparsing  201 "an expression"),
-      (202, yyparsing  202 "a qualified type"),
-      (203, yyparsing  203 "a qualified type"),
-      (204, yyparsing  204 "a constrained type"),
-      (205, yyparsing  205 "a constrained type"),
-      (206, yyparsing  206 "a type application"),
-      (207, yyparsing  207 "non function types"),
-      (208, yyparsing  208 "a non function type"),
-      (209, yyparsing  209 "a non function type"),
-      (210, yyparsing  210 "binary expression"),
-      (211, yyparsing  211 "binary expression"),
-      (212, yyparsing  212 "a primary expression"),
-      (213, yyexpect 213(yyfromId VARID)),
+      (188, yyparsing  188 "a lambda body"),
+      (189, yyparsing  189 "a lambda body"),
+      (190, yyparsing  190 "a lambda abstraction"),
+      (191, yyparsing  191 "lambda patterns")];
+    sub4 = [      (192, yyparsing  192 "a variable name"),
+      (193, yyparsing  193 "a term"),
+      (194, yyparsing  194 "field"),
+      (195, yyexpect 195(yyfromCh '}')),
+      (196, yyparsing  196 "field list"),
+      (197, yyparsing  197 "a type variable"),
+      (198, yyparsing  198 "a qualified constructor or type name"),
+      (199, yyexpect 199(yyfromId VARID)),
+      (200, yyparsing  200 "a non function type"),
+      (201, yyparsing  201 "a non function type"),
+      (202, yyparsing  202 "a type constructor"),
+      (203, yyparsing  203 "an expression"),
+      (204, yyparsing  204 "a qualified type"),
+      (205, yyparsing  205 "a qualified type"),
+      (206, yyparsing  206 "a constrained type"),
+      (207, yyparsing  207 "a constrained type"),
+      (208, yyparsing  208 "a type application"),
+      (209, yyparsing  209 "non function types"),
+      (210, yyparsing  210 "a non function type"),
+      (211, yyparsing  211 "a non function type"),
+      (212, yyparsing  212 "binary expression"),
+      (213, yyparsing  213 "binary expression"),
       (214, yyparsing  214 "a primary expression"),
-      (215, yyparsing  215 "a primary expression"),
+      (215, yyexpect 215(yyfromId VARID)),
       (216, yyparsing  216 "a primary expression"),
       (217, yyparsing  217 "a primary expression"),
-      (218, yyexpect 218(yyfromCh '}')),
-      (219, yyparsing  219 "field list"),
+      (218, yyparsing  218 "a primary expression"),
+      (219, yyparsing  219 "a primary expression"),
       (220, yyexpect 220(yyfromCh '}')),
-      (221, yyparsing  221 "a module import"),
-      (222, yyparsing  222 "the start of a fixity declaration"),
-      (223, yyparsing  223 "the start of a fixity declaration"),
+      (221, yyparsing  221 "field list"),
+      (222, yyexpect 222(yyfromCh '}')),
+      (223, yyparsing  223 "a module import"),
       (224, yyparsing  224 "the start of a fixity declaration"),
-      (225, yybadstart 225 "the type this module derives from"),
-      (226, yyparsing  226 "a native item"),
-      (227, yyparsing  227 "an annotated item"),
+      (225, yyparsing  225 "the start of a fixity declaration"),
+      (226, yyparsing  226 "the start of a fixity declaration"),
+      (227, yybadstart 227 "the type this module derives from"),
       (228, yyparsing  228 "a native item"),
-      (229, yyparsing  229 "a native item"),
+      (229, yyparsing  229 "an annotated item"),
       (230, yyparsing  230 "a native item"),
-      (231, yyparsing  231 "a data definition"),
-      (232, yyparsing  232 "a type class declaration"),
-      (233, yybadstart 233 "a sequence of one or more ','"),
-      (234, yyexpect 234(yyfromCh ']')),
-      (235, yyparsing  235 "an instance declaration"),
-      (236, yyparsing  236 "a protected or private declaration"),
-      (237, yyparsing  237 "a type declaration"),
-      (238, yyparsing  238 "an instance derivation"),
-      (239, yyparsing  239 "a native item"),
-      (240, yyparsing  240 "a protected or private declaration"),
-      (241, yyparsing  241 "a protected or private declaration"),
+      (231, yyparsing  231 "a native item"),
+      (232, yyparsing  232 "a native item"),
+      (233, yyparsing  233 "a data definition"),
+      (234, yyparsing  234 "a type class declaration"),
+      (235, yybadstart 235 "a sequence of one or more ','"),
+      (236, yyexpect 236(yyfromCh ']')),
+      (237, yyparsing  237 "an instance declaration"),
+      (238, yyparsing  238 "a protected or private declaration"),
+      (239, yyparsing  239 "a type declaration"),
+      (240, yyparsing  240 "an instance derivation"),
+      (241, yyparsing  241 "a native item"),
       (242, yyparsing  242 "a protected or private declaration"),
-      (243, yyparsing  243 "a declaration of a native item"),
-      (244, yyparsing  244 "an annotated item"),
-      (245, yyparsing  245 "an annotated item"),
+      (243, yyparsing  243 "a protected or private declaration"),
+      (244, yyparsing  244 "a protected or private declaration"),
+      (245, yyparsing  245 "a declaration of a native item"),
       (246, yyparsing  246 "an annotated item"),
-      (247, yyparsing  247 "declarations"),
-      (248, yyparsing  248 "a declaration"),
-      (249, yyexpect 249(yyfromCh '{')),
-      (250, yyparsing  250 "a function or pattern binding"),
-      (251, yyparsing  251 "an operator"),
-      (252, yyparsing  252 "an operator"),
+      (247, yyparsing  247 "an annotated item"),
+      (248, yyparsing  248 "an annotated item"),
+      (249, yyparsing  249 "declarations"),
+      (250, yyparsing  250 "a declaration"),
+      (251, yyexpect 251(yyfromCh '{')),
+      (252, yyparsing  252 "a function or pattern binding"),
       (253, yyparsing  253 "an operator"),
-      (254, yyparsing  254 "some operators"),
-      (255, yyparsing  255 "a fixity declaration")];
-    sub5 = [      (256, yyparsing  256 "an annotation"),
-      (257, yyparsing  257 "a list of items to annotate"),
-      (258, yyparsing  258 "a valid java identifier"),
-      (259, yyparsing  259 "a valid java identifier"),
-      (260, yybadstart 260 "a valid java identifier"),
+      (254, yyparsing  254 "an operator"),
+      (255, yyparsing  255 "an operator")];
+    sub5 = [      (256, yyparsing  256 "some operators"),
+      (257, yyparsing  257 "a fixity declaration"),
+      (258, yyparsing  258 "an annotation"),
+      (259, yyparsing  259 "a list of items to annotate"),
+      (260, yyparsing  260 "a valid java identifier"),
       (261, yyparsing  261 "a valid java identifier"),
-      (262, yyparsing  262 "a declaration of a native item"),
-      (263, yyexpect 263(yyfromId DCOLON)),
-      (264, yyexpect 264(yyfromId DCOLON)),
+      (262, yybadstart 262 "a valid java identifier"),
+      (263, yyparsing  263 "a valid java identifier"),
+      (264, yyparsing  264 "a declaration of a native item"),
       (265, yyexpect 265(yyfromId DCOLON)),
-      (266, yyexpect 266(yyfromCh '{')),
-      (267, yyparsing  267 "a data definition"),
-      (268, yyparsing  268 "a guarded expression"),
-      (269, yyparsing  269 "a function or pattern binding"),
-      (270, yyparsing  270 "a function or pattern binding"),
-      (271, yyparsing  271 "guarded expressions"),
-      (272, yyparsing  272 "a qualified variable name"),
-      (273, yyexpect 273(yyfromCh ')')),
+      (266, yyexpect 266(yyfromId DCOLON)),
+      (267, yyexpect 267(yyfromId DCOLON)),
+      (268, yyexpect 268(yyfromCh '{')),
+      (269, yyparsing  269 "a data definition"),
+      (270, yyparsing  270 "a guarded expression"),
+      (271, yyparsing  271 "a function or pattern binding"),
+      (272, yyparsing  272 "a function or pattern binding"),
+      (273, yyparsing  273 "guarded expressions"),
       (274, yyparsing  274 "a qualified variable name"),
-      (275, yyparsing  275 "a list of qualified variable names"),
+      (275, yyexpect 275(yyfromCh ')')),
       (276, yyparsing  276 "a qualified variable name"),
-      (277, yyparsing  277 "a module clause"),
-      (278, yyparsing  278 "then branch"),
-      (279, yybadstart 279 "else branch"),
-      (280, yyparsing  280 "a top level expression"),
-      (281, yyparsing  281 "declarations in a let expression or where clause"),
-      (282, yyexpect 282(yyfromId IN)),
-      (283, yyparsing  283 "a list comprehension qualifier"),
-      (284, yyparsing  284 "a guard qualifier"),
+      (277, yyparsing  277 "a list of qualified variable names"),
+      (278, yyparsing  278 "a qualified variable name"),
+      (279, yyparsing  279 "a module clause"),
+      (280, yyparsing  280 "then branch"),
+      (281, yybadstart 281 "else branch"),
+      (282, yyparsing  282 "a top level expression"),
+      (283, yyparsing  283 "declarations in a let expression or where clause"),
+      (284, yyexpect 284(yyfromId IN)),
       (285, yyparsing  285 "a list comprehension qualifier"),
-      (286, yyparsing  286 "do expression qualifiers"),
-      (287, yyparsing  287 "a primary expression"),
-      (288, yyparsing  288 "list of expressions separated by ';'"),
-      (289, yyexpect 289(yyfromCh ')')),
-      (290, yyparsing  290 "list of expressions separated by ','"),
+      (286, yyparsing  286 "a guard qualifier"),
+      (287, yyparsing  287 "a list comprehension qualifier"),
+      (288, yyparsing  288 "do expression qualifiers"),
+      (289, yyparsing  289 "a primary expression"),
+      (290, yyparsing  290 "list of expressions separated by ';'"),
       (291, yyexpect 291(yyfromCh ')')),
-      (292, yyparsing  292 "a term"),
-      (293, yyparsing  293 "a term"),
+      (292, yyparsing  292 "list of expressions separated by ','"),
+      (293, yyexpect 293(yyfromCh ')')),
       (294, yyparsing  294 "a term"),
-      (295, yyparsing  295 "list of expressions separated by ','"),
-      (296, yyparsing  296 "list comprehension qualifiers"),
-      (297, yyexpect 297(yyfromCh ']')),
-      (298, yyparsing  298 "a term"),
+      (295, yyparsing  295 "a term"),
+      (296, yyparsing  296 "a term"),
+      (297, yyparsing  297 "list of expressions separated by ','"),
+      (298, yyparsing  298 "list comprehension qualifiers"),
       (299, yyexpect 299(yyfromCh ']')),
-      (300, yyparsing  300 "a lambda abstraction"),
-      (301, yyparsing  301 "field"),
-      (302, yyparsing  302 "a term"),
-      (303, yyparsing  303 "field list"),
-      (304, yyexpect 304(yyfromId CONID)),
-      (305, yyparsing  305 "a type variable bound in a forall"),
-      (306, yybadstart 306 "'.' or '•'"),
-      (307, yyparsing  307 "type variables bound in a forall"),
-      (308, yyparsing  308 "a type variable"),
-      (309, yyexpect 309(yyfromCh ')')),
-      (310, yyparsing  310 "a type constructor"),
-      (311, yyparsing  311 "a non function type"),
-      (312, yyparsing  312 "a non function type"),
+      (300, yyparsing  300 "a term"),
+      (301, yyexpect 301(yyfromCh ']')),
+      (302, yyparsing  302 "a lambda body"),
+      (303, yyparsing  303 "field"),
+      (304, yyparsing  304 "a term"),
+      (305, yyparsing  305 "field list"),
+      (306, yyexpect 306(yyfromId CONID)),
+      (307, yyparsing  307 "a type variable bound in a forall"),
+      (308, yybadstart 308 "'.' or '•'"),
+      (309, yyparsing  309 "type variables bound in a forall"),
+      (310, yyparsing  310 "a type variable"),
+      (311, yyexpect 311(yyfromCh ')')),
+      (312, yyparsing  312 "a type constructor"),
       (313, yyparsing  313 "a non function type"),
-      (314, yyexpect 314(yyfromCh ')')),
-      (315, yyparsing  315 "a type constructor"),
-      (316, yyexpect 316(yyfromCh ']')),
-      (317, yyparsing  317 "a type"),
-      (318, yyparsing  318 "a constrained type"),
-      (319, yyparsing  319 "non function types")];
-    sub6 = [      (320, yyparsing  320 "a primary expression"),
-      (321, yyexpect 321(yyfromCh '}')),
-      (322, yyexpect 322(yyfromCh ']')),
-      (323, yyparsing  323 "a primary expression"),
-      (324, yyexpect 324(yyfromCh '}')),
+      (314, yyparsing  314 "a non function type"),
+      (315, yyparsing  315 "a non function type"),
+      (316, yyexpect 316(yyfromCh ')')),
+      (317, yyparsing  317 "a type constructor"),
+      (318, yyexpect 318(yyfromCh ']')),
+      (319, yyparsing  319 "a type")];
+    sub6 = [      (320, yyparsing  320 "a constrained type"),
+      (321, yyparsing  321 "non function types"),
+      (322, yyparsing  322 "a primary expression"),
+      (323, yyexpect 323(yyfromCh '}')),
+      (324, yyexpect 324(yyfromCh ']')),
       (325, yyparsing  325 "a primary expression"),
-      (326, yyparsing  326 "a primary expression"),
-      (327, yyparsing  327 "field list"),
-      (328, yyparsing  328 "a module"),
-      (329, yyparsing  329 "a module import"),
-      (330, yyparsing  330 "a module import"),
-      (331, yyparsing  331 "an import list"),
-      (332, yyparsing  332 "an import list"),
-      (333, yyparsing  333 "a module import"),
-      (334, yyexpect 334(yyfromCh '(')),
-      (335, yyparsing  335 "the type this module derives from"),
-      (336, yybadstart 336 "the interfaces this module implements"),
-      (337, yyexpect 337(yyfromCh ')')),
-      (338, yyexpect 338(yyfromCh ')')),
+      (326, yyexpect 326(yyfromCh '}')),
+      (327, yyparsing  327 "a primary expression"),
+      (328, yyparsing  328 "a primary expression"),
+      (329, yyparsing  329 "field list"),
+      (330, yyparsing  330 "a module"),
+      (331, yyparsing  331 "a module import"),
+      (332, yyparsing  332 "a module import"),
+      (333, yyparsing  333 "an import list"),
+      (334, yyparsing  334 "an import list"),
+      (335, yyparsing  335 "a module import"),
+      (336, yyexpect 336(yyfromCh '(')),
+      (337, yyparsing  337 "the type this module derives from"),
+      (338, yybadstart 338 "the interfaces this module implements"),
       (339, yyexpect 339(yyfromCh ')')),
-      (340, yyexpect 340(yyfromId VARID)),
-      (341, yyparsing  341 "a data definition"),
-      (342, yyparsing  342 "a sequence of type variables"),
-      (343, yyexpect 343(yyfromCh '=')),
-      (344, yyexpect 344(yyfromId EARROW)),
-      (345, yybadstart 345 "declarations local to a class, instance or type"),
-      (346, yybadstart 346 "declarations local to a class, instance or type"),
-      (347, yyparsing  347 "a type declaration"),
-      (348, yyexpect 348(yyfromCh '=')),
-      (349, yyparsing  349 "an instance derivation"),
-      (350, yyparsing  350 "an annotated item"),
-      (351, yyparsing  351 "an annotated item"),
+      (340, yyexpect 340(yyfromCh ')')),
+      (341, yyexpect 341(yyfromCh ')')),
+      (342, yyexpect 342(yyfromId VARID)),
+      (343, yyparsing  343 "a data definition"),
+      (344, yyparsing  344 "a sequence of type variables"),
+      (345, yyexpect 345(yyfromCh '=')),
+      (346, yyexpect 346(yyfromId EARROW)),
+      (347, yybadstart 347 "declarations local to a class, instance or type"),
+      (348, yybadstart 348 "declarations local to a class, instance or type"),
+      (349, yyparsing  349 "a type declaration"),
+      (350, yyexpect 350(yyfromCh '=')),
+      (351, yyparsing  351 "an instance derivation"),
       (352, yyparsing  352 "an annotated item"),
-      (353, yyparsing  353 "declarations"),
-      (354, yyparsing  354 "a where clause"),
-      (355, yyparsing  355 "some operators"),
-      (356, yyparsing  356 "an annotation"),
-      (357, yyparsing  357 "a list of items to annotate"),
-      (358, yybadstart 358 "a valid java identifier"),
-      (359, yyparsing  359 "a valid java identifier"),
-      (360, yyparsing  360 "a method type with optional throws clause"),
-      (361, yyparsing  361 "method types with optional throws clauses"),
-      (362, yyparsing  362 "a declaration of a native item"),
-      (363, yyparsing  363 "a declaration of a native item"),
+      (353, yyparsing  353 "an annotated item"),
+      (354, yyparsing  354 "an annotated item"),
+      (355, yyparsing  355 "declarations"),
+      (356, yyparsing  356 "a where clause"),
+      (357, yyparsing  357 "some operators"),
+      (358, yyparsing  358 "an annotation"),
+      (359, yyparsing  359 "a list of items to annotate"),
+      (360, yybadstart 360 "a valid java identifier"),
+      (361, yyparsing  361 "a valid java identifier"),
+      (362, yyparsing  362 "a method type with optional throws clause"),
+      (363, yyparsing  363 "method types with optional throws clauses"),
       (364, yyparsing  364 "a declaration of a native item"),
       (365, yyparsing  365 "a declaration of a native item"),
-      (366, yyparsing  366 "declarations local to a class, instance or type"),
-      (367, yyparsing  367 "a guard qualifier"),
-      (368, yyparsing  368 "guard qualifiers"),
-      (369, yybadstart 369 "'='"),
-      (370, yyparsing  370 "a function or pattern binding"),
-      (371, yyparsing  371 "guarded expressions"),
-      (372, yyparsing  372 "a qualified variable name"),
-      (373, yyparsing  373 "a qualified variable name"),
-      (374, yyparsing  374 "a module clause"),
-      (375, yyparsing  375 "a list of qualified variable names"),
-      (376, yyparsing  376 "else branch"),
-      (377, yyexpect 377(yyfromId ELSE)),
-      (378, yyparsing  378 "a top level expression"),
-      (379, yyparsing  379 "case alternative"),
-      (380, yybadstart 380 "a where clause"),
-      (381, yyexpect 381(yyfromCh '}')),
-      (382, yyparsing  382 "declarations in a let expression or where clause"),
-      (383, yyparsing  383 "a top level expression")];
+      (366, yyparsing  366 "a declaration of a native item"),
+      (367, yyparsing  367 "a declaration of a native item"),
+      (368, yyparsing  368 "declarations local to a class, instance or type"),
+      (369, yyparsing  369 "a guard qualifier"),
+      (370, yyparsing  370 "guard qualifiers"),
+      (371, yybadstart 371 "'='"),
+      (372, yyparsing  372 "a function or pattern binding"),
+      (373, yyparsing  373 "guarded expressions"),
+      (374, yyparsing  374 "a qualified variable name"),
+      (375, yyparsing  375 "a qualified variable name"),
+      (376, yyparsing  376 "a module clause"),
+      (377, yyparsing  377 "a list of qualified variable names"),
+      (378, yyparsing  378 "else branch"),
+      (379, yyexpect 379(yyfromId ELSE)),
+      (380, yyparsing  380 "a top level expression"),
+      (381, yyparsing  381 "a pattern"),
+      (382, yyparsing  382 "case alternative"),
+      (383, yybadstart 383 "a where clause")];
     sub7 = [      (384, yyexpect 384(yyfromCh '}')),
-      (385, yyparsing  385 "a guard qualifier"),
-      (386, yyparsing  386 "a list comprehension qualifier"),
-      (387, yyparsing  387 "do expression qualifiers"),
-      (388, yyparsing  388 "list of expressions separated by ';'"),
-      (389, yyparsing  389 "a term"),
-      (390, yyparsing  390 "a term"),
-      (391, yyparsing  391 "list comprehension qualifiers"),
+      (385, yyparsing  385 "declarations in a let expression or where clause"),
+      (386, yyparsing  386 "a top level expression"),
+      (387, yyexpect 387(yyfromCh '}')),
+      (388, yyparsing  388 "a guard qualifier"),
+      (389, yyparsing  389 "a list comprehension qualifier"),
+      (390, yyparsing  390 "do expression qualifiers"),
+      (391, yyparsing  391 "list of expressions separated by ';'"),
       (392, yyparsing  392 "a term"),
       (393, yyparsing  393 "a term"),
-      (394, yyparsing  394 "field"),
-      (395, yyparsing  395 "field list"),
-      (396, yyparsing  396 "'.' or '•'"),
-      (397, yyparsing  397 "'.' or '•'"),
-      (398, yyparsing  398 "a qualified type"),
-      (399, yyparsing  399 "type variables bound in a forall"),
-      (400, yyparsing  400 "a type variable"),
-      (401, yyparsing  401 "a type constructor"),
-      (402, yyparsing  402 "a non function type"),
-      (403, yyparsing  403 "a non function type"),
-      (404, yyparsing  404 "a non function type"),
+      (394, yyparsing  394 "list comprehension qualifiers"),
+      (395, yyparsing  395 "a term"),
+      (396, yyparsing  396 "a term"),
+      (397, yyparsing  397 "field"),
+      (398, yyparsing  398 "field list"),
+      (399, yyparsing  399 "'.' or '•'"),
+      (400, yyparsing  400 "'.' or '•'"),
+      (401, yyparsing  401 "a qualified type"),
+      (402, yyparsing  402 "type variables bound in a forall"),
+      (403, yyparsing  403 "a type variable"),
+      (404, yyparsing  404 "a type constructor"),
       (405, yyparsing  405 "a non function type"),
-      (406, yyparsing  406 "a type constructor"),
+      (406, yyparsing  406 "a non function type"),
       (407, yyparsing  407 "a non function type"),
-      (408, yyparsing  408 "a type"),
-      (409, yyparsing  409 "a type"),
-      (410, yyparsing  410 "a constrained type"),
-      (411, yyparsing  411 "a primary expression"),
-      (412, yyexpect 412(yyfromCh '}')),
-      (413, yyparsing  413 "a primary expression"),
+      (408, yyparsing  408 "a non function type"),
+      (409, yyparsing  409 "a type constructor"),
+      (410, yyparsing  410 "a non function type"),
+      (411, yyparsing  411 "a type"),
+      (412, yyparsing  412 "a type"),
+      (413, yyparsing  413 "a constrained type"),
       (414, yyparsing  414 "a primary expression"),
-      (415, yyparsing  415 "a primary expression"),
+      (415, yyexpect 415(yyfromCh '}')),
       (416, yyparsing  416 "a primary expression"),
-      (417, yyparsing  417 "field"),
+      (417, yyparsing  417 "a primary expression"),
       (418, yyparsing  418 "a primary expression"),
       (419, yyparsing  419 "a primary expression"),
       (420, yyparsing  420 "field"),
-      (421, yyparsing  421 "field"),
-      (422, yyparsing  422 "field list"),
-      (423, yyparsing  423 "a module import"),
-      (424, yyparsing  424 "a module import"),
-      (425, yyparsing  425 "an import list"),
-      (426, yyparsing  426 "an import item"),
-      (427, yyparsing  427 "a qualified variable name"),
-      (428, yyparsing  428 "an import specification"),
-      (429, yyparsing  429 "an import list"),
-      (430, yyexpect 430(yyfromCh ')')),
-      (431, yyparsing  431 "a list of import items"),
-      (432, yyparsing  432 "an import specification"),
-      (433, yyparsing  433 "an import item"),
-      (434, yyparsing  434 "an import item"),
-      (435, yyparsing  435 "an import item"),
+      (421, yyparsing  421 "a primary expression"),
+      (422, yyparsing  422 "a primary expression"),
+      (423, yyparsing  423 "field"),
+      (424, yyparsing  424 "field"),
+      (425, yyparsing  425 "field list"),
+      (426, yyparsing  426 "a module import"),
+      (427, yyparsing  427 "a module import"),
+      (428, yyparsing  428 "an import list"),
+      (429, yyparsing  429 "an import item"),
+      (430, yyparsing  430 "a qualified variable name"),
+      (431, yyparsing  431 "an import specification"),
+      (432, yyparsing  432 "an import list"),
+      (433, yyexpect 433(yyfromCh ')')),
+      (434, yyparsing  434 "a list of import items"),
+      (435, yyparsing  435 "an import specification"),
       (436, yyparsing  436 "an import item"),
-      (437, yyparsing  437 "an import list"),
-      (438, yyparsing  438 "the type this module derives from"),
-      (439, yyparsing  439 "the interfaces this module implements"),
-      (440, yyexpect 440(yyfromId WHERE)),
-      (441, yyparsing  441 "an annotated item"),
-      (442, yyparsing  442 "an annotated item"),
-      (443, yyparsing  443 "an annotated item"),
-      (444, yyexpect 444(yyfromId DCOLON)),
-      (445, yyparsing  445 "a variant of an algebraic datatype"),
-      (446, yyparsing  446 "a variant of an algebraic datatype"),
-      (447, yyparsing  447 "a native data type")];
+      (437, yyparsing  437 "an import item"),
+      (438, yyparsing  438 "an import item"),
+      (439, yyparsing  439 "an import item"),
+      (440, yyparsing  440 "an import list"),
+      (441, yyparsing  441 "the type this module derives from"),
+      (442, yyparsing  442 "the interfaces this module implements"),
+      (443, yyexpect 443(yyfromId WHERE)),
+      (444, yyparsing  444 "an annotated item"),
+      (445, yyparsing  445 "an annotated item"),
+      (446, yyparsing  446 "an annotated item"),
+      (447, yyexpect 447(yyfromId DCOLON))];
     sub8 = [      (448, yyparsing  448 "a variant of an algebraic datatype"),
       (449, yyparsing  449 "a variant of an algebraic datatype"),
-      (450, yyparsing  450 "a variant of an algebraic datatype"),
-      (451, yyexpect 451(yyfromId NATIVE)),
-      (452, yyexpect 452(yyfromId NATIVE)),
-      (453, yyexpect 453(yyfromId CONID)),
-      (454, yyexpect 454(yyfromId CONID)),
-      (455, yybadstart 455 "a valid java identifier"),
-      (456, yyparsing  456 "a data definition"),
-      (457, yyparsing  457 "an algebraic datatype"),
-      (458, yyparsing  458 "a variant of an algebraic datatype"),
-      (459, yyparsing  459 "a variant of an algebraic datatype"),
-      (460, yyparsing  460 "a variant of an algebraic datatype"),
-      (461, yyparsing  461 "a sequence of type variables"),
-      (462, yyparsing  462 "a data definition"),
-      (463, yyexpect 463(yyfromId VARID)),
-      (464, yyparsing  464 "a type class declaration"),
-      (465, yyparsing  465 "an instance declaration"),
-      (466, yyparsing  466 "a type declaration"),
-      (467, yyparsing  467 "a type declaration"),
-      (468, yyparsing  468 "a where clause"),
-      (469, yyexpect 469(yyfromCh '}')),
-      (470, yyparsing  470 "a valid java identifier"),
-      (471, yyparsing  471 "a method type with optional throws clause"),
-      (472, yyparsing  472 "method types with optional throws clauses"),
-      (473, yyparsing  473 "a declaration of a native item"),
-      (474, yyparsing  474 "a declaration of a native item"),
-      (475, yyparsing  475 "a declaration of a native item"),
-      (476, yyparsing  476 "a protected or private local declaration"),
-      (477, yyparsing  477 "a protected or private local declaration"),
-      (478, yyparsing  478 "a protected or private local declaration"),
-      (479, yyparsing  479 "declarations local to a class, instance or type"),
-      (480, yyparsing  480 "a commented local declaration"),
+      (450, yyparsing  450 "a native data type"),
+      (451, yyparsing  451 "a variant of an algebraic datatype"),
+      (452, yyparsing  452 "a variant of an algebraic datatype"),
+      (453, yyparsing  453 "a variant of an algebraic datatype"),
+      (454, yyexpect 454(yyfromId NATIVE)),
+      (455, yyexpect 455(yyfromId NATIVE)),
+      (456, yyexpect 456(yyfromId CONID)),
+      (457, yyexpect 457(yyfromId CONID)),
+      (458, yybadstart 458 "a valid java identifier"),
+      (459, yyparsing  459 "a data definition"),
+      (460, yyparsing  460 "an algebraic datatype"),
+      (461, yyparsing  461 "a variant of an algebraic datatype"),
+      (462, yyparsing  462 "a variant of an algebraic datatype"),
+      (463, yyparsing  463 "a variant of an algebraic datatype"),
+      (464, yyparsing  464 "a sequence of type variables"),
+      (465, yyparsing  465 "a data definition"),
+      (466, yyexpect 466(yyfromId VARID)),
+      (467, yyparsing  467 "a type class declaration"),
+      (468, yyparsing  468 "an instance declaration"),
+      (469, yyparsing  469 "a type declaration"),
+      (470, yyparsing  470 "a type declaration"),
+      (471, yyparsing  471 "a where clause"),
+      (472, yyexpect 472(yyfromCh '}')),
+      (473, yyparsing  473 "a valid java identifier"),
+      (474, yyparsing  474 "a method type with optional throws clause"),
+      (475, yyparsing  475 "method types with optional throws clauses"),
+      (476, yyparsing  476 "a declaration of a native item"),
+      (477, yyparsing  477 "a declaration of a native item"),
+      (478, yyparsing  478 "a declaration of a native item"),
+      (479, yyparsing  479 "a protected or private local declaration"),
+      (480, yyparsing  480 "a protected or private local declaration"),
       (481, yyparsing  481 "a protected or private local declaration"),
-      (482, yyexpect 482(yyfromCh '}')),
-      (483, yybadstart 483 "the next definition"),
-      (484, yyparsing  484 "a commented local declaration"),
-      (485, yyparsing  485 "guard qualifiers"),
-      (486, yyparsing  486 "'='"),
-      (487, yyparsing  487 "'='"),
-      (488, yyparsing  488 "a guarded expression"),
-      (489, yyparsing  489 "a qualified variable name"),
-      (490, yyparsing  490 "a list of qualified variable names"),
-      (491, yyparsing  491 "else branch"),
-      (492, yyparsing  492 "a top level expression"),
-      (493, yyparsing  493 "case alternative"),
-      (494, yyparsing  494 "case alternative"),
-      (495, yyparsing  495 "list of case alternatives"),
+      (482, yyparsing  482 "declarations local to a class, instance or type"),
+      (483, yyparsing  483 "a commented local declaration"),
+      (484, yyparsing  484 "a protected or private local declaration"),
+      (485, yyexpect 485(yyfromCh '}')),
+      (486, yybadstart 486 "the next definition"),
+      (487, yyparsing  487 "a commented local declaration"),
+      (488, yyparsing  488 "guard qualifiers"),
+      (489, yyparsing  489 "'='"),
+      (490, yyparsing  490 "'='"),
+      (491, yyparsing  491 "a guarded expression"),
+      (492, yyparsing  492 "a qualified variable name"),
+      (493, yyparsing  493 "a list of qualified variable names"),
+      (494, yyparsing  494 "else branch"),
+      (495, yyparsing  495 "a top level expression"),
       (496, yyparsing  496 "case alternative"),
-      (497, yyparsing  497 "a top level expression"),
-      (498, yyparsing  498 "a top level expression"),
-      (499, yyparsing  499 "a list comprehension qualifier"),
-      (500, yyparsing  500 "list of expressions separated by ';'"),
-      (501, yyparsing  501 "list comprehension qualifiers"),
-      (502, yyparsing  502 "a qualified type"),
-      (503, yyparsing  503 "a type kind"),
-      (504, yyparsing  504 "a type kind"),
-      (505, yyparsing  505 "a type kind"),
-      (506, yyexpect 506(yyfromCh ')')),
+      (497, yyparsing  497 "case alternative"),
+      (498, yyparsing  498 "list of case alternatives"),
+      (499, yyparsing  499 "case alternative"),
+      (500, yyparsing  500 "a top level expression"),
+      (501, yyparsing  501 "a top level expression"),
+      (502, yyparsing  502 "a list comprehension qualifier"),
+      (503, yyparsing  503 "list of expressions separated by ';'"),
+      (504, yyparsing  504 "list comprehension qualifiers"),
+      (505, yyparsing  505 "a qualified type"),
+      (506, yyparsing  506 "a type kind"),
       (507, yyparsing  507 "a type kind"),
-      (508, yyparsing  508 "a list of types"),
+      (508, yyparsing  508 "a type kind"),
       (509, yyexpect 509(yyfromCh ')')),
-      (510, yyparsing  510 "a list of types separated by '|'"),
-      (511, yyexpect 511(yyfromCh ')'))];
-    sub9 = [      (512, yyparsing  512 "a non function type"),
-      (513, yyparsing  513 "a primary expression"),
-      (514, yyparsing  514 "a primary expression"),
-      (515, yyparsing  515 "a primary expression"),
-      (516, yyparsing  516 "field"),
-      (517, yyparsing  517 "field"),
-      (518, yyparsing  518 "a module import"),
-      (519, yyparsing  519 "an import item"),
-      (520, yyparsing  520 "a qualified variable name"),
-      (521, yyparsing  521 "an import specification"),
-      (522, yyparsing  522 "an import list"),
-      (523, yyparsing  523 "a list of import items"),
-      (524, yyparsing  524 "a simple name for a member or import item"),
-      (525, yyparsing  525 "a simple name for a member or import item"),
-      (526, yyparsing  526 "a simple name for a member or import item"),
-      (527, yyparsing  527 "an import specification"),
-      (528, yyexpect 528(yyfromCh ')')),
-      (529, yyparsing  529 "the interfaces this module implements"),
-      (530, yyexpect 530(yyfromCh '{')),
-      (531, yyparsing  531 "specification for module class "),
-      (532, yyparsing  532 "a variant of an algebraic datatype"),
-      (533, yyparsing  533 "constructor types"),
-      (534, yyparsing  534 "a variant of an algebraic datatype"),
+      (510, yyparsing  510 "a type kind"),
+      (511, yyparsing  511 "a list of types")];
+    sub9 = [      (512, yyexpect 512(yyfromCh ')')),
+      (513, yyparsing  513 "a list of types separated by '|'"),
+      (514, yyexpect 514(yyfromCh ')')),
+      (515, yyparsing  515 "a non function type"),
+      (516, yyparsing  516 "a primary expression"),
+      (517, yyparsing  517 "a primary expression"),
+      (518, yyparsing  518 "a primary expression"),
+      (519, yyparsing  519 "field"),
+      (520, yyparsing  520 "field"),
+      (521, yyparsing  521 "a module import"),
+      (522, yyparsing  522 "an import item"),
+      (523, yyparsing  523 "a qualified variable name"),
+      (524, yyparsing  524 "an import specification"),
+      (525, yyparsing  525 "an import list"),
+      (526, yyparsing  526 "a list of import items"),
+      (527, yyparsing  527 "a simple name for a member or import item"),
+      (528, yyparsing  528 "a simple name for a member or import item"),
+      (529, yyparsing  529 "a simple name for a member or import item"),
+      (530, yyparsing  530 "an import specification"),
+      (531, yyexpect 531(yyfromCh ')')),
+      (532, yyparsing  532 "the interfaces this module implements"),
+      (533, yyexpect 533(yyfromCh '{')),
+      (534, yyparsing  534 "specification for module class "),
       (535, yyparsing  535 "a variant of an algebraic datatype"),
-      (536, yyparsing  536 "a variant of an algebraic datatype"),
+      (536, yyparsing  536 "constructor types"),
       (537, yyparsing  537 "a variant of an algebraic datatype"),
       (538, yyparsing  538 "a variant of an algebraic datatype"),
-      (539, yyparsing  539 "a native data type"),
-      (540, yyparsing  540 "a native data type"),
+      (539, yyparsing  539 "a variant of an algebraic datatype"),
+      (540, yyparsing  540 "a variant of an algebraic datatype"),
       (541, yyparsing  541 "a variant of an algebraic datatype"),
-      (542, yyparsing  542 "a variant of an algebraic datatype"),
-      (543, yyparsing  543 "a data definition"),
-      (544, yyparsing  544 "an algebraic datatype"),
+      (542, yyparsing  542 "a native data type"),
+      (543, yyparsing  543 "a native data type"),
+      (544, yyparsing  544 "a variant of an algebraic datatype"),
       (545, yyparsing  545 "a variant of an algebraic datatype"),
-      (546, yybadstart 546 "a valid java identifier"),
-      (547, yyparsing  547 "a data definition"),
-      (548, yybadstart 548 "declarations local to a class, instance or type"),
-      (549, yyparsing  549 "a type declaration"),
-      (550, yyparsing  550 "a where clause"),
-      (551, yyparsing  551 "a method type with optional throws clause"),
-      (552, yyparsing  552 "method types with optional throws clauses"),
-      (553, yyparsing  553 "a protected or private local declaration"),
-      (554, yyparsing  554 "a protected or private local declaration"),
-      (555, yyparsing  555 "a protected or private local declaration"),
-      (556, yyparsing  556 "a commented local declaration"),
-      (557, yyparsing  557 "declarations local to a class, instance or type"),
-      (558, yyparsing  558 "local declarations"),
-      (559, yyparsing  559 "guard qualifiers"),
-      (560, yyparsing  560 "a guarded expression"),
-      (561, yyparsing  561 "case alternative"),
-      (562, yyparsing  562 "list of case alternatives"),
-      (563, yyexpect 563(yyfromCh ')')),
-      (564, yyparsing  564 "a type variable"),
-      (565, yyparsing  565 "a type kind"),
-      (566, yyparsing  566 "a list of types"),
-      (567, yyparsing  567 "a non function type"),
-      (568, yyparsing  568 "a list of types separated by '|'"),
-      (569, yyparsing  569 "a non function type"),
-      (570, yyparsing  570 "a member import specification"),
-      (571, yyparsing  571 "an import item"),
-      (572, yyexpect 572(yyfromCh ')')),
+      (546, yyparsing  546 "a data definition"),
+      (547, yyparsing  547 "an algebraic datatype"),
+      (548, yyparsing  548 "a variant of an algebraic datatype"),
+      (549, yybadstart 549 "a valid java identifier"),
+      (550, yyparsing  550 "a data definition"),
+      (551, yybadstart 551 "declarations local to a class, instance or type"),
+      (552, yyparsing  552 "a type declaration"),
+      (553, yyparsing  553 "a where clause"),
+      (554, yyparsing  554 "a method type with optional throws clause"),
+      (555, yyparsing  555 "method types with optional throws clauses"),
+      (556, yyparsing  556 "a protected or private local declaration"),
+      (557, yyparsing  557 "a protected or private local declaration"),
+      (558, yyparsing  558 "a protected or private local declaration"),
+      (559, yyparsing  559 "a commented local declaration"),
+      (560, yyparsing  560 "declarations local to a class, instance or type"),
+      (561, yyparsing  561 "local declarations"),
+      (562, yyparsing  562 "guard qualifiers"),
+      (563, yyparsing  563 "a guarded expression"),
+      (564, yyparsing  564 "case alternative"),
+      (565, yyparsing  565 "list of case alternatives"),
+      (566, yyexpect 566(yyfromCh ')')),
+      (567, yyparsing  567 "a type variable"),
+      (568, yyparsing  568 "a type kind"),
+      (569, yyparsing  569 "a list of types"),
+      (570, yyparsing  570 "a non function type"),
+      (571, yyparsing  571 "a list of types separated by '|'"),
+      (572, yyparsing  572 "a non function type"),
       (573, yyparsing  573 "a member import specification"),
-      (574, yyparsing  574 "a list of member imports"),
-      (575, yyparsing  575 "a list of import items")];
-    sub10 = [      (576, yyparsing  576 "an import list"),
-      (577, yyparsing  577 "java code"),
-      (578, yyparsing  578 "a field specification"),
-      (579, yyparsing  579 "a field specification"),
-      (580, yyexpect 580(yyfromId VARID)),
-      (581, yyexpect 581(yyfromId VARID)),
-      (582, yyparsing  582 "a constructor field"),
-      (583, yyparsing  583 "a field specification"),
-      (584, yyexpect 584(yyfromCh '}')),
-      (585, yyparsing  585 "constructor fields"),
-      (586, yyexpect 586(yyfromId DCOLON)),
-      (587, yyparsing  587 "field specifications"),
-      (588, yyparsing  588 "a field specification"),
-      (589, yyparsing  589 "a field specification"),
-      (590, yyparsing  590 "an algebraic datatype"),
-      (591, yyparsing  591 "a data definition"),
-      (592, yyparsing  592 "a type class declaration"),
-      (593, yyparsing  593 "local declarations"),
-      (594, yyparsing  594 "a type kind"),
-      (595, yyparsing  595 "a type kind"),
-      (596, yyparsing  596 "a list of types"),
-      (597, yyparsing  597 "a list of types separated by '|'"),
-      (598, yyparsing  598 "a member import specification"),
-      (599, yyparsing  599 "an import item"),
-      (600, yyparsing  600 "a member import specification"),
-      (601, yyparsing  601 "a list of member imports"),
-      (602, yyparsing  602 "java token"),
-      (603, yyparsing  603 "java token"),
-      (604, yyparsing  604 "java token"),
+      (574, yyparsing  574 "an import item"),
+      (575, yyexpect 575(yyfromCh ')'))];
+    sub10 = [      (576, yyparsing  576 "a member import specification"),
+      (577, yyparsing  577 "a list of member imports"),
+      (578, yyparsing  578 "a list of import items"),
+      (579, yyparsing  579 "an import list"),
+      (580, yyparsing  580 "java code"),
+      (581, yyparsing  581 "a field specification"),
+      (582, yyparsing  582 "a field specification"),
+      (583, yyexpect 583(yyfromId VARID)),
+      (584, yyexpect 584(yyfromId VARID)),
+      (585, yyparsing  585 "a constructor field"),
+      (586, yyparsing  586 "a field specification"),
+      (587, yyexpect 587(yyfromCh '}')),
+      (588, yyparsing  588 "constructor fields"),
+      (589, yyexpect 589(yyfromId DCOLON)),
+      (590, yyparsing  590 "field specifications"),
+      (591, yyparsing  591 "a field specification"),
+      (592, yyparsing  592 "a field specification"),
+      (593, yyparsing  593 "an algebraic datatype"),
+      (594, yyparsing  594 "a data definition"),
+      (595, yyparsing  595 "a type class declaration"),
+      (596, yyparsing  596 "local declarations"),
+      (597, yyparsing  597 "a type kind"),
+      (598, yyparsing  598 "a type kind"),
+      (599, yyparsing  599 "a list of types"),
+      (600, yyparsing  600 "a list of types separated by '|'"),
+      (601, yyparsing  601 "a member import specification"),
+      (602, yyparsing  602 "an import item"),
+      (603, yyparsing  603 "a member import specification"),
+      (604, yyparsing  604 "a list of member imports"),
       (605, yyparsing  605 "java token"),
       (606, yyparsing  606 "java token"),
       (607, yyparsing  607 "java token"),
@@ -9361,11 +9400,11 @@ private yyrecs  = let
       (650, yyparsing  650 "java token"),
       (651, yyparsing  651 "java token"),
       (652, yyparsing  652 "java token"),
-      (653, yyparsing  653 "java tokens"),
-      (654, yyparsing  654 "java code"),
+      (653, yyparsing  653 "java token"),
+      (654, yyparsing  654 "java token"),
       (655, yyparsing  655 "java token"),
-      (656, yyparsing  656 "java token"),
-      (657, yyparsing  657 "java token"),
+      (656, yyparsing  656 "java tokens"),
+      (657, yyparsing  657 "java code"),
       (658, yyparsing  658 "java token"),
       (659, yyparsing  659 "java token"),
       (660, yyparsing  660 "java token"),
@@ -9374,32 +9413,35 @@ private yyrecs  = let
       (663, yyparsing  663 "java token"),
       (664, yyparsing  664 "java token"),
       (665, yyparsing  665 "java token"),
-      (666, yyexpect 666(yyfromCh '}')),
-      (667, yyparsing  667 "java tokens"),
-      (668, yyparsing  668 "a field specification"),
-      (669, yyparsing  669 "a field specification"),
-      (670, yyparsing  670 "a field specification"),
+      (666, yyparsing  666 "java token"),
+      (667, yyparsing  667 "java token"),
+      (668, yyparsing  668 "java token"),
+      (669, yyexpect 669(yyfromCh '}')),
+      (670, yyparsing  670 "java tokens"),
       (671, yyparsing  671 "a field specification"),
-      (672, yyexpect 672(yyfromId DCOLON)),
-      (673, yyparsing  673 "a variant of an algebraic datatype"),
-      (674, yyparsing  674 "constructor fields"),
-      (675, yyparsing  675 "constructor fields"),
-      (676, yyparsing  676 "a constructor field"),
-      (677, yyparsing  677 "field specifications"),
-      (678, yyparsing  678 "a list of member imports"),
-      (679, yyparsing  679 "java tokens"),
-      (680, yyexpect 680(yyfromCh '}')),
-      (681, yyparsing  681 "java code"),
+      (672, yyparsing  672 "a field specification"),
+      (673, yyparsing  673 "a field specification"),
+      (674, yyparsing  674 "a field specification"),
+      (675, yyexpect 675(yyfromId DCOLON)),
+      (676, yyparsing  676 "a variant of an algebraic datatype"),
+      (677, yyparsing  677 "constructor fields"),
+      (678, yyparsing  678 "constructor fields"),
+      (679, yyparsing  679 "a constructor field"),
+      (680, yyparsing  680 "field specifications"),
+      (681, yyparsing  681 "a list of member imports"),
       (682, yyparsing  682 "java tokens"),
-      (683, yyparsing  683 "a constructor field"),
-      (684, yyparsing  684 "constructor fields"),
-      (685, yyparsing  685 "constructor fields"),
+      (683, yyexpect 683(yyfromCh '}')),
+      (684, yyparsing  684 "java code"),
+      (685, yyparsing  685 "java tokens"),
       (686, yyparsing  686 "a constructor field"),
-      (687, yyparsing  687 "field specifications"),
-      (688, yyparsing  688 "java tokens"),
-      (689, yyparsing  689 "java tokens"),
-      (690, yyparsing  690 "a constructor field"),
-      (691, yyparsing  691 "java tokens")];
+      (687, yyparsing  687 "constructor fields"),
+      (688, yyparsing  688 "constructor fields"),
+      (689, yyparsing  689 "a constructor field"),
+      (690, yyparsing  690 "field specifications"),
+      (691, yyparsing  691 "java tokens"),
+      (692, yyparsing  692 "java tokens"),
+      (693, yyparsing  693 "a constructor field"),
+      (694, yyparsing  694 "java tokens")];
       in sub1 `seq` sub2 `seq` sub3 `seq` sub4 `seq` sub5 `seq` sub6 `seq` sub7 `seq` sub8 `seq` sub9 `seq` sub10 `seq` sub11 `seq` arrayFromIndexList (sub1 ++ sub2 ++ sub3 ++ sub4 ++ sub5 ++ sub6 ++ sub7 ++ sub8 ++ sub9 ++ sub10 ++ sub11);
 private yyeacts = let 
     sub1 = [      (5, yyAccept),
@@ -9429,19 +9471,19 @@ private yyeacts = let
       (40, (-328)),
       (44, (-195)),
       (45, (-194)),
-      (47, (-398)),
+      (47, (-401)),
       (48, (-3)),
       (49, (-4)),
-      (50, (-396)),
-      (51, (-399)),
-      (53, (-362)),
-      (54, (-397)),
-      (55, (-374)),
-      (56, (-370)),
-      (57, (-375)),
-      (58, (-376)),
-      (59, (-378)),
-      (61, (-382)),
+      (50, (-399)),
+      (51, (-402)),
+      (53, (-363)),
+      (54, (-400)),
+      (55, (-375)),
+      (56, (-371)),
+      (57, (-376)),
+      (58, (-377)),
+      (59, (-379)),
+      (61, (-385)),
       (62, (-22)),
       (69, (-26)),
       (70, (-16)),
@@ -9451,13 +9493,12 @@ private yyeacts = let
       (75, (-185)),
       (77, (-188)),
       (78, (-182)),
-      (83, (-369)),
+      (83, (-370)),
       (84, (-193)),
-      (86, (-402)),
-      (93, (-413)),
-      (96, (-333)),
-      (99, (-379)),
-      (103, (-377)),
+      (86, (-405)),
+      (93, (-416)),
+      (99, (-380)),
+      (103, (-378)),
       (108, (-117)),
       (125, (-1)),
       (126, (-27)),
@@ -9465,9 +9506,9 @@ private yyeacts = let
       (128, (-32)),
       (129, (-33)),
       (130, (-41)),
-      (131, (-119))];
-    sub2 = [      (132, (-38)),
-      (133, (-39)),
+      (131, (-119)),
+      (132, (-38))];
+    sub2 = [      (133, (-39)),
       (134, (-40)),
       (135, (-118)),
       (136, (-120)),
@@ -9485,314 +9526,317 @@ private yyeacts = let
       (156, (-11)),
       (157, (-184)),
       (158, (-181)),
-      (159, (-364)),
+      (159, (-365)),
       (163, (-137)),
       (170, (-336)),
-      (172, (-406)),
-      (173, (-419)),
-      (175, (-412)),
-      (177, (-405)),
-      (179, (-404)),
-      (180, (-403)),
-      (187, (-414)),
-      (189, (-359)),
-      (190, (-171)),
-      (191, (-400)),
-      (195, (-252)),
-      (200, (-254)),
-      (201, (-361)),
-      (202, (-229)),
-      (203, (-230)),
-      (204, (-236)),
-      (205, (-235)),
-      (206, (-245)),
-      (207, (-294)),
-      (208, (-246)),
-      (209, (-247)),
-      (210, (-367)),
-      (211, (-368)),
-      (212, (-384)),
-      (215, (-385)),
-      (216, (-386)),
-      (221, (-145)),
-      (222, (-196)),
-      (223, (-198)),
-      (224, (-197)),
-      (226, (-217)),
-      (228, (-215)),
-      (229, (-216)),
-      (230, (-214)),
-      (236, (-37)),
-      (240, (-34)),
-      (241, (-35)),
-      (242, (-36)),
-      (243, (-212)),
-      (247, (-28)),
-      (248, (-31)),
-      (250, (-321))];
-    sub3 = [      (251, (-200)),
-      (252, (-201)),
-      (253, (-199)),
-      (254, (-202)),
-      (255, (-204)),
-      (258, (-5)),
-      (259, (-6)),
-      (261, (-9)),
-      (267, (-268)),
-      (270, (-320)),
-      (271, (-351)),
-      (274, (-192)),
-      (276, (-191)),
-      (277, (-19)),
-      (278, (-363)),
-      (287, (-383)),
-      (292, (-407)),
-      (293, (-409)),
-      (294, (-408)),
-      (295, (-432)),
-      (298, (-415)),
-      (300, (-360)),
-      (302, (-401)),
-      (305, (-228)),
-      (310, (-256)),
-      (312, (-239)),
-      (313, (-238)),
-      (315, (-255)),
-      (319, (-295)),
-      (326, (-390)),
-      (328, (-2)),
-      (330, (-145)),
-      (331, (-145)),
-      (333, (-142)),
-      (345, (-314)),
-      (346, (-314)),
-      (349, (-267)),
-      (353, (-29)),
-      (355, (-203)),
-      (356, (-205)),
-      (357, (-211)),
-      (359, (-8)),
-      (360, (-219)),
-      (361, (-220)),
-      (362, (-222)),
-      (370, (-319)),
-      (371, (-352)),
-      (373, (-190)),
-      (374, (-21)),
-      (376, (-366)),
-      (382, (-141)),
-      (385, (-346)),
-      (386, (-337)),
-      (387, (-344)),
-      (389, (-411)),
-      (390, (-410)),
-      (392, (-417)),
-      (393, (-416)),
-      (394, (-429)),
-      (395, (-421)),
-      (396, (-233)),
-      (397, (-232)),
-      (399, (-227)),
-      (401, (-258))];
-    sub4 = [      (402, (-248)),
-      (406, (-257)),
-      (407, (-251)),
-      (408, (-236)),
-      (409, (-237)),
-      (410, (-234)),
-      (414, (-394)),
-      (415, (-395)),
-      (416, (-389)),
-      (417, (-426)),
-      (418, (-387)),
-      (419, (-388)),
-      (420, (-427)),
-      (422, (-424)),
-      (423, (-145)),
-      (424, (-144)),
-      (425, (-149)),
-      (429, (-147)),
-      (433, (-153)),
-      (434, (-156)),
-      (435, (-157)),
-      (436, (-158)),
-      (438, (-44)),
-      (441, (-209)),
-      (442, (-207)),
-      (443, (-208)),
-      (445, (-290)),
-      (447, (-271)),
-      (456, (-275)),
-      (457, (-278)),
-      (458, (-280)),
-      (459, (-283)),
-      (460, (-289)),
-      (461, (-277)),
-      (464, (-264)),
-      (465, (-266)),
-      (466, (-312)),
-      (468, (-317)),
-      (470, (-7)),
-      (473, (-223)),
-      (474, (-224)),
-      (475, (-225)),
-      (479, (-315)),
-      (481, (-130)),
-      (484, (-136)),
-      (486, (-334)),
-      (487, (-335)),
-      (489, (-189)),
-      (490, (-180)),
-      (491, (-365)),
-      (492, (-371)),
-      (493, (-354)),
-      (496, (-355)),
-      (497, (-372)),
-      (498, (-373)),
-      (500, (-435)),
-      (501, (-340)),
-      (502, (-231)),
-      (503, (-262)),
-      (504, (-261)),
-      (508, (-241)),
-      (512, (-240)),
-      (513, (-393)),
-      (514, (-391))];
-    sub5 = [      (515, (-392)),
-      (518, (-143)),
-      (521, (-161)),
-      (522, (-148)),
-      (524, (-168)),
-      (525, (-169)),
-      (526, (-170)),
-      (527, (-160)),
-      (529, (-46)),
-      (531, (-42)),
-      (533, (-293)),
-      (534, (-292)),
-      (535, (-282)),
-      (536, (-285)),
-      (537, (-286)),
-      (538, (-284)),
-      (539, (-269)),
-      (540, (-270)),
-      (541, (-288)),
-      (542, (-287)),
-      (543, (-272)),
-      (545, (-281)),
-      (547, (-274)),
-      (548, (-314)),
-      (549, (-313)),
-      (550, (-318)),
-      (551, (-218)),
-      (552, (-221)),
-      (553, (-131)),
-      (554, (-132)),
-      (555, (-133)),
-      (556, (-135)),
-      (557, (-316)),
-      (559, (-348)),
-      (560, (-350)),
-      (561, (-353)),
-      (562, (-357)),
-      (564, (-253)),
-      (567, (-249)),
-      (569, (-250)),
-      (571, (-155)),
-      (575, (-152)),
-      (576, (-146)),
-      (583, (-311)),
-      (588, (-305)),
-      (589, (-308)),
-      (590, (-279)),
-      (591, (-273)),
-      (592, (-265)),
-      (593, (-126)),
-      (594, (-263)),
-      (595, (-259)),
-      (596, (-242)),
-      (597, (-244)),
-      (598, (-164)),
-      (599, (-154)),
-      (600, (-163)),
-      (602, (-49)),
-      (603, (-50)),
-      (604, (-51)),
-      (605, (-52)),
-      (606, (-53)),
-      (607, (-54)),
-      (608, (-55))];
-    sub6 = [      (609, (-56)),
-      (610, (-57)),
-      (611, (-58)),
-      (612, (-59)),
-      (613, (-60)),
-      (614, (-61)),
-      (615, (-62)),
-      (616, (-63)),
-      (617, (-64)),
-      (618, (-65)),
-      (619, (-66)),
-      (620, (-67)),
-      (621, (-68)),
-      (622, (-69)),
-      (623, (-70)),
-      (624, (-71)),
-      (625, (-72)),
-      (626, (-73)),
-      (627, (-74)),
-      (628, (-75)),
-      (629, (-76)),
-      (630, (-77)),
-      (631, (-78)),
-      (632, (-79)),
-      (633, (-80)),
-      (634, (-81)),
-      (635, (-82)),
-      (636, (-83)),
-      (637, (-84)),
-      (638, (-85)),
-      (639, (-86)),
-      (640, (-87)),
-      (641, (-88)),
-      (642, (-89)),
-      (643, (-90)),
-      (644, (-91)),
-      (645, (-92)),
-      (646, (-93)),
-      (647, (-94)),
-      (648, (-95)),
-      (649, (-96)),
-      (650, (-97)),
-      (651, (-106)),
-      (652, (-107)),
-      (654, (-48)),
-      (655, (-104)),
-      (656, (-102)),
-      (657, (-103)),
-      (658, (-98)),
-      (659, (-99)),
-      (660, (-100)),
-      (661, (-101)),
-      (662, (-105)),
-      (663, (-108)),
-      (664, (-109)),
-      (665, (-110)),
-      (668, (-307)),
-      (669, (-306)),
-      (670, (-310)),
-      (671, (-309)),
-      (673, (-291)),
-      (678, (-167)),
-      (681, (-47)),
-      (682, (-112))];
-    sub7 = [      (684, (-300)),
-      (685, (-299)),
-      (686, (-301)),
-      (687, (-304)),
-      (688, (-116)),
-      (690, (-302)),
-      (691, (-114))];
+      (172, (-409)),
+      (173, (-422)),
+      (175, (-415)),
+      (177, (-408)),
+      (179, (-407)),
+      (180, (-406)),
+      (187, (-417)),
+      (189, (-360)),
+      (190, (-359)),
+      (191, (-382)),
+      (192, (-171)),
+      (193, (-403)),
+      (197, (-252)),
+      (202, (-254)),
+      (203, (-362)),
+      (204, (-229)),
+      (205, (-230)),
+      (206, (-236)),
+      (207, (-235)),
+      (208, (-245)),
+      (209, (-294)),
+      (210, (-246)),
+      (211, (-247)),
+      (212, (-368)),
+      (213, (-369)),
+      (214, (-387)),
+      (217, (-388)),
+      (218, (-389)),
+      (223, (-145)),
+      (224, (-196)),
+      (225, (-198)),
+      (226, (-197)),
+      (228, (-217)),
+      (230, (-215)),
+      (231, (-216)),
+      (232, (-214)),
+      (238, (-37)),
+      (242, (-34)),
+      (243, (-35)),
+      (244, (-36)),
+      (245, (-212)),
+      (249, (-28)),
+      (250, (-31))];
+    sub3 = [      (252, (-321)),
+      (253, (-200)),
+      (254, (-201)),
+      (255, (-199)),
+      (256, (-202)),
+      (257, (-204)),
+      (260, (-5)),
+      (261, (-6)),
+      (263, (-9)),
+      (269, (-268)),
+      (272, (-320)),
+      (273, (-351)),
+      (276, (-192)),
+      (278, (-191)),
+      (279, (-19)),
+      (280, (-364)),
+      (289, (-386)),
+      (294, (-410)),
+      (295, (-412)),
+      (296, (-411)),
+      (297, (-435)),
+      (300, (-418)),
+      (302, (-361)),
+      (304, (-404)),
+      (307, (-228)),
+      (312, (-256)),
+      (314, (-239)),
+      (315, (-238)),
+      (317, (-255)),
+      (321, (-295)),
+      (328, (-393)),
+      (330, (-2)),
+      (332, (-145)),
+      (333, (-145)),
+      (335, (-142)),
+      (347, (-314)),
+      (348, (-314)),
+      (351, (-267)),
+      (355, (-29)),
+      (357, (-203)),
+      (358, (-205)),
+      (359, (-211)),
+      (361, (-8)),
+      (362, (-219)),
+      (363, (-220)),
+      (364, (-222)),
+      (372, (-319)),
+      (373, (-352)),
+      (375, (-190)),
+      (376, (-21)),
+      (378, (-367)),
+      (381, (-333)),
+      (385, (-141)),
+      (388, (-346)),
+      (389, (-337)),
+      (390, (-344)),
+      (392, (-414)),
+      (393, (-413)),
+      (395, (-420)),
+      (396, (-419)),
+      (397, (-432)),
+      (398, (-424)),
+      (399, (-233)),
+      (400, (-232))];
+    sub4 = [      (402, (-227)),
+      (404, (-258)),
+      (405, (-248)),
+      (409, (-257)),
+      (410, (-251)),
+      (411, (-236)),
+      (412, (-237)),
+      (413, (-234)),
+      (417, (-397)),
+      (418, (-398)),
+      (419, (-392)),
+      (420, (-429)),
+      (421, (-390)),
+      (422, (-391)),
+      (423, (-430)),
+      (425, (-427)),
+      (426, (-145)),
+      (427, (-144)),
+      (428, (-149)),
+      (432, (-147)),
+      (436, (-153)),
+      (437, (-156)),
+      (438, (-157)),
+      (439, (-158)),
+      (441, (-44)),
+      (444, (-209)),
+      (445, (-207)),
+      (446, (-208)),
+      (448, (-290)),
+      (450, (-271)),
+      (459, (-275)),
+      (460, (-278)),
+      (461, (-280)),
+      (462, (-283)),
+      (463, (-289)),
+      (464, (-277)),
+      (467, (-264)),
+      (468, (-266)),
+      (469, (-312)),
+      (471, (-317)),
+      (473, (-7)),
+      (476, (-223)),
+      (477, (-224)),
+      (478, (-225)),
+      (482, (-315)),
+      (484, (-130)),
+      (487, (-136)),
+      (489, (-334)),
+      (490, (-335)),
+      (492, (-189)),
+      (493, (-180)),
+      (494, (-366)),
+      (495, (-372)),
+      (496, (-354)),
+      (499, (-355)),
+      (500, (-373)),
+      (501, (-374)),
+      (503, (-438)),
+      (504, (-340)),
+      (505, (-231)),
+      (506, (-262)),
+      (507, (-261)),
+      (511, (-241)),
+      (515, (-240))];
+    sub5 = [      (516, (-396)),
+      (517, (-394)),
+      (518, (-395)),
+      (521, (-143)),
+      (524, (-161)),
+      (525, (-148)),
+      (527, (-168)),
+      (528, (-169)),
+      (529, (-170)),
+      (530, (-160)),
+      (532, (-46)),
+      (534, (-42)),
+      (536, (-293)),
+      (537, (-292)),
+      (538, (-282)),
+      (539, (-285)),
+      (540, (-286)),
+      (541, (-284)),
+      (542, (-269)),
+      (543, (-270)),
+      (544, (-288)),
+      (545, (-287)),
+      (546, (-272)),
+      (548, (-281)),
+      (550, (-274)),
+      (551, (-314)),
+      (552, (-313)),
+      (553, (-318)),
+      (554, (-218)),
+      (555, (-221)),
+      (556, (-131)),
+      (557, (-132)),
+      (558, (-133)),
+      (559, (-135)),
+      (560, (-316)),
+      (562, (-348)),
+      (563, (-350)),
+      (564, (-353)),
+      (565, (-357)),
+      (567, (-253)),
+      (570, (-249)),
+      (572, (-250)),
+      (574, (-155)),
+      (578, (-152)),
+      (579, (-146)),
+      (586, (-311)),
+      (591, (-305)),
+      (592, (-308)),
+      (593, (-279)),
+      (594, (-273)),
+      (595, (-265)),
+      (596, (-126)),
+      (597, (-263)),
+      (598, (-259)),
+      (599, (-242)),
+      (600, (-244)),
+      (601, (-164)),
+      (602, (-154)),
+      (603, (-163)),
+      (605, (-49)),
+      (606, (-50)),
+      (607, (-51)),
+      (608, (-52)),
+      (609, (-53))];
+    sub6 = [      (610, (-54)),
+      (611, (-55)),
+      (612, (-56)),
+      (613, (-57)),
+      (614, (-58)),
+      (615, (-59)),
+      (616, (-60)),
+      (617, (-61)),
+      (618, (-62)),
+      (619, (-63)),
+      (620, (-64)),
+      (621, (-65)),
+      (622, (-66)),
+      (623, (-67)),
+      (624, (-68)),
+      (625, (-69)),
+      (626, (-70)),
+      (627, (-71)),
+      (628, (-72)),
+      (629, (-73)),
+      (630, (-74)),
+      (631, (-75)),
+      (632, (-76)),
+      (633, (-77)),
+      (634, (-78)),
+      (635, (-79)),
+      (636, (-80)),
+      (637, (-81)),
+      (638, (-82)),
+      (639, (-83)),
+      (640, (-84)),
+      (641, (-85)),
+      (642, (-86)),
+      (643, (-87)),
+      (644, (-88)),
+      (645, (-89)),
+      (646, (-90)),
+      (647, (-91)),
+      (648, (-92)),
+      (649, (-93)),
+      (650, (-94)),
+      (651, (-95)),
+      (652, (-96)),
+      (653, (-97)),
+      (654, (-106)),
+      (655, (-107)),
+      (657, (-48)),
+      (658, (-104)),
+      (659, (-102)),
+      (660, (-103)),
+      (661, (-98)),
+      (662, (-99)),
+      (663, (-100)),
+      (664, (-101)),
+      (665, (-105)),
+      (666, (-108)),
+      (667, (-109)),
+      (668, (-110)),
+      (671, (-307)),
+      (672, (-306)),
+      (673, (-310)),
+      (674, (-309)),
+      (676, (-291)),
+      (681, (-167))];
+    sub7 = [      (684, (-47)),
+      (685, (-112)),
+      (687, (-300)),
+      (688, (-299)),
+      (689, (-301)),
+      (690, (-304)),
+      (691, (-116)),
+      (693, (-302)),
+      (694, (-114))];
       in sub1 `seq` sub2 `seq` sub3 `seq` sub4 `seq` sub5 `seq` sub6 `seq` sub7 `seq` arrayFromIndexList (sub1 ++ sub2 ++ sub3 ++ sub4 ++ sub5 ++ sub6 ++ sub7);
 
 
@@ -9804,211 +9848,212 @@ decodeArr s1 s2 = arrayFromIndexList (zip (un s1) (un s2))
 private yygo0 = decodeArr "\u0001\u0002\u0003\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015" "\u0005\u0005\u0005\u0007\u0007\u0007\u0006\u0006\u0006\u0006\u0006"
 private yygo1 = decodeArr "\u000e\u000f\u0010\u0019\u001a" "\t\t\t\n\n"
 private yygo2 = decodeArr "\n\u000b\f\r¬­®¯°±²" "\u0014\u0014\u0014\u0016\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
-private yygo4 = decodeArr "\u0004µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "0222333446666666666771155558888899::<<;;;;;;;;;;;;;;======================"
+private yygo4 = decodeArr "\u0004µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "022233344666666666671155558888899::<<;;;;;;;;;;;;;;======================"
 private yygo6 = decodeArr "\u0016\u0017\u0018" "BAA"
 private yygo8 = decodeArr "\u0019\u001a" "EE"
 private yygo10 = decodeArr "\u000e\u000f\u0010" "FFF"
 private yygo13 = decodeArr "\n\u000b\f¬­®¯°±²" "GGG\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
 private yygo23 = decodeArr "\n\u000b\f\r¬­®¯°±²" "\u0014\u0014\u0014I\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
 private yygo26 = decodeArr "»¼ÂÃ" "NNMM"
-private yygo29 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677OO55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo30 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677PP55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo41 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677SSSSS99::<<;;;;;;;;;;;;;;======================"
-private yygo42 = decodeArr "µ¶·¸¹ºÁÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣ" "222333YZZ666666666677XX\\\\\\\\8888899::<<;;;;;;;;;;;;;;======================[["
-private yygo43 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƯưƱ" "22233344666666666677^^55558888899::<<;;;;;;;;;;;;;;======================___"
-private yygo46 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌōŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "222333446666666666a77``55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo52 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "222333446666666666cc<<;;;;;;;;;;;;;;======================"
-private yygo57 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "222333446666666666gg<<;;;;;;;;;;;;;;======================"
-private yygo64 = decodeArr "\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "}}}~~~~\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo29 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667OO55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo30 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667PP55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo41 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667SSSSS99::<<;;;;;;;;;;;;;;======================"
+private yygo42 = decodeArr "µ¶·¸¹ºÁÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦ" "222333YZZ66666666667XX\\\\\\\\8888899::<<;;;;;;;;;;;;;;======================[["
+private yygo43 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƲƳƴ" "2223334466666666667^^55558888899::<<;;;;;;;;;;;;;;======================___"
+private yygo46 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666aa``<<;;;;;;;;;;;;;;======================"
+private yygo52 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666cc<<;;;;;;;;;;;;;;======================"
+private yygo57 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666gg<<;;;;;;;;;;;;;;======================"
+private yygo64 = decodeArr "\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "}}}~~~~\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
 private yygo66 = decodeArr "\u0016\u0017\u0018" "B\u0099\u0099"
 private yygo67 = decodeArr "\n\u000b\f\r¬­®¯°±²" "\u0014\u0014\u0014\u009a\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
 private yygo72 = decodeArr "\n\u000b\f¬­®¯°±²" "\u009c\u009c\u009c\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
 private yygo76 = decodeArr "»¼ÂÃ" "\u009e\u009eMM"
-private yygo79 = decodeArr "ūŬ" "¡¡"
-private yygo81 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "¥¥¦¦¦\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo82 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŐőŒŖŗŘřŚŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "222333446666666666©©©«««ªª77¨¨55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo85 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677SSSSS99::<<;;;;;;;;;;;;;;======================"
-private yygo87 = decodeArr "Ƣƣ" "­­"
-private yygo89 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677²²55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo90 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "222333446666666666cc<<;;;;;;;;;;;;;;======================"
+private yygo79 = decodeArr "Ŭŭ" "¡¡"
+private yygo81 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "¥¥¦¦¦\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo82 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŐőŒŖŗŘřŚŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666©©©«««ªª7¨¨55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo85 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667SSSSS99::<<;;;;;;;;;;;;;;======================"
+private yygo87 = decodeArr "ƥƦ" "­­"
+private yygo89 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667²²55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo90 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666cc<<;;;;;;;;;;;;;;======================"
 private yygo92 = decodeArr "Á" "·"
-private yygo97 = decodeArr "ŧŨ" "½½"
-private yygo98 = decodeArr "«ƤƥƦƭƮ" "ÀÁÁÁÂÂ"
-private yygo100 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈÉÉÊËËÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo101 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ÒÒÒÒ8888899::<<;;;;;;;;;;;;;;======================"
-private yygo102 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ÓÓÓÓ8888899::<<;;;;;;;;;;;;;;======================"
-private yygo104 = decodeArr "ÁÂÃ" "×ØØ"
-private yygo105 = decodeArr "ƧƨƩƪƫƬ" "ÚÚÚÛÛÛ"
-private yygo106 = decodeArr "\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "ÜÜÜ~~~~\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo109 = decodeArr "\n\u000b\f\r¬­®¯°±²" "\u0014\u0014\u0014Ý\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
-private yygo113 = decodeArr "«ÁÂÃÎÏÐÑ" "\u008fäååææææ"
-private yygo116 = decodeArr "¸¹ºþÿĀāĂ" "ÈÈÈëëëëë"
-private yygo117 = decodeArr "ČĐđĒē" "ì\u0095\u0095\u0095\u0095"
-private yygo119 = decodeArr "¸¹ºþÿĀāĂ" "ÈÈÈîîîîî"
-private yygo120 = decodeArr "vwxyz{\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "ðððððð\u008b\u008b\u008b\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo121 = decodeArr "vwxyz{\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "ññññññ\u008b\u008b\u008b\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo122 = decodeArr "vwxyz{\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "òòòòòò\u008b\u008b\u008b\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo123 = decodeArr "Ö×ØÙÞßàá" "\u0094\u0094\u0094\u0094óóóó"
-private yygo124 = decodeArr "µ¶·¸¹ºÁÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣ" "222333õöö666666666677XX\\\\\\\\8888899::<<;;;;;;;;;;;;;;======================[["
-private yygo126 = decodeArr "\u0019\u001a" "÷÷"
-private yygo127 = decodeArr "\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "øøøø\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo142 = decodeArr "Ľľ" "úú"
-private yygo144 = decodeArr "ÁÇÈÉÊË" "ýþþþÿÿ"
-private yygo148 = decodeArr "\u0005\u0006\u0007\b\tÁÂÃ" "ćććććĈĉĉ"
-private yygo149 = decodeArr "ĺĻļ" "ċċċ"
-private yygo150 = decodeArr "ŞşŠ" "ďĎĎ"
-private yygo152 = decodeArr "³´»¼½¾¿ÀÁÂÃ" "đđĔĔēēēēĒMM"
-private yygo155 = decodeArr "\n\u000b\f\r¬­®¯°±²" "\u0014\u0014\u0014ĕ\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
-private yygo161 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ėė55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo164 = decodeArr "Ľľ" "úú"
-private yygo165 = decodeArr "\u0019\u001a" "ęę"
-private yygo169 = decodeArr "\u0019\u001a" "ĞĞ"
-private yygo174 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƲƳƴ" "22233344666666666677ĠĠ55558888899::<<;;;;;;;;;;;;;;======================ġġġ"
-private yygo176 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƯưƱ" "22233344666666666677ĢĢ55558888899::<<;;;;;;;;;;;;;;======================ģģģ"
-private yygo181 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ÒÒÒÒ8888899::<<;;;;;;;;;;;;;;======================"
-private yygo182 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ÓÓÓÓ8888899::<<;;;;;;;;;;;;;;======================"
-private yygo184 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƯưƱ" "22233344666666666677ĢĢ55558888899::<<;;;;;;;;;;;;;;======================ħħħ"
-private yygo185 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŐőŒœŔŕřŚŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "222333446666666666ĨĨĨĩĩĩªª77¨¨55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo186 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677īī55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo188 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ĬĬ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo197 = decodeArr "âãä" "ĲĲĳ"
-private yygo198 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħƢƣ" "ÈÈÈĸķķķĹÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎĺĺ"
-private yygo199 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈĸļļļĹÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo207 = decodeArr "¸¹ºö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈÏÏÏÏÏÏÐÐÑÑÑÑÑĿĿ"
-private yygo213 = decodeArr "ƧƨƩƪƫƬ" "ŁŁŁÛÛÛ"
-private yygo214 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677łł55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo221 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ōōōōōŎ"
-private yygo225 = decodeArr "+," "ŐŐ"
-private yygo227 = decodeArr "ÁÂÃ" "Œœœ"
-private yygo231 = decodeArr "üýĔĕ" "ŖŖŗŗ"
-private yygo232 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈĸŘŘŘĹÏÏÏÏÏÏřřÑÑÑÑÑÎÎ"
-private yygo233 = decodeArr "Ƣƣ" "ĺĺ"
-private yygo235 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈŚŚÊËËÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo237 = decodeArr "üýĔĕ" "ŖŖŜŜ"
-private yygo238 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈŝŝÊËËÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo239 = decodeArr "«ÁÂÃÎÏÐÑ" "\u008fäååææææ"
-private yygo244 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677SSSSS99::<<;;;;;;;;;;;;;;======================"
-private yygo245 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677²²55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo246 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "222333446666666666cc<<;;;;;;;;;;;;;;======================"
-private yygo247 = decodeArr "\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "ššš~~~~\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo254 = decodeArr "ÁÇÈÉÊË" "ýþþþţţ"
-private yygo256 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈŤŤÊËËÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo257 = decodeArr "«ÎÏÐÑÒÓ" "\u008f\u0092\u0092\u0092\u0092ťť"
-private yygo260 = decodeArr "\u0005\u0006\u0007\b\t" "ŧŧŧŧŧ"
-private yygo262 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈũũŪŪŨŨÊËËÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo268 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌřŚśŜŝŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "222333446666666666ŰŰűűű77ůů55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo269 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ŲŲ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo271 = decodeArr "ŞşŠ" "ďųų"
-private yygo272 = decodeArr "»¼ÂÃ" "ŵŵMM"
-private yygo279 = decodeArr "ŭŮ" "źź"
-private yygo280 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌōšŢţŤťŦŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "222333446666666666ŻżżżŽŽŽ77``55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo281 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "¥¥žžž\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo283 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "¥¥ƀƀƀ\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo284 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ƁƁ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo285 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ƂƂ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo286 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŐőŒŖŗŘřŚŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "222333446666666666©©©ƃƃƃªª77¨¨55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo301 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ƊƊ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo303 = decodeArr "«ƤƥƦƭƮ" "ÀƋƋƋÂÂ"
-private yygo306 = decodeArr "èé" "ƎƎ"
-private yygo307 = decodeArr "âãä" "ƏƏĳ"
-private yygo317 = decodeArr "¸¹ºìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈƙƙƘÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo318 = decodeArr "¸¹ºìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈƚƚƘÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo323 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ơơ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo325 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ƤƤ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo327 = decodeArr "ƧƨƩƪƫƬ" "ƦƦƦÛÛÛ"
-private yygo330 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ƨƨƨƨƨŎ"
-private yygo331 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ƩƩƩƩƩŎ"
-private yygo332 = decodeArr "\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ƮƮƮưưưưưưƯƯƯƱƱƱƲƲƲƳƴƴ"
-private yygo335 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈĸƶƶƶĹÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo336 = decodeArr "-." "ƸƸ"
-private yygo341 = decodeArr "čĎďĖėĘęĚěĜĝĞğĠġĢģĤ" "ǇǇǇǈǈǉǉǉǊǊǊǊǋǋǋǌǌǌ"
-private yygo342 = decodeArr "üýĔĕ" "ŖŖǍǍ"
-private yygo345 = decodeArr "ĺĻļ" "ǐǐǐ"
-private yygo346 = decodeArr "ĺĻļ" "ǑǑǑ"
-private yygo347 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈǒǒÊËËÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo354 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "¥¥ǕǕǕ\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo358 = decodeArr "\u0005\u0006\u0007\b\t" "ǖǖǖǖǖ"
-private yygo363 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈũũǙǙŨŨÊËËÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo364 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈũũǚǚŨŨÊËËÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo365 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈũũǛǛŨŨÊËËÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo366 = decodeArr "u|}~\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "ǠǢǢǢǡǡǡǤǤǤǤǣǣǣ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo369 = decodeArr "Ŏŏ" "ǨǨ"
-private yygo372 = decodeArr "»¼ÂÃ" "ǩǩMM"
-private yygo375 = decodeArr "³´»¼½¾¿ÀÁÂÃ" "ǪǪĔĔēēēēĒMM"
-private yygo378 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ǬǬ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo379 = decodeArr "ŎŏŞşŠ" "ǮǮďǭǭ"
-private yygo380 = decodeArr "Ľľ" "ǰǰ"
-private yygo383 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ǲǲ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo388 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƲƳƴ" "22233344666666666677ĠĠ55558888899::<<;;;;;;;;;;;;;;======================ǴǴǴ"
-private yygo391 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŐőŒœŔŕřŚŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "222333446666666666ĨĨĨǵǵǵªª77¨¨55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo398 = decodeArr "¸¹ºêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈǶǶÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo400 = decodeArr "ăĄąĆć" "ǺǺǻǻǻ"
-private yygo403 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈĸǼǼǼǽǽĹÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo404 = decodeArr "¸¹ºçîïðóôõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈĸǾǾǾǿǿĹÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo405 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈĸȀȀȀĹÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo411 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ơơ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo413 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ƤƤ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo423 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ȆȆȆȆȆŎ"
-private yygo427 = decodeArr "»¼ÂÃ" "NNMM"
-private yygo428 = decodeArr "\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ưưưưưưȉȉȉƱƱƱƲƲƲƳƴƴ"
-private yygo432 = decodeArr "¨©ªÁ" "ȏȏȏȎ"
-private yygo437 = decodeArr "\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ȐȐȐưưưưưưƯƯƯƱƱƱƲƲƲƳƴƴ"
-private yygo439 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈĸǼǼǼȑȑĹÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo440 = decodeArr "/0" "ȓȓ"
-private yygo445 = decodeArr "¸¹ºö÷øùúûüýþÿĀāĂĥĦħ" "ÈÈÈÏÏÏÏÏÏÐÐÑÑÑÑÑȖȕȕ"
-private yygo446 = decodeArr "ěĜĝĞğĠġĢģĤ" "ȗȗȗȗǋǋǋǌǌǌ"
-private yygo448 = decodeArr "ğĠġĢģĤ" "ȘȘȘǌǌǌ"
-private yygo449 = decodeArr "ğĠġĢģĤ" "șșșǌǌǌ"
-private yygo450 = decodeArr "ğĠġĢģĤ" "ȚȚȚǌǌǌ"
-private yygo453 = decodeArr "ĢģĤ" "ȝȝȝ"
-private yygo454 = decodeArr "ĢģĤ" "ȞȞȞ"
-private yygo455 = decodeArr "\u0005\u0006\u0007\b\t" "ȟȟȟȟȟ"
-private yygo462 = decodeArr "čĎďĖėĘęĚěĜĝĞğĠġĢģĤ" "ȢȢȢȣȣǉǉǉǊǊǊǊǋǋǋǌǌǌ"
-private yygo463 = decodeArr "«" "Ȥ"
-private yygo467 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈȥȥÊËËÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo471 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈĸǼǼǼȧȧĹÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo472 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈũũȨȨŨŨÊËËÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo476 = decodeArr "\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "ȩȩȩ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo477 = decodeArr "\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "ȪȪȪ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo478 = decodeArr "\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "ȫȫȫ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo480 = decodeArr "u\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "ǠǡǡǡǤǤǤǤȬȬȬ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo483 = decodeArr "\u0019\u001a" "ȮȮ"
-private yygo485 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌřŚśŜŝŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "222333446666666666ŰŰȯȯȯ77ůů55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo488 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ȰȰ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo494 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ȱȱ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo495 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌōšŢţŤťŦŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "222333446666666666ŻżżżȲȲȲ77``55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo505 = decodeArr "ăĄąĆć" "ȳȳǻǻǻ"
-private yygo516 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ơơ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo517 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŨũŪůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "22233344666666666677ƤƤ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo519 = decodeArr "¢£¤¥¦§¨©ªÁ" "ȾȾȾȼȼȼȽȽȽȎ"
-private yygo520 = decodeArr "»¼ÂÃ" "\u009e\u009eMM"
-private yygo523 = decodeArr "\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ȿȿȿưưưưưưƯƯƯƱƱƱƲƲƲƳƴƴ"
-private yygo532 = decodeArr "\u000e\u000f\u0010«ĨĩĪīĬĭĮįİıĲĳĴĵĶķ" "ɆɆɆɇɈɈɈɈɈɉɉɊɊɋɋɋɌɌɌɍ"
-private yygo544 = decodeArr "ĖėĘęĚěĜĝĞğĠġĢģĤ" "ɎɎǉǉǉǊǊǊǊǋǋǋǌǌǌ"
-private yygo546 = decodeArr "\u0005\u0006\u0007\b\t" "ɏɏɏɏɏ"
-private yygo548 = decodeArr "ĺĻļ" "ɐɐɐ"
-private yygo558 = decodeArr "u|}~\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŨůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơ" "ǠɑɑɑǡǡǡǤǤǤǤǣǣǣ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u0096666666666677\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo565 = decodeArr "ăĄąĆć" "ɓɓǻǻǻ"
-private yygo566 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈĸǼǼǼɔɔĹÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo568 = decodeArr "¸¹ºçîïðóôõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈĸǾǾǾɕɕĹÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo570 = decodeArr "¢£¤¨©ªÁ" "ɖɖɖȽȽȽȎ"
-private yygo573 = decodeArr "¨©ªÁ" "ɘɘɘȎ"
-private yygo577 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʚʚʚʚʚʚ"
-private yygo578 = decodeArr "«ĴĵĶķ" "ɇʜʜʜɍ"
-private yygo579 = decodeArr "«ĴĵĶķ" "ɇʝʝʝɍ"
-private yygo580 = decodeArr "«ķ" "ɇʞ"
-private yygo581 = decodeArr "«ķ" "ɇʟ"
-private yygo582 = decodeArr "«įİıĲĳĴĵĶķ" "ɇʠʠɋɋɋɌɌɌɍ"
-private yygo601 = decodeArr "¢£¤¥¦§¨©ªÁ" "ȾȾȾʦʦʦȽȽȽȎ"
-private yygo653 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʨʨʨʨʨʨ"
-private yygo667 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʪʪʪʪʪʪ"
-private yygo674 = decodeArr "\u000e\u000f\u0010«ĨĩĪīĬĭĮįİıĲĳĴĵĶķ" "ɆɆɆɇʬʬʬʬʬɉɉɊɊɋɋɋɌɌɌɍ"
-private yygo675 = decodeArr "\u000e\u000f\u0010«ĨĩĪīĬĭĮįİıĲĳĴĵĶķ" "ɆɆɆɇʭʭʭʭʭɉɉɊɊɋɋɋɌɌɌɍ"
-private yygo676 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈʮʮÊËËÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo677 = decodeArr "«įİıĲĳĴĵĶķ" "ɇʯʯɋɋɋɌɌɌɍ"
-private yygo679 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʰʰʰʰʰʰ"
-private yygo683 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÈÈÈʲʲÊËËÍÍÌÏÏÏÏÏÏÐÐÑÑÑÑÑÎÎ"
-private yygo689 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʛʳʳʳʳʳʳ"
+private yygo96 = decodeArr "ŧŨũ" "½¾¾"
+private yygo97 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666aa¿¿<<;;;;;;;;;;;;;;======================"
+private yygo98 = decodeArr "«ƧƨƩưƱ" "ÂÃÃÃÄÄ"
+private yygo100 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊËËÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo101 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ÔÔÔÔ8888899::<<;;;;;;;;;;;;;;======================"
+private yygo102 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ÕÕÕÕ8888899::<<;;;;;;;;;;;;;;======================"
+private yygo104 = decodeArr "ÁÂÃ" "ÙÚÚ"
+private yygo105 = decodeArr "ƪƫƬƭƮƯ" "ÜÜÜÝÝÝ"
+private yygo106 = decodeArr "\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ÞÞÞ~~~~\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo109 = decodeArr "\n\u000b\f\r¬­®¯°±²" "\u0014\u0014\u0014ß\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
+private yygo113 = decodeArr "«ÁÂÃÎÏÐÑ" "\u008fæççèèèè"
+private yygo116 = decodeArr "¸¹ºþÿĀāĂ" "ÊÊÊííííí"
+private yygo117 = decodeArr "ČĐđĒē" "î\u0095\u0095\u0095\u0095"
+private yygo119 = decodeArr "¸¹ºþÿĀāĂ" "ÊÊÊððððð"
+private yygo120 = decodeArr "vwxyz{\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "òòòòòò\u008b\u008b\u008b\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo121 = decodeArr "vwxyz{\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "óóóóóó\u008b\u008b\u008b\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo122 = decodeArr "vwxyz{\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ôôôôôô\u008b\u008b\u008b\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo123 = decodeArr "Ö×ØÙÞßàá" "\u0094\u0094\u0094\u0094õõõõ"
+private yygo124 = decodeArr "µ¶·¸¹ºÁÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦ" "222333÷øø66666666667XX\\\\\\\\8888899::<<;;;;;;;;;;;;;;======================[["
+private yygo126 = decodeArr "\u0019\u001a" "ùù"
+private yygo127 = decodeArr "\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "úúúú\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo142 = decodeArr "Ľľ" "üü"
+private yygo144 = decodeArr "ÁÇÈÉÊË" "ÿĀĀĀāā"
+private yygo148 = decodeArr "\u0005\u0006\u0007\b\tÁÂÃ" "ĉĉĉĉĉĊċċ"
+private yygo149 = decodeArr "ĺĻļ" "ččč"
+private yygo150 = decodeArr "ŞşŠ" "đĐĐ"
+private yygo152 = decodeArr "³´»¼½¾¿ÀÁÂÃ" "ēēĖĖĕĕĕĕĔMM"
+private yygo155 = decodeArr "\n\u000b\f\r¬­®¯°±²" "\u0014\u0014\u0014ė\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
+private yygo161 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ęę55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo164 = decodeArr "Ľľ" "üü"
+private yygo165 = decodeArr "\u0019\u001a" "ěě"
+private yygo169 = decodeArr "\u0019\u001a" "ĠĠ"
+private yygo174 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƵƶƷ" "2223334466666666667ĢĢ55558888899::<<;;;;;;;;;;;;;;======================ģģģ"
+private yygo176 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƲƳƴ" "2223334466666666667ĤĤ55558888899::<<;;;;;;;;;;;;;;======================ĥĥĥ"
+private yygo181 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ÔÔÔÔ8888899::<<;;;;;;;;;;;;;;======================"
+private yygo182 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ÕÕÕÕ8888899::<<;;;;;;;;;;;;;;======================"
+private yygo184 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƲƳƴ" "2223334466666666667ĤĤ55558888899::<<;;;;;;;;;;;;;;======================ĩĩĩ"
+private yygo185 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŐőŒœŔŕřŚŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666ĪĪĪīīīªª7¨¨55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo186 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ĭĭ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo188 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ĮĮ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo199 = decodeArr "âãä" "ĴĴĵ"
+private yygo200 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħƥƦ" "ÊÊÊĺĹĹĹĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐļļ"
+private yygo201 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺľľľĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo209 = decodeArr "¸¹ºö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊÑÑÑÑÑÑÒÒÓÓÓÓÓŁŁ"
+private yygo215 = decodeArr "ƪƫƬƭƮƯ" "ŃŃŃÝÝÝ"
+private yygo216 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ńń55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo223 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ŏŏŏŏŏŐ"
+private yygo227 = decodeArr "+," "ŒŒ"
+private yygo229 = decodeArr "ÁÂÃ" "Ŕŕŕ"
+private yygo233 = decodeArr "üýĔĕ" "ŘŘřř"
+private yygo234 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺŚŚŚĻÑÑÑÑÑÑśśÓÓÓÓÓÐÐ"
+private yygo235 = decodeArr "ƥƦ" "ļļ"
+private yygo237 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊŜŜÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo239 = decodeArr "üýĔĕ" "ŘŘŞŞ"
+private yygo240 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊşşÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo241 = decodeArr "«ÁÂÃÎÏÐÑ" "\u008fæççèèèè"
+private yygo246 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667SSSSS99::<<;;;;;;;;;;;;;;======================"
+private yygo247 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667²²55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo248 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666cc<<;;;;;;;;;;;;;;======================"
+private yygo249 = decodeArr "\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ţţţ~~~~\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo256 = decodeArr "ÁÇÈÉÊË" "ÿĀĀĀťť"
+private yygo258 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊŦŦÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo259 = decodeArr "«ÎÏÐÑÒÓ" "\u008f\u0092\u0092\u0092\u0092ŧŧ"
+private yygo262 = decodeArr "\u0005\u0006\u0007\b\t" "ũũũũũ"
+private yygo264 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊūūŬŬŪŪÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo270 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌřŚśŜŝŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666ŲŲųųų7űű55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo271 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ŴŴ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo273 = decodeArr "ŞşŠ" "đŵŵ"
+private yygo274 = decodeArr "»¼ÂÃ" "ŷŷMM"
+private yygo281 = decodeArr "Ůů" "żż"
+private yygo282 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌōšŢţŤťŦŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666žſſſƀƀƀ7ŽŽ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo283 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "¥¥ƁƁƁ\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo285 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "¥¥ƃƃƃ\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo286 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƄƄ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo287 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƅƅ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo288 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŐőŒŖŗŘřŚŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666©©©ƆƆƆªª7¨¨55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo303 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƍƍ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo305 = decodeArr "«ƧƨƩưƱ" "ÂƎƎƎÄÄ"
+private yygo308 = decodeArr "èé" "ƑƑ"
+private yygo309 = decodeArr "âãä" "ƒƒĵ"
+private yygo319 = decodeArr "¸¹ºìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊƜƜƛÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo320 = decodeArr "¸¹ºìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊƝƝƛÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo325 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƤƤ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo327 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƧƧ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo329 = decodeArr "ƪƫƬƭƮƯ" "ƩƩƩÝÝÝ"
+private yygo332 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ƫƫƫƫƫŐ"
+private yygo333 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ƬƬƬƬƬŐ"
+private yygo334 = decodeArr "\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ƱƱƱƳƳƳƳƳƳƲƲƲƴƴƴƵƵƵƶƷƷ"
+private yygo337 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺƹƹƹĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo338 = decodeArr "-." "ƻƻ"
+private yygo343 = decodeArr "čĎďĖėĘęĚěĜĝĞğĠġĢģĤ" "ǊǊǊǋǋǌǌǌǍǍǍǍǎǎǎǏǏǏ"
+private yygo344 = decodeArr "üýĔĕ" "ŘŘǐǐ"
+private yygo347 = decodeArr "ĺĻļ" "ǓǓǓ"
+private yygo348 = decodeArr "ĺĻļ" "ǔǔǔ"
+private yygo349 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊǕǕÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo356 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "¥¥ǘǘǘ\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo360 = decodeArr "\u0005\u0006\u0007\b\t" "ǙǙǙǙǙ"
+private yygo365 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊūūǜǜŪŪÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo366 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊūūǝǝŪŪÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo367 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊūūǞǞŪŪÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo368 = decodeArr "u|}~\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ǣǥǥǥǤǤǤǧǧǧǧǦǦǦ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo371 = decodeArr "Ŏŏ" "ǫǫ"
+private yygo374 = decodeArr "»¼ÂÃ" "ǬǬMM"
+private yygo377 = decodeArr "³´»¼½¾¿ÀÁÂÃ" "ǭǭĖĖĕĕĕĕĔMM"
+private yygo380 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ǯǯ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo382 = decodeArr "ŎŏŞşŠ" "ǱǱđǰǰ"
+private yygo383 = decodeArr "Ľľ" "ǳǳ"
+private yygo386 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ǵǵ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo391 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƵƶƷ" "2223334466666666667ĢĢ55558888899::<<;;;;;;;;;;;;;;======================ǷǷǷ"
+private yygo394 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŐőŒœŔŕřŚŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666ĪĪĪǸǸǸªª7¨¨55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo401 = decodeArr "¸¹ºêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊǹǹÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo403 = decodeArr "ăĄąĆć" "ǽǽǾǾǾ"
+private yygo406 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺǿǿǿȀȀĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo407 = decodeArr "¸¹ºçîïðóôõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺȁȁȁȂȂĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo408 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺȃȃȃĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo414 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƤƤ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo416 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƧƧ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo426 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ȉȉȉȉȉŐ"
+private yygo430 = decodeArr "»¼ÂÃ" "NNMM"
+private yygo431 = decodeArr "\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ƳƳƳƳƳƳȌȌȌƴƴƴƵƵƵƶƷƷ"
+private yygo435 = decodeArr "¨©ªÁ" "ȒȒȒȑ"
+private yygo440 = decodeArr "\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ȓȓȓƳƳƳƳƳƳƲƲƲƴƴƴƵƵƵƶƷƷ"
+private yygo442 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺǿǿǿȔȔĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo443 = decodeArr "/0" "ȖȖ"
+private yygo448 = decodeArr "¸¹ºö÷øùúûüýþÿĀāĂĥĦħ" "ÊÊÊÑÑÑÑÑÑÒÒÓÓÓÓÓșȘȘ"
+private yygo449 = decodeArr "ěĜĝĞğĠġĢģĤ" "ȚȚȚȚǎǎǎǏǏǏ"
+private yygo451 = decodeArr "ğĠġĢģĤ" "țțțǏǏǏ"
+private yygo452 = decodeArr "ğĠġĢģĤ" "ȜȜȜǏǏǏ"
+private yygo453 = decodeArr "ğĠġĢģĤ" "ȝȝȝǏǏǏ"
+private yygo456 = decodeArr "ĢģĤ" "ȠȠȠ"
+private yygo457 = decodeArr "ĢģĤ" "ȡȡȡ"
+private yygo458 = decodeArr "\u0005\u0006\u0007\b\t" "ȢȢȢȢȢ"
+private yygo465 = decodeArr "čĎďĖėĘęĚěĜĝĞğĠġĢģĤ" "ȥȥȥȦȦǌǌǌǍǍǍǍǎǎǎǏǏǏ"
+private yygo466 = decodeArr "«" "ȧ"
+private yygo470 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊȨȨÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo474 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺǿǿǿȪȪĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo475 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊūūȫȫŪŪÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo479 = decodeArr "\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ȬȬȬ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo480 = decodeArr "\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ȭȭȭ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo481 = decodeArr "\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ȮȮȮ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo483 = decodeArr "u\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ǣǤǤǤǧǧǧǧȯȯȯ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo486 = decodeArr "\u0019\u001a" "ȱȱ"
+private yygo488 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌřŚśŜŝŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666ŲŲȲȲȲ7űű55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo491 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ȳȳ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo497 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ȴȴ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo498 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌōšŢţŤťŦŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666žſſſȵȵȵ7ŽŽ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo508 = decodeArr "ăĄąĆć" "ȶȶǾǾǾ"
+private yygo519 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƤƤ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo520 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƧƧ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo522 = decodeArr "¢£¤¥¦§¨©ªÁ" "ɁɁɁȿȿȿɀɀɀȑ"
+private yygo523 = decodeArr "»¼ÂÃ" "\u009e\u009eMM"
+private yygo526 = decodeArr "\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ɂɂɂƳƳƳƳƳƳƲƲƲƴƴƴƵƵƵƶƷƷ"
+private yygo535 = decodeArr "\u000e\u000f\u0010«ĨĩĪīĬĭĮįİıĲĳĴĵĶķ" "ɉɉɉɊɋɋɋɋɋɌɌɍɍɎɎɎɏɏɏɐ"
+private yygo547 = decodeArr "ĖėĘęĚěĜĝĞğĠġĢģĤ" "ɑɑǌǌǌǍǍǍǍǎǎǎǏǏǏ"
+private yygo549 = decodeArr "\u0005\u0006\u0007\b\t" "ɒɒɒɒɒ"
+private yygo551 = decodeArr "ĺĻļ" "ɓɓɓ"
+private yygo561 = decodeArr "u|}~\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ǣɔɔɔǤǤǤǧǧǧǧǦǦǦ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo568 = decodeArr "ăĄąĆć" "ɖɖǾǾǾ"
+private yygo569 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺǿǿǿɗɗĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo571 = decodeArr "¸¹ºçîïðóôõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺȁȁȁɘɘĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo573 = decodeArr "¢£¤¨©ªÁ" "əəəɀɀɀȑ"
+private yygo576 = decodeArr "¨©ªÁ" "ɛɛɛȑ"
+private yygo580 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʝʝʝʝʝʝ"
+private yygo581 = decodeArr "«ĴĵĶķ" "Ɋʟʟʟɐ"
+private yygo582 = decodeArr "«ĴĵĶķ" "Ɋʠʠʠɐ"
+private yygo583 = decodeArr "«ķ" "Ɋʡ"
+private yygo584 = decodeArr "«ķ" "Ɋʢ"
+private yygo585 = decodeArr "«įİıĲĳĴĵĶķ" "ɊʣʣɎɎɎɏɏɏɐ"
+private yygo604 = decodeArr "¢£¤¥¦§¨©ªÁ" "ɁɁɁʩʩʩɀɀɀȑ"
+private yygo656 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʫʫʫʫʫʫ"
+private yygo670 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʭʭʭʭʭʭ"
+private yygo677 = decodeArr "\u000e\u000f\u0010«ĨĩĪīĬĭĮįİıĲĳĴĵĶķ" "ɉɉɉɊʯʯʯʯʯɌɌɍɍɎɎɎɏɏɏɐ"
+private yygo678 = decodeArr "\u000e\u000f\u0010«ĨĩĪīĬĭĮįİıĲĳĴĵĶķ" "ɉɉɉɊʰʰʰʰʰɌɌɍɍɎɎɎɏɏɏɐ"
+private yygo679 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊʱʱÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo680 = decodeArr "«įİıĲĳĴĵĶķ" "ɊʲʲɎɎɎɏɏɏɐ"
+private yygo682 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʳʳʳʳʳʳ"
+private yygo686 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊʵʵÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo692 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʶʶʶʶʶʶ"
 private yygos = let 
     sub1 = [      (0, yygo0),
       (1, yygo1),
@@ -10041,6 +10086,7 @@ private yygos = let
       (89, yygo89),
       (90, yygo90),
       (92, yygo92),
+      (96, yygo96),
       (97, yygo97),
       (98, yygo98),
       (100, yygo100),
@@ -10072,152 +10118,152 @@ private yygos = let
       (164, yygo164),
       (165, yygo165),
       (169, yygo169),
-      (174, yygo174),
-      (176, yygo176)];
-    sub2 = [      (181, yygo181),
+      (174, yygo174)];
+    sub2 = [      (176, yygo176),
+      (181, yygo181),
       (182, yygo182),
       (184, yygo184),
       (185, yygo185),
       (186, yygo186),
       (188, yygo188),
-      (197, yygo197),
-      (198, yygo198),
       (199, yygo199),
-      (207, yygo207),
-      (213, yygo213),
-      (214, yygo214),
-      (221, yygo221),
-      (225, yygo225),
+      (200, yygo200),
+      (201, yygo201),
+      (209, yygo209),
+      (215, yygo215),
+      (216, yygo216),
+      (223, yygo223),
       (227, yygo227),
-      (231, yygo231),
-      (232, yygo232),
+      (229, yygo229),
       (233, yygo233),
+      (234, yygo234),
       (235, yygo235),
       (237, yygo237),
-      (238, yygo238),
       (239, yygo239),
-      (244, yygo244),
-      (245, yygo245),
+      (240, yygo240),
+      (241, yygo241),
       (246, yygo246),
       (247, yygo247),
-      (254, yygo254),
+      (248, yygo248),
+      (249, yygo249),
       (256, yygo256),
-      (257, yygo257),
-      (260, yygo260),
+      (258, yygo258),
+      (259, yygo259),
       (262, yygo262),
-      (268, yygo268),
-      (269, yygo269),
+      (264, yygo264),
+      (270, yygo270),
       (271, yygo271),
-      (272, yygo272),
-      (279, yygo279),
-      (280, yygo280),
+      (273, yygo273),
+      (274, yygo274),
       (281, yygo281),
+      (282, yygo282),
       (283, yygo283),
-      (284, yygo284),
       (285, yygo285),
       (286, yygo286),
-      (301, yygo301),
+      (287, yygo287),
+      (288, yygo288),
       (303, yygo303),
-      (306, yygo306),
-      (307, yygo307),
-      (317, yygo317),
-      (318, yygo318),
-      (323, yygo323),
+      (305, yygo305),
+      (308, yygo308),
+      (309, yygo309),
+      (319, yygo319),
+      (320, yygo320),
       (325, yygo325),
       (327, yygo327),
-      (330, yygo330),
-      (331, yygo331),
+      (329, yygo329),
       (332, yygo332),
-      (335, yygo335),
-      (336, yygo336),
-      (341, yygo341),
-      (342, yygo342),
-      (345, yygo345),
-      (346, yygo346),
+      (333, yygo333),
+      (334, yygo334),
+      (337, yygo337),
+      (338, yygo338),
+      (343, yygo343),
+      (344, yygo344),
       (347, yygo347),
-      (354, yygo354),
-      (358, yygo358),
-      (363, yygo363)];
-    sub3 = [      (364, yygo364),
-      (365, yygo365),
+      (348, yygo348),
+      (349, yygo349),
+      (356, yygo356),
+      (360, yygo360)];
+    sub3 = [      (365, yygo365),
       (366, yygo366),
-      (369, yygo369),
-      (372, yygo372),
-      (375, yygo375),
-      (378, yygo378),
-      (379, yygo379),
+      (367, yygo367),
+      (368, yygo368),
+      (371, yygo371),
+      (374, yygo374),
+      (377, yygo377),
       (380, yygo380),
+      (382, yygo382),
       (383, yygo383),
-      (388, yygo388),
+      (386, yygo386),
       (391, yygo391),
-      (398, yygo398),
-      (400, yygo400),
+      (394, yygo394),
+      (401, yygo401),
       (403, yygo403),
-      (404, yygo404),
-      (405, yygo405),
-      (411, yygo411),
-      (413, yygo413),
-      (423, yygo423),
-      (427, yygo427),
-      (428, yygo428),
-      (432, yygo432),
-      (437, yygo437),
-      (439, yygo439),
+      (406, yygo406),
+      (407, yygo407),
+      (408, yygo408),
+      (414, yygo414),
+      (416, yygo416),
+      (426, yygo426),
+      (430, yygo430),
+      (431, yygo431),
+      (435, yygo435),
       (440, yygo440),
-      (445, yygo445),
-      (446, yygo446),
+      (442, yygo442),
+      (443, yygo443),
       (448, yygo448),
       (449, yygo449),
-      (450, yygo450),
+      (451, yygo451),
+      (452, yygo452),
       (453, yygo453),
-      (454, yygo454),
-      (455, yygo455),
-      (462, yygo462),
-      (463, yygo463),
-      (467, yygo467),
-      (471, yygo471),
-      (472, yygo472),
-      (476, yygo476),
-      (477, yygo477),
-      (478, yygo478),
+      (456, yygo456),
+      (457, yygo457),
+      (458, yygo458),
+      (465, yygo465),
+      (466, yygo466),
+      (470, yygo470),
+      (474, yygo474),
+      (475, yygo475),
+      (479, yygo479),
       (480, yygo480),
+      (481, yygo481),
       (483, yygo483),
-      (485, yygo485),
+      (486, yygo486),
       (488, yygo488),
-      (494, yygo494),
-      (495, yygo495),
-      (505, yygo505),
-      (516, yygo516),
-      (517, yygo517),
+      (491, yygo491),
+      (497, yygo497),
+      (498, yygo498),
+      (508, yygo508),
       (519, yygo519),
       (520, yygo520),
+      (522, yygo522),
       (523, yygo523),
-      (532, yygo532),
-      (544, yygo544),
-      (546, yygo546),
-      (548, yygo548),
-      (558, yygo558),
-      (565, yygo565),
-      (566, yygo566),
+      (526, yygo526),
+      (535, yygo535),
+      (547, yygo547),
+      (549, yygo549),
+      (551, yygo551),
+      (561, yygo561),
       (568, yygo568),
-      (570, yygo570),
+      (569, yygo569),
+      (571, yygo571),
       (573, yygo573)];
-    sub4 = [      (577, yygo577),
-      (578, yygo578),
-      (579, yygo579),
+    sub4 = [      (576, yygo576),
       (580, yygo580),
       (581, yygo581),
       (582, yygo582),
-      (601, yygo601),
-      (653, yygo653),
-      (667, yygo667),
-      (674, yygo674),
-      (675, yygo675),
-      (676, yygo676),
+      (583, yygo583),
+      (584, yygo584),
+      (585, yygo585),
+      (604, yygo604),
+      (656, yygo656),
+      (670, yygo670),
       (677, yygo677),
+      (678, yygo678),
       (679, yygo679),
-      (683, yygo683),
-      (689, yygo689)];
+      (680, yygo680),
+      (682, yygo682),
+      (686, yygo686),
+      (692, yygo692)];
       in sub1 `seq` sub2 `seq` sub3 `seq` sub4 `seq` genericArrayFromIndexList (sub1 ++ sub2 ++ sub3 ++ sub4);
 {-
 

--- a/frege/runtime/Phantom.java
+++ b/frege/runtime/Phantom.java
@@ -19,10 +19,12 @@ public class Phantom {
 		public interface JavaFX extends RealWorld {}
 		/** Software transactional memory */
 		public interface STM extends RealWorld {}
-		public interface XXX extends RealWorld {}
-		public interface YYY extends RealWorld {}
-		public interface AAA extends XXX, YYY {}
-	
+		/** Subtypes to play with */
+		public interface XorY extends RealWorld {}
+		public interface XorZ extends RealWorld {}
+		public interface XXX extends XorY, XorZ {}
+		public interface YYY extends XorY {}
+		public interface ZZZ extends XorZ {}
 	/**
 	 *	this should not be exposed, but ... 
 	 */

--- a/frege/tools/YYgen.fr
+++ b/frege/tools/YYgen.fr
@@ -567,7 +567,7 @@ extrrules sts = fold (\as\s -> append as (extrrule s)) [] sts;
 
 printpr monadic states reds (stdout::PrintWriter) = let
     prods = uniq (sort (extrrules states))
-    grules = (map genrule • uniqBy (\Prod a _ _\Prod b _ _ -> a==b)) prods
+    grules = (map genrule • uniqBy (\(Prod a _ _)\(Prod b _ _) -> a==b)) prods
     prlines xs = mapM_ prline xs where
         prline x = stdout.print (x ++ ";\n")
     prprods (x:xs) | (Prod r _ _) <- x = do
@@ -583,8 +583,8 @@ printpr monadic states reds (stdout::PrintWriter) = let
                 prprods (rest r)
             where
                 emptystack ps = any e ps where e (Prod _ _ s) = null s
-                same r = x : takeWhile (\Prod p _ _ -> p == r) xs
-                rest r = dropWhile     (\Prod p _ _ -> p == r) xs
+                same r = x : takeWhile (\(Prod p _ _) -> p == r) xs
+                rest r = dropWhile     (\(Prod p _ _) -> p == r) xs
     prprods [] = return ()
   in do
     prlines grules;

--- a/tests/hcm/Lambda.fr
+++ b/tests/hcm/Lambda.fr
@@ -1,0 +1,17 @@
+--- Haskell Lambda syntax
+
+module tests.hcm.Lambda where
+
+f = \a b -> (b,a)
+
+-- the following is now a syntax error
+--      Frege: unexpected operator : while trying to parse lambda patterns
+--      Haskell: parse error on input `:'
+-- s = \x:xs -> xs 
+
+-- and this is also an error
+--      Frege: constructor Maybe.Just demands 1 arguments, but you gave 0
+--      Haskell: Constructor `Just' should have 1 argument, but has been given none
+-- j = \Just x -> x
+
+main = println (f true 'a')

--- a/tests/qc/PreludeProperties.fr
+++ b/tests/qc/PreludeProperties.fr
@@ -220,12 +220,12 @@ p_initLast = forAll lists (\xs ->
     if null xs
         then label "not applicable" true
         else label "not empty" (init xs ++ [last xs] == xs))
-p_scanlFold = forAll funs (\Fun f ->
+p_scanlFold = forAll funs (\(Fun f) ->
     forAll lists (\xs ->
         property (\z ->
             trivial (null xs) $ last (scanl f z xs) == fold f z xs)))
 
-p_foldrFoldrs = forAll funs (\Fun f ->
+p_foldrFoldrs = forAll funs (\(Fun f) ->
     forAll lists (\xs ->
         property (\z -> trivial (null xs) $ foldr f z xs == foldrs f z xs)))
 


### PR DESCRIPTION
The following works now:

    f = \a b -> (b,a)

The following is now a syntax error:

    --      Frege: unexpected operator : while trying to parse lambda patterns
    --      Haskell: parse error on input `:'
    s = \x:xs -> xs 

And this is also used to work, but is now an error:

    --      Frege: constructor Maybe.Just demands 1 arguments, but you gave 0
    --      Haskell: Constructor `Just' should have 1 argument, but has been given none
    j = \Just x -> x
