### PR TITLE
Support for True/False

### DIFF
--- a/frege/compiler/common/SymbolTable.fr
+++ b/frege/compiler/common/SymbolTable.fr
@@ -108,6 +108,7 @@ enter sym
                 case g.find sym.name of
                     Nothing -> enterByName sym
                     Just that
+                        | SymL{} <- that, SymL{} <- sym, that.alias == sym.alias = pure ()  -- do nothing
                         | SymL {alias} <- that, alias.getpack != sym.name.getpack = do
                                 E.warn sym.pos (fill (break("hiding previously (line " ++ show that.pos
                                     ++ ") imported "

--- a/frege/compiler/passes/Transdef.fr
+++ b/frege/compiler/passes/Transdef.fr
@@ -542,7 +542,12 @@ transPatUnique fname pat = do
                 let pos = positionOf name.id 
                 qname <- resolveVName fname pos name
                 checkCon pos qname []
-                return (PCon {pos,qname,pats=[]})
+                case qname of 
+                    MName{tynm=TName{pack, base="HaskellBool"}, base}
+                        | pack == pPreludeBase
+                        = pure PLit{pos, kind=LBool, 
+                                    value=if base=="True" then "true" else "false"}
+                    _ -> pure (PCon {pos,qname,pats=[]})
             App{} -> case flats pat of
                 Con{name}:pats = do
                             let pos = positionOf name.id 
@@ -676,7 +681,13 @@ transExpr env fname ex = do
                         let pos = positionOf name.id
                         name <- resolveVName fname pos name
                         checkCon pos name
-                        stio (D.Con {pos, name, typ=Nothing})
+                        case name of 
+                            MName{tynm=TName{pack, base="HaskellBool"}, base}
+                                | pack == pPreludeBase
+                                = pure D.Lit{pos, kind=LBool, 
+                                            value=if base=="True" then "true" else "false", 
+                                            typ=Nothing}
+                            _ -> pure (D.Con {pos, name, typ=Nothing})
         Mem x s     -> do
                             x <- transExpr env fname x
                             stio (D.Mem x s Nothing)

--- a/frege/prelude/PreludeBase.fr
+++ b/frege/prelude/PreludeBase.fr
@@ -195,6 +195,26 @@ pure native constructor "frege.runtime.Runtime.constructor" :: a -> Int
 data Bool = native boolean
 
 {--
+    For compatibility with Haskell, the 'HaskellBool' type defines
+    constructors 'True' and 'False'.
+
+    When the identifiers @True@ or @False@ are used in patterns or expressions, 
+    qualified or unqualified, and name resolution detects that they
+    resolve to 'PreludeBase.HaskellBool.True' or 'PreludeBase.HaskellBool.False'
+    they will be replaced by literals @true@ or @false@.
+
+    This is, of course, a hack, but I see no other way to bridge the gap between
+    redefinable constructor ids and literals. For example, we couldn't simply
+    define @True@ as another literal keyword, because some Haskell code 
+    might use @Prelude.True@ or could have code like.
+    
+    > import Prelude hiding(True, False)
+    > data TriBool = False | Perhaps | True 
+-}
+data HaskellBool = False     --- will be replaced by literal @false@
+                 | True      --- will be replaced by literal @true@
+
+{--
 This is a constant with the value @true@.
 It is most often used as the last alternative in pattern guards:
 

--- a/shadow/frege/java/util/Regex.fr
+++ b/shadow/frege/java/util/Regex.fr
@@ -14,7 +14,7 @@
     Regular expression literals have type 'Regex' and are written:
 
     > ´\b(foo|bar)\b´       -- string enclosed in grave accents
-    > '\w+'                 -- string with length > 1 enclosed in apostrphes
+    > '\w+'                 -- string with length > 1 enclosed in apostrophes
 
     The notation with the apostrophes has been introduced because many
     have a hard time entering a grave accent mark on their terminal. However,

--- a/shadow/frege/prelude/Math.fr
+++ b/shadow/frege/prelude/Math.fr
@@ -31,46 +31,46 @@ infixr 15  `**`
 sqr :: Num a => a -> a
 sqr x = x * x
 
-class  Floating Real 𝖗 ⇒ 𝖗 where
+class  Floating Real r ⇒ r where
 
     --- The value that is closer than any other to @pi@, the ratio of the circumference of a circle to its diameter.
-    pi                  ∷ 𝖗
+    pi                  ∷ r
 
     --- The value that is closer than any other to @e@, the base of the natural logarithms.
-    e                   ∷ 𝖗
+    e                   ∷ r
 
     --- Returns the arc sine of a value; the returned angle is in the range -'pi'/2 through 'pi'/2.
-    asin                ∷ 𝖗 → Double
+    asin                ∷ r → Double
 
     --- Returns the arc cosine of a value; the returned angle is in the range 0.0 through 'pi'.
-    acos                ∷ 𝖗 → Double
+    acos                ∷ r → Double
 
     --- Returns the arc tangent of a value; the returned angle is in the range -'pi'/2 through 'pi'/2.
-    atan                ∷ 𝖗 → Double
+    atan                ∷ r → Double
 
     --- Returns the angle theta from the conversion of rectangular coordinates (x, y) to polar coordinates (r, theta).
-    atan2               ∷ 𝖗 → 𝖗 → Double
+    atan2               ∷ r → r → Double
 
     --- Returns the cube root of a value.
-    cbrt                ∷ 𝖗 → Double
+    cbrt                ∷ r → Double
 
     --- Returns the smallest (closest to negative infinity) value that is greater than or equal to the argument and is equal to a mathematical integer.
-    ceil                ∷ 𝖗 → Double
+    ceil                ∷ r → Double
 
     --- Returns the first argument with the sign of the second argument.
-    copySign            ∷ 𝖗 → 𝖗 → 𝖗
+    copySign            ∷ r → r → r
 
     --- Returns the trigonometric cosine of an angle.
-    cos                 ∷ 𝖗 → Double
+    cos                 ∷ r → Double
 
     --- Returns the hyperbolic cosine of a floating point value.
-    cosh                ∷ 𝖗 → Double
+    cosh                ∷ r → Double
 
     --- Returns Euler's number 'e' raised to the power of a floating-point value. 
-    exp                 ∷ 𝖗 → Double
+    exp                 ∷ r → Double
 
     --- Returns @e^x -1@.
-    expm1               ∷ 𝖗 → Double
+    expm1               ∷ r → Double
 
     {--
       Returns the largest (closest to positive infinity) value that is
@@ -84,83 +84,83 @@ class  Floating Real 𝖗 ⇒ 𝖗 where
         negative zero, then the result is the same as the argument.
 
     -}
-    floor               ∷ 𝖗 -> Double
+    floor               ∷ r -> Double
 
     --- Returns the unbiased exponent used in the representation of a floating point number.
-    getExponent         ∷ 𝖗 → Int
+    getExponent         ∷ r → Int
 
     --- Returns 'sqrt' @(x² + y²)@ without intermediate overflow or underflow.
-    hypot               ∷ 𝖗 → 𝖗 → Double
+    hypot               ∷ r → r → Double
 
     --- Computes the remainder operation on two arguments as prescribed by the IEEE 754 standard.
-    ieeeRemainder       ∷ 𝖗 → 𝖗 → Double
+    ieeeRemainder       ∷ r → r → Double
 
     --- Returns the natural logarithm (base 'e') of a value.
-    log                 ∷ 𝖗 → Double
+    log                 ∷ r → Double
 
     --- Returns the base 10 logarithm of a value.
-    log10               ∷ 𝖗 → Double
+    log10               ∷ r → Double
 
     --- Returns the natural logarithm of the sum of the argument and 1.
-    log1p               ∷ 𝖗 → Double
+    log1p               ∷ r → Double
     
     --- Returns the logarithm of the second argument to the base given by the first argument. 
-    logBase             ∷ 𝖗 → 𝖗 → Double
+    logBase             ∷ r → r → Double
 
     --- Returns the floating-point number adjacent to the first argument in the direction of the second argument.
-    nextAfter           ∷ 𝖗 → 𝖗 → Double
+    nextAfter           ∷ r → r → Double
 
     --- Returns the floating-point value adjacent to the argument in the direction of positive infinity.
-    nextUp              ∷ 𝖗 → 𝖗
+    nextUp              ∷ r → r
 
     --- Returns the value of the first argument raised to the power of the second argument.
-    pow                 ∷ 𝖗 → 𝖗 → Double
+    pow                 ∷ r → r → Double
 
     --- Returns the double value that is closest in value to the argument and is equal to a mathematical integer.
-    rint                ∷ 𝖗 → Double
+    rint                ∷ r → Double
 
     --- Returns the closest 'Long' to the argument, with ties rounding up.
-    round               ∷ 𝖗 → Long
+    round               ∷ r → Long
 
     --- > scalb d scaleFactor
     --- Return @d * 2^scaleFactor@ rounded as if performed by a single correctly rounded floating-point multiply.
-    scalb               ∷ 𝖗 → Int → 𝖗
+    scalb               ∷ r → Int → r
 
     --- Returns the signum function of the argument; zero if the argument is zero, 1.0 if the argument is greater than zero, -1.0 if the argument is less than zero.
-    signum              ∷ 𝖗 → 𝖗
+    signum              ∷ r → r
 
     --- Returns the trigonometric sine of an angle.
-    sin                 ∷ 𝖗 → Double
+    sin                 ∷ r → Double
 
     --- Returns the hyperbolic sine of a value.
-    sinh                ∷ 𝖗 → Double
+    sinh                ∷ r → Double
 
     --- Returns the correctly rounded positive square root of a value.
-    sqrt                ∷ 𝖗 → Double
+    sqrt                ∷ r → Double
 
     --- Returns the trigonometric tangent of an angle.
-    tan                 ∷ 𝖗 → Double
+    tan                 ∷ r → Double
 
     --- Returns the hyperbolic tangent of a floating point value.
-    tanh                ∷ 𝖗 → Double
+    tanh                ∷ r → Double
 
     --- Converts an angle measured in radians to an approximately equivalent angle measured in degrees.
-    toDegrees           ∷ 𝖗 → Double
+    toDegrees           ∷ r → Double
 
     --- Converts an angle measured in degrees to an approximately equivalent angle measured in radians.
-    toRadians           ∷ 𝖗 → Double
+    toRadians           ∷ r → Double
 
     --- Returns the size of an ulp of the argument.
-    ulp                 ∷ 𝖗 → 𝖗
+    ulp                 ∷ r → r
 
     --- Inverse hyperbolic function for 'sinh'
-    asinh               ∷ 𝖗 → Double
+    asinh               ∷ r → Double
 
     --- Inverse hyperbolic function for 'cosh'
-    acosh               ∷ 𝖗 → Double
+    acosh               ∷ r → Double
 
     --- Inverse hyperbolic function for 'tanh'
-    atanh               ∷ 𝖗 → Double
+    atanh               ∷ r → Double
 
     logBase x y         =  log y / log x
 

--- a/shadow/frege/prelude/PreludeArrays.fr
+++ b/shadow/frege/prelude/PreludeArrays.fr
@@ -303,7 +303,7 @@ toMaybeList ja = map ja.itemAt [0..ja.length-1]
 --- does not guarantee reconstruction of the original array, because @null@s get lost, whereas
 --- > arrayFromMaybeList . toMaybeList
 --- does.
-arrayFromMaybeList ∷ ArrayElem 𝖆 ⇒ [Maybe 𝖆] → JArray 𝖆
+arrayFromMaybeList ∷ ArrayElem a ⇒ [Maybe a] → JArray a
 arrayFromMaybeList !xs = (JArray.fromMaybeList xs >>= readonly id).run
 
 --- Create an immutable array from a finite list whose elements are 'ArrayElem`

--- a/shadow/frege/prelude/PreludeBase.fr
+++ b/shadow/frege/prelude/PreludeBase.fr
@@ -195,6 +195,26 @@ pure native constructor "frege.runtime.Runtime.constructor" :: a -> Int
 data Bool = native boolean
 
 {--
+    For compatibility with Haskell, the 'HaskellBool' type defines
+    constructors 'True' and 'False'.
+
+    When the identifiers @True@ or @False@ are used in patterns or expressions, 
+    qualified or unqualified, and name resolution detects that they
+    resolve to 'PreludeBase.HaskellBool.True' or 'PreludeBase.HaskellBool.False'
+    they will be replaced by literals @true@ or @false@.
+
+    This is, of course, a hack, but I see no other way to bridge the gap between
+    redefinable constructor ids and literals. For example, we couldn't simply
+    define @True@ as another literal keyword, because some Haskell code 
+    might use @Prelude.True@ or could have code like.
+    
+    > import Prelude hiding(True, False)
+    > data TriBool = False | Perhaps | True 
+-}
+data HaskellBool = False     --- will be replaced by literal @false@
+                 | True      --- will be replaced by literal @true@
+
+{--
 This is a constant with the value @true@.
 It is most often used as the last alternative in pattern guards:
 

--- a/tests/hcm/Bool.fr
+++ b/tests/hcm/Bool.fr
@@ -13,3 +13,7 @@ alle = [False ..]
     can detect whether we run under Frege
 -} 
 isThisFrege = show True == "true"
+
+import frege.prelude.PreludeBase (True Wahr, False Falsch)
+
+youCanTrickMe = Wahr == Falsch      -- no, you can't

--- a/tests/hcm/Bool.fr
+++ b/tests/hcm/Bool.fr
@@ -1,0 +1,15 @@
+--- This is an undocumented module
+module tests.hcm.Bool where
+
+--- can be used qualified or unqualified
+--- in patterns as well as expressions
+nicht True = Prelude.False
+nicht HaskellBool.False = True
+
+all = [False..]
+
+{-- 
+    interestingly, we have now a function that
+    can detect whether we run under Frege
+-} 
+isThisFrege = show True == "true"

--- a/tests/hcm/Bool.fr
+++ b/tests/hcm/Bool.fr
@@ -3,10 +3,10 @@ module tests.hcm.Bool where
 
 --- can be used qualified or unqualified
 --- in patterns as well as expressions
-nicht True = Prelude.False
+nicht True = Prelude.HaskellBool.False
 nicht HaskellBool.False = True
 
-all = [False..]
+alle = [False ..]
 
 {-- 
     interestingly, we have now a function that


### PR DESCRIPTION
This contributes to Haskell compatibility.
The constructors True and False belong to a pseudo type HaskellBool, but are magically replaced in expressions and patterns with boolean literals true and false.

You can still define your own types with constructors `True` or `False` or use those words in types, type classes or modules.