### PR TITLE
Implement Haskell class/instance syntax

### DIFF
--- a/frege/Prelude.fr
+++ b/frege/Prelude.fr
@@ -27,8 +27,8 @@ derive Eq   Ordering
 derive Ord  Ordering
 derive Enum Ordering
 
-derive Eq   Either a b
-derive Ord  Either a b
+derive Eq   (Either a b)
+derive Ord  (Either a b)
 
 
 -- ----------------------- tuple instances ---------------------------
@@ -36,14 +36,14 @@ derive Ord      ()
 
 derive Eq       (a,b)
 derive Ord      (a,b)
-instance Bounded (Bounded a, Bounded b) => (a,b) where
+instance (Bounded a, Bounded b) => Bounded (a,b) where
     maxBound = (maxBound, maxBound) 
     minBound = (minBound, minBound)
 
 
 derive Eq       (a,b,c)
 derive Ord      (a,b,c)
-instance Bounded (Bounded a, Bounded b, Bounded c) => (a,b,c) where
+instance (Bounded a, Bounded b, Bounded c) => Bounded (a,b,c) where
     maxBound = (maxBound, maxBound, maxBound) 
     minBound = (minBound, minBound, minBound)
 

--- a/frege/compiler/Classes.fr
+++ b/frege/compiler/Classes.fr
@@ -62,7 +62,9 @@ import  Compiler.common.SymbolTable
 
 import  Compiler.classes.Nice
 
-import Lib.PP (msgdoc, text, <+>, </>, <>, nest)
+import  Compiler.instances.Nicer (nicerctx)
+
+import Lib.PP (msgdoc, text, <+>, </>, <+/>, <>, nest)
 import frege.compiler.Utilities     as U()
 import frege.compiler.tc.Util       as T()
 import frege.compiler.Kinds         as K()
@@ -453,10 +455,17 @@ checkSuperInstance iname tname cname bname = do
                 
                 case notimplied of
                     (_:_) -> do
-                        let msg  = "context of " ++ msg2 ++ " must imply context of super instance " ++ msg3
-                            msg2 = "instance " ++ cname.nicer g ++ " " ++ isym.typ.rho.nicer g
-                            msg3 = bname.nicer g ++ " " ++ ssym.typ.rho.nicer g 
-                        E.error isym.pos (text msg)
+                        let msg  = text "context of "
+                                    <+/> (text "instance" <+> msg2) 
+                                    <+/> text " must imply context of super " 
+                                    <+/> (text "instance" <+> msg3)
+                            msg2 = text (nicerctx isym.typ.rho.context g)
+                                        <> text (cname.nicer g)
+                                        <+> (text "(" <> text (isym.typ.rho.{context=[]}.nicer g) <> text ")")
+                            msg3 = text (nicerctx ssym.typ.rho.context g)
+                                        <> text (bname.nicer g)
+                                        <+> (text "(" <> text (ssym.typ.rho.{context=[]}.nicer g) <> text ")") 
+                        E.error isym.pos msg
                     [] -> return ()
             _ -> return ()
 

--- a/frege/compiler/Typecheck.fr
+++ b/frege/compiler/Typecheck.fr
@@ -822,7 +822,7 @@ realVar     = ForAll [("int", KType)]
                       pos = Position.null
 
 
-instance Nice Nice z => Maybe z where
+instance Nice z => Nice (Maybe z) where
     nicer (Just x) g = x.nicer g
     nicer Nothing  g = "Nothing"
     nice x y = nicer x y

--- a/frege/compiler/common/Annotate.fr
+++ b/frege/compiler/common/Annotate.fr
@@ -104,7 +104,7 @@ instance Anno RState where
     anno = lit . RState.set         -- assuming we need only a few bits    
 
 
-instance Anno Anno x => [x] where
+instance Anno x => Anno [x] where
     anno :: Anno x => [x] -> DOCUMENT
     anno [] = text "{}"
     anno as = bracket "{" (sep "," (map Anno.anno as)) "}"

--- a/frege/compiler/grammar/Frege.fr
+++ b/frege/compiler/grammar/Frege.fr
@@ -116,6 +116,7 @@ data YYsi res tok  =
 	| YYNTboundvars [String]
 	| YYNTcalt CAltS
 	| YYNTcalts [CAltS]
+	| YYNTccontext [ContextS]
 	| YYNTclassdef Def
 	| YYNTcommata Int
 	| YYNTconfld [ConField SName]
@@ -151,6 +152,7 @@ data YYsi res tok  =
 	| YYNTgquals [Qual]
 	| YYNTguard Guard
 	| YYNTguards [Guard]
+	| YYNTicontext [ContextS]
 	| YYNTimport Def
 	| YYNTimportitem ImportItem
 	| YYNTimportliste ImportList
@@ -159,6 +161,7 @@ data YYsi res tok  =
 	| YYNTimpurenativedef Def
 	| YYNTinfix Def
 	| YYNTinstdef Def
+	| YYNTinsthead Def
 	| YYNTinterfaces [TauS]
 	| YYNTjtoken Token
 	| YYNTjtokens [Token]
@@ -199,8 +202,12 @@ data YYsi res tok  =
 	| YYNTqvarop SName
 	| YYNTrho RhoS
 	| YYNTrhofun RhoS
+	| YYNTscontext ContextS
+	| YYNTscontexts [ContextS]
 	| YYNTscript ParseResult
 	| YYNTsemicoli Int
+	| YYNTsicontext ContextS
+	| YYNTsicontexts [ContextS]
 	| YYNTsigex SigExs
 	| YYNTsigexs [SigExs]
 	| YYNTsigma SigmaS
@@ -249,6 +256,7 @@ showsi (YYStart  _) = "%start ";
 	showsi (YYNTboundvars _) = "<boundvars>";
 	showsi (YYNTcalt _) = "<calt>";
 	showsi (YYNTcalts _) = "<calts>";
+	showsi (YYNTccontext _) = "<ccontext>";
 	showsi (YYNTclassdef _) = "<classdef>";
 	showsi (YYNTcommata _) = "<commata>";
 	showsi (YYNTconfld _) = "<confld>";
@@ -284,6 +292,7 @@ showsi (YYStart  _) = "%start ";
 	showsi (YYNTgquals _) = "<gquals>";
 	showsi (YYNTguard _) = "<guard>";
 	showsi (YYNTguards _) = "<guards>";
+	showsi (YYNTicontext _) = "<icontext>";
 	showsi (YYNTimport _) = "<import>";
 	showsi (YYNTimportitem _) = "<importitem>";
 	showsi (YYNTimportliste _) = "<importliste>";
@@ -292,6 +301,7 @@ showsi (YYStart  _) = "%start ";
 	showsi (YYNTimpurenativedef _) = "<impurenativedef>";
 	showsi (YYNTinfix _) = "<infix>";
 	showsi (YYNTinstdef _) = "<instdef>";
+	showsi (YYNTinsthead _) = "<insthead>";
 	showsi (YYNTinterfaces _) = "<interfaces>";
 	showsi (YYNTjtoken _) = "<jtoken>";
 	showsi (YYNTjtokens _) = "<jtokens>";
@@ -332,8 +342,12 @@ showsi (YYStart  _) = "%start ";
 	showsi (YYNTqvarop _) = "<qvarop>";
 	showsi (YYNTrho _) = "<rho>";
 	showsi (YYNTrhofun _) = "<rhofun>";
+	showsi (YYNTscontext _) = "<scontext>";
+	showsi (YYNTscontexts _) = "<scontexts>";
 	showsi (YYNTscript _) = "<script>";
 	showsi (YYNTsemicoli _) = "<semicoli>";
+	showsi (YYNTsicontext _) = "<sicontext>";
+	showsi (YYNTsicontexts _) = "<sicontexts>";
 	showsi (YYNTsigex _) = "<sigex>";
 	showsi (YYNTsigexs _) = "<sigexs>";
 	showsi (YYNTsigma _) = "<sigma>";
@@ -549,7 +563,7 @@ private yyaction25 t = YYAction (-186);
 private yyaction26 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
-  '{' -> YYAction (-383);
+  '{' -> YYAction (-397);
   _ ->   case yytoken t of {
     VARID -> YYAction 74;
     CONID -> YYAction 75;
@@ -557,8 +571,8 @@ private yyaction26 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction27 t = YYAction (-323);
-private yyaction28 t = YYAction (-324);
+private yyaction27 t = YYAction (-337);
+private yyaction28 t = YYAction (-338);
 private yyaction29 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
@@ -625,14 +639,14 @@ private yyaction32 t =   case yychar t of {
   '{' -> YYAction 82;
   _ -> (YYAction yyErr);
 };
-private yyaction33 t = YYAction (-327);
-private yyaction34 t = YYAction (-326);
-private yyaction35 t = YYAction (-329);
-private yyaction36 t = YYAction (-330);
-private yyaction37 t = YYAction (-331);
-private yyaction38 t = YYAction (-325);
-private yyaction39 t = YYAction (-332);
-private yyaction40 t = YYAction (-328);
+private yyaction33 t = YYAction (-341);
+private yyaction34 t = YYAction (-340);
+private yyaction35 t = YYAction (-343);
+private yyaction36 t = YYAction (-344);
+private yyaction37 t = YYAction (-345);
+private yyaction38 t = YYAction (-339);
+private yyaction39 t = YYAction (-346);
+private yyaction40 t = YYAction (-342);
 private yyaction41 t =   case yychar t of {
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -749,51 +763,51 @@ private yyaction46 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction47 t = YYAction (-401);
+private yyaction47 t = YYAction (-415);
 private yyaction48 t = YYAction (-3);
 private yyaction49 t = YYAction (-4);
-private yyaction50 t = YYAction (-399);
+private yyaction50 t = YYAction (-413);
 private yyaction51 t =   case yychar t of {
   '{' -> YYAction 98;
-  '-' -> YYAction (-402);
-  ';' -> YYAction (-402);
-  '}' -> YYAction (-402);
-  '.' -> YYAction (-402);
-  '(' -> YYAction (-402);
-  ')' -> YYAction (-402);
-  ',' -> YYAction (-402);
-  '|' -> YYAction (-402);
-  '[' -> YYAction (-402);
-  ']' -> YYAction (-402);
-  '?' -> YYAction (-402);
-  '!' -> YYAction (-402);
-  '=' -> YYAction (-402);
-  '\\' -> YYAction (-402);
-  '_' -> YYAction (-402);
+  '-' -> YYAction (-416);
+  ';' -> YYAction (-416);
+  '}' -> YYAction (-416);
+  '.' -> YYAction (-416);
+  '(' -> YYAction (-416);
+  ')' -> YYAction (-416);
+  ',' -> YYAction (-416);
+  '|' -> YYAction (-416);
+  '[' -> YYAction (-416);
+  ']' -> YYAction (-416);
+  '?' -> YYAction (-416);
+  '!' -> YYAction (-416);
+  '=' -> YYAction (-416);
+  '\\' -> YYAction (-416);
+  '_' -> YYAction (-416);
   _ ->   case yytoken t of {
-    VARID -> YYAction (-402);
-    CONID -> YYAction (-402);
-    QUALIFIER -> YYAction (-402);
-    WHERE -> YYAction (-402);
-    TRUE -> YYAction (-402);
-    FALSE -> YYAction (-402);
-    THEN -> YYAction (-402);
-    ELSE -> YYAction (-402);
-    OF -> YYAction (-402);
-    DO -> YYAction (-402);
-    INTCONST -> YYAction (-402);
-    STRCONST -> YYAction (-402);
-    LONGCONST -> YYAction (-402);
-    FLTCONST -> YYAction (-402);
-    DBLCONST -> YYAction (-402);
-    CHRCONST -> YYAction (-402);
-    REGEXP -> YYAction (-402);
-    BIGCONST -> YYAction (-402);
-    ARROW -> YYAction (-402);
-    DCOLON -> YYAction (-402);
-    GETS -> YYAction (-402);
-    DOTDOT -> YYAction (-402);
-    SOMEOP -> YYAction (-402);
+    VARID -> YYAction (-416);
+    CONID -> YYAction (-416);
+    QUALIFIER -> YYAction (-416);
+    WHERE -> YYAction (-416);
+    TRUE -> YYAction (-416);
+    FALSE -> YYAction (-416);
+    THEN -> YYAction (-416);
+    ELSE -> YYAction (-416);
+    OF -> YYAction (-416);
+    DO -> YYAction (-416);
+    INTCONST -> YYAction (-416);
+    STRCONST -> YYAction (-416);
+    LONGCONST -> YYAction (-416);
+    FLTCONST -> YYAction (-416);
+    DBLCONST -> YYAction (-416);
+    CHRCONST -> YYAction (-416);
+    REGEXP -> YYAction (-416);
+    BIGCONST -> YYAction (-416);
+    ARROW -> YYAction (-416);
+    DCOLON -> YYAction (-416);
+    GETS -> YYAction (-416);
+    DOTDOT -> YYAction (-416);
+    SOMEOP -> YYAction (-416);
     _ -> (YYAction yyErr);
   };
 };
@@ -823,43 +837,43 @@ private yyaction52 t =   case yychar t of {
 };
 private yyaction53 t =   case yychar t of {
   '-' -> YYAction 102;
-  ';' -> YYAction (-363);
-  '}' -> YYAction (-363);
-  ')' -> YYAction (-363);
-  ',' -> YYAction (-363);
-  '|' -> YYAction (-363);
-  ']' -> YYAction (-363);
-  '=' -> YYAction (-363);
+  ';' -> YYAction (-377);
+  '}' -> YYAction (-377);
+  ')' -> YYAction (-377);
+  ',' -> YYAction (-377);
+  '|' -> YYAction (-377);
+  ']' -> YYAction (-377);
+  '=' -> YYAction (-377);
   _ ->   case yytoken t of {
     DCOLON -> YYAction 100;
     SOMEOP -> YYAction 101;
-    WHERE -> YYAction (-363);
-    THEN -> YYAction (-363);
-    ELSE -> YYAction (-363);
-    OF -> YYAction (-363);
-    ARROW -> YYAction (-363);
-    GETS -> YYAction (-363);
-    DOTDOT -> YYAction (-363);
+    WHERE -> YYAction (-377);
+    THEN -> YYAction (-377);
+    ELSE -> YYAction (-377);
+    OF -> YYAction (-377);
+    ARROW -> YYAction (-377);
+    GETS -> YYAction (-377);
+    DOTDOT -> YYAction (-377);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction54 t = YYAction (-400);
-private yyaction55 t = YYAction (-375);
-private yyaction56 t = YYAction (-371);
+private yyaction54 t = YYAction (-414);
+private yyaction55 t = YYAction (-389);
+private yyaction56 t = YYAction (-385);
 private yyaction57 t =   case yychar t of {
   '(' -> YYAction 42;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   '_' -> YYAction 47;
-  '-' -> YYAction (-376);
-  ';' -> YYAction (-376);
-  '}' -> YYAction (-376);
-  ')' -> YYAction (-376);
-  ',' -> YYAction (-376);
-  '|' -> YYAction (-376);
-  ']' -> YYAction (-376);
-  '=' -> YYAction (-376);
+  '-' -> YYAction (-390);
+  ';' -> YYAction (-390);
+  '}' -> YYAction (-390);
+  ')' -> YYAction (-390);
+  ',' -> YYAction (-390);
+  '|' -> YYAction (-390);
+  ']' -> YYAction (-390);
+  '=' -> YYAction (-390);
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
     CONID -> YYAction 25;
@@ -875,59 +889,59 @@ private yyaction57 t =   case yychar t of {
     CHRCONST -> YYAction 38;
     REGEXP -> YYAction 39;
     BIGCONST -> YYAction 40;
-    WHERE -> YYAction (-376);
-    THEN -> YYAction (-376);
-    ELSE -> YYAction (-376);
-    OF -> YYAction (-376);
-    ARROW -> YYAction (-376);
-    DCOLON -> YYAction (-376);
-    GETS -> YYAction (-376);
-    DOTDOT -> YYAction (-376);
-    SOMEOP -> YYAction (-376);
+    WHERE -> YYAction (-390);
+    THEN -> YYAction (-390);
+    ELSE -> YYAction (-390);
+    OF -> YYAction (-390);
+    ARROW -> YYAction (-390);
+    DCOLON -> YYAction (-390);
+    GETS -> YYAction (-390);
+    DOTDOT -> YYAction (-390);
+    SOMEOP -> YYAction (-390);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction58 t = YYAction (-377);
+private yyaction58 t = YYAction (-391);
 private yyaction59 t =   case yychar t of {
   '.' -> YYAction 104;
-  '-' -> YYAction (-379);
-  ';' -> YYAction (-379);
-  '}' -> YYAction (-379);
-  '(' -> YYAction (-379);
-  ')' -> YYAction (-379);
-  ',' -> YYAction (-379);
-  '|' -> YYAction (-379);
-  '[' -> YYAction (-379);
-  ']' -> YYAction (-379);
-  '?' -> YYAction (-379);
-  '!' -> YYAction (-379);
-  '=' -> YYAction (-379);
-  '\\' -> YYAction (-379);
-  '_' -> YYAction (-379);
+  '-' -> YYAction (-393);
+  ';' -> YYAction (-393);
+  '}' -> YYAction (-393);
+  '(' -> YYAction (-393);
+  ')' -> YYAction (-393);
+  ',' -> YYAction (-393);
+  '|' -> YYAction (-393);
+  '[' -> YYAction (-393);
+  ']' -> YYAction (-393);
+  '?' -> YYAction (-393);
+  '!' -> YYAction (-393);
+  '=' -> YYAction (-393);
+  '\\' -> YYAction (-393);
+  '_' -> YYAction (-393);
   _ ->   case yytoken t of {
-    VARID -> YYAction (-379);
-    CONID -> YYAction (-379);
-    QUALIFIER -> YYAction (-379);
-    WHERE -> YYAction (-379);
-    TRUE -> YYAction (-379);
-    FALSE -> YYAction (-379);
-    THEN -> YYAction (-379);
-    ELSE -> YYAction (-379);
-    OF -> YYAction (-379);
-    DO -> YYAction (-379);
-    INTCONST -> YYAction (-379);
-    STRCONST -> YYAction (-379);
-    LONGCONST -> YYAction (-379);
-    FLTCONST -> YYAction (-379);
-    DBLCONST -> YYAction (-379);
-    CHRCONST -> YYAction (-379);
-    REGEXP -> YYAction (-379);
-    BIGCONST -> YYAction (-379);
-    ARROW -> YYAction (-379);
-    DCOLON -> YYAction (-379);
-    GETS -> YYAction (-379);
-    DOTDOT -> YYAction (-379);
-    SOMEOP -> YYAction (-379);
+    VARID -> YYAction (-393);
+    CONID -> YYAction (-393);
+    QUALIFIER -> YYAction (-393);
+    WHERE -> YYAction (-393);
+    TRUE -> YYAction (-393);
+    FALSE -> YYAction (-393);
+    THEN -> YYAction (-393);
+    ELSE -> YYAction (-393);
+    OF -> YYAction (-393);
+    DO -> YYAction (-393);
+    INTCONST -> YYAction (-393);
+    STRCONST -> YYAction (-393);
+    LONGCONST -> YYAction (-393);
+    FLTCONST -> YYAction (-393);
+    DBLCONST -> YYAction (-393);
+    CHRCONST -> YYAction (-393);
+    REGEXP -> YYAction (-393);
+    BIGCONST -> YYAction (-393);
+    ARROW -> YYAction (-393);
+    DCOLON -> YYAction (-393);
+    GETS -> YYAction (-393);
+    DOTDOT -> YYAction (-393);
+    SOMEOP -> YYAction (-393);
     _ -> (YYAction yyErr);
   };
 };
@@ -935,7 +949,7 @@ private yyaction60 t =   case yychar t of {
   '{' -> YYAction 105;
   _ -> (YYAction yyErr);
 };
-private yyaction61 t = YYAction (-385);
+private yyaction61 t = YYAction (-399);
 private yyaction62 t = YYAction (-22);
 private yyaction63 t =   case yychar t of {
   '{' -> YYAction 106;
@@ -1034,7 +1048,7 @@ private yyaction75 t = YYAction (-185);
 private yyaction76 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
-  '{' -> YYAction (-384);
+  '{' -> YYAction (-398);
   _ ->   case yytoken t of {
     VARID -> YYAction 74;
     CONID -> YYAction 157;
@@ -1112,7 +1126,7 @@ private yyaction82 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction83 t = YYAction (-370);
+private yyaction83 t = YYAction (-384);
 private yyaction84 t = YYAction (-193);
 private yyaction85 t =   case yychar t of {
   '(' -> YYAction 42;
@@ -1143,10 +1157,10 @@ private yyaction85 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction86 t = YYAction (-405);
+private yyaction86 t = YYAction (-419);
 private yyaction87 t =   case yychar t of {
   ',' -> YYAction 87;
-  ')' -> YYAction (-421);
+  ')' -> YYAction (-435);
   _ -> (YYAction yyErr);
 };
 private yyaction88 t =   case yychar t of {
@@ -1216,22 +1230,22 @@ private yyaction91 t =   case yychar t of {
 };
 private yyaction92 t =   case yychar t of {
   '-' -> YYAction 182;
-  ';' -> YYAction (-363);
-  ')' -> YYAction (-363);
-  ',' -> YYAction (-363);
+  ';' -> YYAction (-377);
+  ')' -> YYAction (-377);
+  ',' -> YYAction (-377);
   _ ->   case yytoken t of {
     DCOLON -> YYAction 100;
     SOMEOP -> YYAction 181;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction93 t = YYAction (-416);
+private yyaction93 t = YYAction (-430);
 private yyaction94 t =   case yychar t of {
   ',' -> YYAction 184;
   '|' -> YYAction 185;
-  ']' -> YYAction (-434);
+  ']' -> YYAction (-448);
   _ ->   case yytoken t of {
-    DOTDOT -> YYAction (-434);
+    DOTDOT -> YYAction (-448);
     _ -> (YYAction yyErr);
   };
 };
@@ -1255,7 +1269,7 @@ private yyaction97 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   '_' -> YYAction 47;
-  '\\' -> YYAction (-381);
+  '\\' -> YYAction (-395);
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
     CONID -> YYAction 25;
@@ -1271,7 +1285,7 @@ private yyaction97 t =   case yychar t of {
     CHRCONST -> YYAction 38;
     REGEXP -> YYAction 39;
     BIGCONST -> YYAction 40;
-    ARROW -> YYAction (-381);
+    ARROW -> YYAction (-395);
     _ -> (YYAction yyErr);
   };
 };
@@ -1282,7 +1296,7 @@ private yyaction98 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction99 t = YYAction (-380);
+private yyaction99 t = YYAction (-394);
 private yyaction100 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
@@ -1352,7 +1366,7 @@ private yyaction102 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction103 t = YYAction (-378);
+private yyaction103 t = YYAction (-392);
 private yyaction104 t =   case yychar t of {
   '{' -> YYAction 215;
   '[' -> YYAction 216;
@@ -1485,13 +1499,16 @@ private yyaction114 t =   case yytoken t of {
     CONID -> YYAction 233;
     _ -> (YYAction yyErr);
   };
-private yyaction115 t =   case yytoken t of {
-    CONID -> YYAction 234;
+private yyaction115 t =   case yychar t of {
+  '(' -> YYAction 234;
+  _ ->   case yytoken t of {
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
     _ -> (YYAction yyErr);
   };
+};
 private yyaction116 t =   case yychar t of {
-  '(' -> YYAction 235;
-  '[' -> YYAction 236;
+  '(' -> YYAction 238;
   _ ->   case yytoken t of {
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 198;
@@ -1503,12 +1520,11 @@ private yyaction117 t =   case yytoken t of {
     _ -> (YYAction yyErr);
   };
 private yyaction118 t =   case yytoken t of {
-    CONID -> YYAction 239;
+    CONID -> YYAction 244;
     _ -> (YYAction yyErr);
   };
 private yyaction119 t =   case yychar t of {
-  '(' -> YYAction 235;
-  '[' -> YYAction 236;
+  '(' -> YYAction 238;
   _ ->   case yytoken t of {
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 198;
@@ -1527,7 +1543,7 @@ private yyaction120 t =   case yychar t of {
     VARID -> YYAction 107;
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
-    NATIVE -> YYAction 241;
+    NATIVE -> YYAction 246;
     DATA -> YYAction 114;
     CLASS -> YYAction 115;
     INSTANCE -> YYAction 116;
@@ -1563,7 +1579,7 @@ private yyaction121 t =   case yychar t of {
     VARID -> YYAction 107;
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
-    NATIVE -> YYAction 241;
+    NATIVE -> YYAction 246;
     DATA -> YYAction 114;
     CLASS -> YYAction 115;
     INSTANCE -> YYAction 116;
@@ -1599,7 +1615,7 @@ private yyaction122 t =   case yychar t of {
     VARID -> YYAction 107;
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
-    NATIVE -> YYAction 241;
+    NATIVE -> YYAction 246;
     DATA -> YYAction 114;
     CLASS -> YYAction 115;
     INSTANCE -> YYAction 116;
@@ -1624,11 +1640,11 @@ private yyaction122 t =   case yychar t of {
   };
 };
 private yyaction123 t =   case yytoken t of {
-    NATIVE -> YYAction 241;
+    NATIVE -> YYAction 246;
     _ -> (YYAction yyErr);
   };
 private yyaction124 t =   case yychar t of {
-  '-' -> YYAction 246;
+  '-' -> YYAction 251;
   '(' -> YYAction 42;
   ')' -> YYAction 86;
   ',' -> YYAction 87;
@@ -1730,25 +1746,25 @@ private yyaction142 t =   case yychar t of {
   ';' -> YYAction (-129);
   '}' -> YYAction (-129);
   _ ->   case yytoken t of {
-    WHERE -> YYAction 251;
+    WHERE -> YYAction 256;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction143 t = YYAction (-206);
 private yyaction144 t =   case yychar t of {
-  '-' -> YYAction 254;
+  '-' -> YYAction 259;
   _ ->   case yytoken t of {
-    VARID -> YYAction 253;
+    VARID -> YYAction 258;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction145 t =   case yytoken t of {
-    DCOLON -> YYAction 258;
+    DCOLON -> YYAction 263;
     _ -> (YYAction yyErr);
   };
 private yyaction146 t =   case yychar t of {
-  ',' -> YYAction 259;
+  ',' -> YYAction 264;
   _ ->   case yytoken t of {
     DCOLON -> YYAction (-210);
     _ -> (YYAction yyErr);
@@ -1759,32 +1775,32 @@ private yyaction148 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
-    VARID -> YYAction 260;
-    CONID -> YYAction 261;
-    QUALIFIER -> YYAction 262;
-    STRCONST -> YYAction 263;
-    DCOLON -> YYAction 264;
+    VARID -> YYAction 265;
+    CONID -> YYAction 266;
+    QUALIFIER -> YYAction 267;
+    STRCONST -> YYAction 268;
+    DCOLON -> YYAction 269;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction149 t =   case yychar t of {
-  ';' -> YYAction (-314);
-  '}' -> YYAction (-314);
+  ';' -> YYAction (-328);
+  '}' -> YYAction (-328);
   _ ->   case yytoken t of {
-    WHERE -> YYAction 268;
+    WHERE -> YYAction 273;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction150 t =   case yychar t of {
-  '|' -> YYAction 270;
-  '=' -> YYAction 271;
+  '|' -> YYAction 275;
+  '=' -> YYAction 276;
   _ -> (YYAction yyErr);
 };
 private yyaction151 t =   case yychar t of {
   '-' -> YYAction 102;
-  '|' -> YYAction (-322);
-  '=' -> YYAction (-322);
+  '|' -> YYAction (-336);
+  '=' -> YYAction (-336);
   _ ->   case yytoken t of {
     SOMEOP -> YYAction 101;
     _ -> (YYAction yyErr);
@@ -1795,7 +1811,7 @@ private yyaction152 t =   case yychar t of {
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
     VARID -> YYAction 74;
-    QUALIFIER -> YYAction 274;
+    QUALIFIER -> YYAction 279;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
@@ -1817,9 +1833,9 @@ private yyaction155 t =   case yytoken t of {
 private yyaction156 t = YYAction (-11);
 private yyaction157 t = YYAction (-184);
 private yyaction158 t = YYAction (-181);
-private yyaction159 t = YYAction (-365);
+private yyaction159 t = YYAction (-379);
 private yyaction160 t =   case yytoken t of {
-    THEN -> YYAction 280;
+    THEN -> YYAction 285;
     _ -> (YYAction yyErr);
   };
 private yyaction161 t =   case yychar t of {
@@ -1852,7 +1868,7 @@ private yyaction161 t =   case yychar t of {
   };
 };
 private yyaction162 t =   case yychar t of {
-  '{' -> YYAction 282;
+  '{' -> YYAction 287;
   _ -> (YYAction yyErr);
 };
 private yyaction163 t = YYAction (-137);
@@ -1860,7 +1876,7 @@ private yyaction164 t =   case yychar t of {
   ';' -> YYAction (-138);
   '}' -> YYAction (-138);
   _ ->   case yytoken t of {
-    WHERE -> YYAction 251;
+    WHERE -> YYAction 256;
     _ -> (YYAction yyErr);
   };
 };
@@ -1870,36 +1886,36 @@ private yyaction165 t =   case yychar t of {
   _ -> (YYAction yyErr);
 };
 private yyaction166 t =   case yychar t of {
-  '}' -> YYAction 284;
+  '}' -> YYAction 289;
   _ -> (YYAction yyErr);
 };
 private yyaction167 t =   case yychar t of {
-  '{' -> YYAction 285;
+  '{' -> YYAction 290;
   _ -> (YYAction yyErr);
 };
 private yyaction168 t =   case yychar t of {
-  '=' -> YYAction 287;
-  ';' -> YYAction (-345);
-  '}' -> YYAction (-345);
-  ',' -> YYAction (-345);
-  ']' -> YYAction (-345);
+  '=' -> YYAction 292;
+  ';' -> YYAction (-359);
+  '}' -> YYAction (-359);
+  ',' -> YYAction (-359);
+  ']' -> YYAction (-359);
   _ ->   case yytoken t of {
-    GETS -> YYAction 286;
+    GETS -> YYAction 291;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction169 t =   case yychar t of {
   ';' -> YYAction 8;
-  '}' -> YYAction (-342);
+  '}' -> YYAction (-356);
   _ -> (YYAction yyErr);
 };
-private yyaction170 t = YYAction (-336);
+private yyaction170 t = YYAction (-350);
 private yyaction171 t =   case yychar t of {
-  '}' -> YYAction 289;
+  '}' -> YYAction 294;
   _ -> (YYAction yyErr);
 };
-private yyaction172 t = YYAction (-409);
-private yyaction173 t = YYAction (-422);
+private yyaction172 t = YYAction (-423);
+private yyaction173 t = YYAction (-436);
 private yyaction174 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
@@ -1929,7 +1945,7 @@ private yyaction174 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction175 t = YYAction (-415);
+private yyaction175 t = YYAction (-429);
 private yyaction176 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
@@ -1959,13 +1975,13 @@ private yyaction176 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction177 t = YYAction (-408);
+private yyaction177 t = YYAction (-422);
 private yyaction178 t =   case yychar t of {
-  ')' -> YYAction 294;
+  ')' -> YYAction 299;
   _ -> (YYAction yyErr);
 };
-private yyaction179 t = YYAction (-407);
-private yyaction180 t = YYAction (-406);
+private yyaction179 t = YYAction (-421);
+private yyaction180 t = YYAction (-420);
 private yyaction181 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
@@ -1999,7 +2015,7 @@ private yyaction181 t =   case yychar t of {
 private yyaction182 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
-  ')' -> YYAction 295;
+  ')' -> YYAction 300;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
@@ -2027,7 +2043,7 @@ private yyaction182 t =   case yychar t of {
   };
 };
 private yyaction183 t =   case yychar t of {
-  ')' -> YYAction 296;
+  ')' -> YYAction 301;
   _ -> (YYAction yyErr);
 };
 private yyaction184 t =   case yychar t of {
@@ -2038,8 +2054,8 @@ private yyaction184 t =   case yychar t of {
   '!' -> YYAction 45;
   '\\' -> YYAction 46;
   '_' -> YYAction 47;
-  ')' -> YYAction (-436);
-  ']' -> YYAction (-436);
+  ')' -> YYAction (-450);
+  ']' -> YYAction (-450);
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
     CONID -> YYAction 25;
@@ -2058,7 +2074,7 @@ private yyaction184 t =   case yychar t of {
     CHRCONST -> YYAction 38;
     REGEXP -> YYAction 39;
     BIGCONST -> YYAction 40;
-    DOTDOT -> YYAction (-436);
+    DOTDOT -> YYAction (-450);
     _ -> (YYAction yyErr);
   };
 };
@@ -2095,7 +2111,7 @@ private yyaction186 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
-  ']' -> YYAction 300;
+  ']' -> YYAction 305;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   '\\' -> YYAction 46;
@@ -2121,7 +2137,7 @@ private yyaction186 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction187 t = YYAction (-417);
+private yyaction187 t = YYAction (-431);
 private yyaction188 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
@@ -2151,54 +2167,54 @@ private yyaction188 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction189 t = YYAction (-360);
-private yyaction190 t = YYAction (-359);
-private yyaction191 t = YYAction (-382);
+private yyaction189 t = YYAction (-374);
+private yyaction190 t = YYAction (-373);
+private yyaction191 t = YYAction (-396);
 private yyaction192 t = YYAction (-171);
-private yyaction193 t = YYAction (-403);
+private yyaction193 t = YYAction (-417);
 private yyaction194 t =   case yychar t of {
-  '=' -> YYAction 303;
-  '}' -> YYAction (-433);
-  ',' -> YYAction (-433);
+  '=' -> YYAction 308;
+  '}' -> YYAction (-447);
+  ',' -> YYAction (-447);
   _ -> (YYAction yyErr);
 };
 private yyaction195 t =   case yychar t of {
-  '}' -> YYAction 304;
+  '}' -> YYAction 309;
   _ -> (YYAction yyErr);
 };
 private yyaction196 t =   case yychar t of {
-  ',' -> YYAction 305;
-  '}' -> YYAction (-423);
+  ',' -> YYAction 310;
+  '}' -> YYAction (-437);
   _ -> (YYAction yyErr);
 };
 private yyaction197 t = YYAction (-252);
 private yyaction198 t =   case yytoken t of {
     CONID -> YYAction 75;
-    QUALIFIER -> YYAction 306;
+    QUALIFIER -> YYAction 311;
     _ -> (YYAction yyErr);
   };
 private yyaction199 t =   case yytoken t of {
-    VARID -> YYAction 307;
+    VARID -> YYAction 312;
     _ -> (YYAction yyErr);
   };
 private yyaction200 t =   case yychar t of {
   '(' -> YYAction 200;
-  ')' -> YYAction 312;
+  ')' -> YYAction 317;
   ',' -> YYAction 87;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
-    VARID -> YYAction 310;
+    VARID -> YYAction 315;
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 198;
     FORALL -> YYAction 199;
-    ARROW -> YYAction 311;
+    ARROW -> YYAction 316;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction201 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
-  ']' -> YYAction 317;
+  ']' -> YYAction 322;
   _ ->   case yytoken t of {
     VARID -> YYAction 197;
     CONID -> YYAction 25;
@@ -2208,7 +2224,7 @@ private yyaction201 t =   case yychar t of {
   };
 };
 private yyaction202 t = YYAction (-254);
-private yyaction203 t = YYAction (-362);
+private yyaction203 t = YYAction (-376);
 private yyaction204 t = YYAction (-229);
 private yyaction205 t = YYAction (-230);
 private yyaction206 t =   case yychar t of {
@@ -2221,8 +2237,8 @@ private yyaction206 t =   case yychar t of {
   ']' -> YYAction (-236);
   '=' -> YYAction (-236);
   _ ->   case yytoken t of {
-    ARROW -> YYAction 319;
-    EARROW -> YYAction 320;
+    ARROW -> YYAction 324;
+    EARROW -> YYAction 325;
     DOCUMENTATION -> YYAction (-236);
     WHERE -> YYAction (-236);
     CLASS -> YYAction (-236);
@@ -2242,31 +2258,31 @@ private yyaction208 t = YYAction (-245);
 private yyaction209 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
-  '-' -> YYAction (-294);
-  ';' -> YYAction (-294);
-  '}' -> YYAction (-294);
-  ')' -> YYAction (-294);
-  ',' -> YYAction (-294);
-  '|' -> YYAction (-294);
-  ']' -> YYAction (-294);
-  '=' -> YYAction (-294);
+  '-' -> YYAction (-308);
+  ';' -> YYAction (-308);
+  '}' -> YYAction (-308);
+  ')' -> YYAction (-308);
+  ',' -> YYAction (-308);
+  '|' -> YYAction (-308);
+  ']' -> YYAction (-308);
+  '=' -> YYAction (-308);
   _ ->   case yytoken t of {
     VARID -> YYAction 197;
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 198;
-    DOCUMENTATION -> YYAction (-294);
-    WHERE -> YYAction (-294);
-    CLASS -> YYAction (-294);
-    THEN -> YYAction (-294);
-    ELSE -> YYAction (-294);
-    OF -> YYAction (-294);
-    THROWS -> YYAction (-294);
-    ARROW -> YYAction (-294);
-    DCOLON -> YYAction (-294);
-    GETS -> YYAction (-294);
-    EARROW -> YYAction (-294);
-    DOTDOT -> YYAction (-294);
-    SOMEOP -> YYAction (-294);
+    DOCUMENTATION -> YYAction (-308);
+    WHERE -> YYAction (-308);
+    CLASS -> YYAction (-308);
+    THEN -> YYAction (-308);
+    ELSE -> YYAction (-308);
+    OF -> YYAction (-308);
+    THROWS -> YYAction (-308);
+    ARROW -> YYAction (-308);
+    DCOLON -> YYAction (-308);
+    GETS -> YYAction (-308);
+    EARROW -> YYAction (-308);
+    DOTDOT -> YYAction (-308);
+    SOMEOP -> YYAction (-308);
     _ -> (YYAction yyErr);
   };
 };
@@ -2274,51 +2290,51 @@ private yyaction210 t = YYAction (-246);
 private yyaction211 t = YYAction (-247);
 private yyaction212 t =   case yychar t of {
   '-' -> YYAction 102;
-  ';' -> YYAction (-368);
-  '}' -> YYAction (-368);
-  ')' -> YYAction (-368);
-  ',' -> YYAction (-368);
-  '|' -> YYAction (-368);
-  ']' -> YYAction (-368);
-  '=' -> YYAction (-368);
+  ';' -> YYAction (-382);
+  '}' -> YYAction (-382);
+  ')' -> YYAction (-382);
+  ',' -> YYAction (-382);
+  '|' -> YYAction (-382);
+  ']' -> YYAction (-382);
+  '=' -> YYAction (-382);
   _ ->   case yytoken t of {
     SOMEOP -> YYAction 101;
-    WHERE -> YYAction (-368);
-    THEN -> YYAction (-368);
-    ELSE -> YYAction (-368);
-    OF -> YYAction (-368);
-    ARROW -> YYAction (-368);
-    DCOLON -> YYAction (-368);
-    GETS -> YYAction (-368);
-    DOTDOT -> YYAction (-368);
+    WHERE -> YYAction (-382);
+    THEN -> YYAction (-382);
+    ELSE -> YYAction (-382);
+    OF -> YYAction (-382);
+    ARROW -> YYAction (-382);
+    DCOLON -> YYAction (-382);
+    GETS -> YYAction (-382);
+    DOTDOT -> YYAction (-382);
     _ -> (YYAction yyErr);
   };
 };
 private yyaction213 t =   case yychar t of {
   '-' -> YYAction 102;
-  ';' -> YYAction (-369);
-  '}' -> YYAction (-369);
-  ')' -> YYAction (-369);
-  ',' -> YYAction (-369);
-  '|' -> YYAction (-369);
-  ']' -> YYAction (-369);
-  '=' -> YYAction (-369);
+  ';' -> YYAction (-383);
+  '}' -> YYAction (-383);
+  ')' -> YYAction (-383);
+  ',' -> YYAction (-383);
+  '|' -> YYAction (-383);
+  ']' -> YYAction (-383);
+  '=' -> YYAction (-383);
   _ ->   case yytoken t of {
     SOMEOP -> YYAction 101;
-    WHERE -> YYAction (-369);
-    THEN -> YYAction (-369);
-    ELSE -> YYAction (-369);
-    OF -> YYAction (-369);
-    ARROW -> YYAction (-369);
-    DCOLON -> YYAction (-369);
-    GETS -> YYAction (-369);
-    DOTDOT -> YYAction (-369);
+    WHERE -> YYAction (-383);
+    THEN -> YYAction (-383);
+    ELSE -> YYAction (-383);
+    OF -> YYAction (-383);
+    ARROW -> YYAction (-383);
+    DCOLON -> YYAction (-383);
+    GETS -> YYAction (-383);
+    DOTDOT -> YYAction (-383);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction214 t = YYAction (-387);
+private yyaction214 t = YYAction (-401);
 private yyaction215 t =   case yytoken t of {
-    VARID -> YYAction 322;
+    VARID -> YYAction 327;
     _ -> (YYAction yyErr);
   };
 private yyaction216 t =   case yychar t of {
@@ -2350,39 +2366,39 @@ private yyaction216 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction217 t = YYAction (-388);
-private yyaction218 t = YYAction (-389);
+private yyaction217 t = YYAction (-402);
+private yyaction218 t = YYAction (-403);
 private yyaction219 t =   case yychar t of {
-  '?' -> YYAction 326;
-  '=' -> YYAction 327;
-  '}' -> YYAction (-431);
-  ',' -> YYAction (-431);
+  '?' -> YYAction 331;
+  '=' -> YYAction 332;
+  '}' -> YYAction (-445);
+  ',' -> YYAction (-445);
   _ ->   case yytoken t of {
-    GETS -> YYAction 325;
+    GETS -> YYAction 330;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction220 t =   case yychar t of {
-  '}' -> YYAction 328;
+  '}' -> YYAction 333;
   _ -> (YYAction yyErr);
 };
 private yyaction221 t =   case yychar t of {
-  ',' -> YYAction 329;
-  '}' -> YYAction (-426);
+  ',' -> YYAction 334;
+  '}' -> YYAction (-440);
   _ -> (YYAction yyErr);
 };
 private yyaction222 t =   case yychar t of {
-  '}' -> YYAction 330;
+  '}' -> YYAction 335;
   _ -> (YYAction yyErr);
 };
 private yyaction223 t =   case yychar t of {
-  '(' -> YYAction 334;
+  '(' -> YYAction 339;
   ';' -> YYAction (-145);
   '}' -> YYAction (-145);
   _ ->   case yytoken t of {
-    VARID -> YYAction 331;
-    CONID -> YYAction 332;
-    PUBLIC -> YYAction 333;
+    VARID -> YYAction 336;
+    CONID -> YYAction 337;
+    PUBLIC -> YYAction 338;
     _ -> (YYAction yyErr);
   };
 };
@@ -2390,14 +2406,14 @@ private yyaction224 t = YYAction (-196);
 private yyaction225 t = YYAction (-198);
 private yyaction226 t = YYAction (-197);
 private yyaction227 t =   case yytoken t of {
-    TYPE -> YYAction 337;
+    TYPE -> YYAction 342;
     WHERE -> YYAction (-43);
     CLASS -> YYAction (-43);
     _ -> (YYAction yyErr);
   };
 private yyaction228 t = YYAction (-217);
 private yyaction229 t =   case yychar t of {
-  '-' -> YYAction 339;
+  '-' -> YYAction 344;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
@@ -2409,68 +2425,79 @@ private yyaction230 t = YYAction (-215);
 private yyaction231 t = YYAction (-216);
 private yyaction232 t = YYAction (-214);
 private yyaction233 t =   case yychar t of {
-  '(' -> YYAction 342;
-  '=' -> YYAction 343;
+  '(' -> YYAction 347;
+  '=' -> YYAction 348;
   _ ->   case yytoken t of {
     VARID -> YYAction 197;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction234 t =   case yychar t of {
-  '(' -> YYAction 200;
-  '[' -> YYAction 201;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 197;
+private yyaction234 t =   case yytoken t of {
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 198;
-    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
-};
 private yyaction235 t =   case yychar t of {
-  ')' -> YYAction 312;
-  ',' -> YYAction 87;
+  '(' -> YYAction 347;
   _ ->   case yytoken t of {
-    ARROW -> YYAction 311;
+    VARID -> YYAction 197;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction236 t =   case yychar t of {
-  ']' -> YYAction 317;
-  _ -> (YYAction yyErr);
-};
+private yyaction236 t = YYAction (-268);
 private yyaction237 t =   case yychar t of {
-  '(' -> YYAction 200;
-  '[' -> YYAction 201;
+  ';' -> YYAction (-328);
+  '}' -> YYAction (-328);
   _ ->   case yytoken t of {
-    VARID -> YYAction 197;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 198;
-    FORALL -> YYAction 199;
+    WHERE -> YYAction 273;
+    EARROW -> YYAction 354;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction238 t = YYAction (-37);
+private yyaction238 t =   case yytoken t of {
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    _ -> (YYAction yyErr);
+  };
 private yyaction239 t =   case yychar t of {
-  '(' -> YYAction 342;
-  '=' -> YYAction 349;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 197;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction240 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
     VARID -> YYAction 197;
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 198;
-    FORALL -> YYAction 199;
     _ -> (YYAction yyErr);
   };
 };
+private yyaction240 t = YYAction (-276);
 private yyaction241 t =   case yychar t of {
+  ';' -> YYAction (-279);
+  '}' -> YYAction (-279);
+  _ ->   case yytoken t of {
+    EARROW -> YYAction 359;
+    WHERE -> YYAction (-279);
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction242 t =   case yychar t of {
+  ';' -> YYAction (-328);
+  '}' -> YYAction (-328);
+  _ ->   case yytoken t of {
+    WHERE -> YYAction 273;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction243 t = YYAction (-37);
+private yyaction244 t =   case yychar t of {
+  '(' -> YYAction 347;
+  '=' -> YYAction 361;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction245 t = YYAction (-281);
+private yyaction246 t =   case yychar t of {
   '-' -> YYAction 228;
   '(' -> YYAction 229;
   '?' -> YYAction 44;
@@ -2481,13 +2508,13 @@ private yyaction241 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction242 t = YYAction (-34);
-private yyaction243 t = YYAction (-35);
-private yyaction244 t = YYAction (-36);
-private yyaction245 t = YYAction (-212);
-private yyaction246 t =   case yychar t of {
+private yyaction247 t = YYAction (-34);
+private yyaction248 t = YYAction (-35);
+private yyaction249 t = YYAction (-36);
+private yyaction250 t = YYAction (-212);
+private yyaction251 t =   case yychar t of {
   '(' -> YYAction 42;
-  ')' -> YYAction 352;
+  ')' -> YYAction 363;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
@@ -2514,10 +2541,10 @@ private yyaction246 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction247 t =   case yychar t of {
+private yyaction252 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
-  ')' -> YYAction 353;
+  ')' -> YYAction 364;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
@@ -2544,9 +2571,9 @@ private yyaction247 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction248 t =   case yychar t of {
+private yyaction253 t =   case yychar t of {
   '(' -> YYAction 42;
-  ')' -> YYAction 354;
+  ')' -> YYAction 365;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
@@ -2569,7 +2596,7 @@ private yyaction248 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction249 t =   case yychar t of {
+private yyaction254 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 124;
   '[' -> YYAction 43;
@@ -2615,27 +2642,27 @@ private yyaction249 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction250 t = YYAction (-31);
-private yyaction251 t =   case yychar t of {
-  '{' -> YYAction 356;
+private yyaction255 t = YYAction (-31);
+private yyaction256 t =   case yychar t of {
+  '{' -> YYAction 367;
   _ -> (YYAction yyErr);
 };
-private yyaction252 t = YYAction (-321);
-private yyaction253 t = YYAction (-200);
-private yyaction254 t = YYAction (-201);
-private yyaction255 t = YYAction (-199);
-private yyaction256 t =   case yychar t of {
-  '-' -> YYAction 254;
+private yyaction257 t = YYAction (-335);
+private yyaction258 t = YYAction (-200);
+private yyaction259 t = YYAction (-201);
+private yyaction260 t = YYAction (-199);
+private yyaction261 t =   case yychar t of {
+  '-' -> YYAction 259;
   ';' -> YYAction (-202);
   '}' -> YYAction (-202);
   _ ->   case yytoken t of {
-    VARID -> YYAction 253;
+    VARID -> YYAction 258;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction257 t = YYAction (-204);
-private yyaction258 t =   case yychar t of {
+private yyaction262 t = YYAction (-204);
+private yyaction263 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
@@ -2646,15 +2673,15 @@ private yyaction258 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction259 t =   case yychar t of {
+private yyaction264 t =   case yychar t of {
   '(' -> YYAction 229;
   _ ->   case yytoken t of {
     VARID -> YYAction 192;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction260 t =   case yychar t of {
-  '.' -> YYAction 360;
+private yyaction265 t =   case yychar t of {
+  '.' -> YYAction 371;
   ';' -> YYAction (-5);
   '}' -> YYAction (-5);
   _ ->   case yytoken t of {
@@ -2663,16 +2690,16 @@ private yyaction260 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction261 t = YYAction (-6);
-private yyaction262 t =   case yytoken t of {
-    VARID -> YYAction 260;
-    CONID -> YYAction 261;
-    QUALIFIER -> YYAction 262;
-    STRCONST -> YYAction 263;
+private yyaction266 t = YYAction (-6);
+private yyaction267 t =   case yytoken t of {
+    VARID -> YYAction 265;
+    CONID -> YYAction 266;
+    QUALIFIER -> YYAction 267;
+    STRCONST -> YYAction 268;
     _ -> (YYAction yyErr);
   };
-private yyaction263 t = YYAction (-9);
-private yyaction264 t =   case yychar t of {
+private yyaction268 t = YYAction (-9);
+private yyaction269 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
@@ -2683,24 +2710,24 @@ private yyaction264 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction265 t =   case yytoken t of {
-    DCOLON -> YYAction 365;
+private yyaction270 t =   case yytoken t of {
+    DCOLON -> YYAction 376;
     _ -> (YYAction yyErr);
   };
-private yyaction266 t =   case yytoken t of {
-    DCOLON -> YYAction 366;
+private yyaction271 t =   case yytoken t of {
+    DCOLON -> YYAction 377;
     _ -> (YYAction yyErr);
   };
-private yyaction267 t =   case yytoken t of {
-    DCOLON -> YYAction 367;
+private yyaction272 t =   case yytoken t of {
+    DCOLON -> YYAction 378;
     _ -> (YYAction yyErr);
   };
-private yyaction268 t =   case yychar t of {
-  '{' -> YYAction 368;
+private yyaction273 t =   case yychar t of {
+  '{' -> YYAction 379;
   _ -> (YYAction yyErr);
 };
-private yyaction269 t = YYAction (-268);
-private yyaction270 t =   case yychar t of {
+private yyaction274 t = YYAction (-282);
+private yyaction275 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -2729,7 +2756,7 @@ private yyaction270 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction271 t =   case yychar t of {
+private yyaction276 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -2758,163 +2785,42 @@ private yyaction271 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction272 t = YYAction (-320);
-private yyaction273 t =   case yychar t of {
-  '|' -> YYAction 270;
-  ';' -> YYAction (-351);
-  '}' -> YYAction (-351);
+private yyaction277 t = YYAction (-334);
+private yyaction278 t =   case yychar t of {
+  '|' -> YYAction 275;
+  ';' -> YYAction (-365);
+  '}' -> YYAction (-365);
   _ ->   case yytoken t of {
-    WHERE -> YYAction (-351);
+    WHERE -> YYAction (-365);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction274 t =   case yychar t of {
+private yyaction279 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
     VARID -> YYAction 74;
-    QUALIFIER -> YYAction 374;
+    QUALIFIER -> YYAction 385;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction275 t =   case yychar t of {
-  ')' -> YYAction 376;
+private yyaction280 t =   case yychar t of {
+  ')' -> YYAction 387;
   _ -> (YYAction yyErr);
 };
-private yyaction276 t = YYAction (-192);
-private yyaction277 t =   case yychar t of {
-  ',' -> YYAction 377;
+private yyaction281 t = YYAction (-192);
+private yyaction282 t =   case yychar t of {
+  ',' -> YYAction 388;
   ')' -> YYAction (-179);
   _ -> (YYAction yyErr);
 };
-private yyaction278 t = YYAction (-191);
-private yyaction279 t = YYAction (-19);
-private yyaction280 t = YYAction (-364);
-private yyaction281 t =   case yychar t of {
-  ';' -> YYAction 379;
-  _ ->   case yytoken t of {
-    ELSE -> YYAction 378;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction282 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction283 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 124;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  '}' -> YYAction (-140);
-  _ ->   case yytoken t of {
-    VARID -> YYAction 107;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction284 t =   case yytoken t of {
-    IN -> YYAction 386;
-    _ -> (YYAction yyErr);
-  };
-private yyaction285 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 124;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 107;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
+private yyaction283 t = YYAction (-191);
+private yyaction284 t = YYAction (-19);
+private yyaction285 t = YYAction (-378);
 private yyaction286 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
+  ';' -> YYAction 390;
   _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
+    ELSE -> YYAction 389;
     _ -> (YYAction yyErr);
   };
 };
@@ -2949,22 +2855,22 @@ private yyaction287 t =   case yychar t of {
 };
 private yyaction288 t =   case yychar t of {
   '-' -> YYAction 41;
-  '(' -> YYAction 42;
+  '(' -> YYAction 124;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   '\\' -> YYAction 46;
   '_' -> YYAction 47;
-  '}' -> YYAction (-343);
+  '}' -> YYAction (-140);
   _ ->   case yytoken t of {
-    VARID -> YYAction 24;
+    VARID -> YYAction 107;
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
     TRUE -> YYAction 27;
     FALSE -> YYAction 28;
     IF -> YYAction 29;
     CASE -> YYAction 30;
-    LET -> YYAction 167;
+    LET -> YYAction 31;
     DO -> YYAction 32;
     INTCONST -> YYAction 33;
     STRCONST -> YYAction 34;
@@ -2977,512 +2883,12 @@ private yyaction288 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction289 t = YYAction (-386);
+private yyaction289 t =   case yytoken t of {
+    IN -> YYAction 397;
+    _ -> (YYAction yyErr);
+  };
 private yyaction290 t =   case yychar t of {
-  ';' -> YYAction 391;
-  ')' -> YYAction (-437);
-  _ -> (YYAction yyErr);
-};
-private yyaction291 t =   case yychar t of {
-  ')' -> YYAction 392;
-  _ -> (YYAction yyErr);
-};
-private yyaction292 t =   case yychar t of {
-  ',' -> YYAction 184;
-  ')' -> YYAction (-434);
-  ']' -> YYAction (-434);
-  _ ->   case yytoken t of {
-    DOTDOT -> YYAction (-434);
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction293 t =   case yychar t of {
-  ')' -> YYAction 393;
-  _ -> (YYAction yyErr);
-};
-private yyaction294 t = YYAction (-410);
-private yyaction295 t = YYAction (-412);
-private yyaction296 t = YYAction (-411);
-private yyaction297 t = YYAction (-435);
-private yyaction298 t =   case yychar t of {
-  ',' -> YYAction 394;
-  ']' -> YYAction (-339);
-  _ -> (YYAction yyErr);
-};
-private yyaction299 t =   case yychar t of {
-  ']' -> YYAction 395;
-  _ -> (YYAction yyErr);
-};
-private yyaction300 t = YYAction (-418);
-private yyaction301 t =   case yychar t of {
-  ']' -> YYAction 396;
-  _ -> (YYAction yyErr);
-};
-private yyaction302 t = YYAction (-361);
-private yyaction303 t =   case yychar t of {
   '-' -> YYAction 41;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction304 t = YYAction (-404);
-private yyaction305 t =   case yychar t of {
-  '}' -> YYAction (-425);
-  _ ->   case yytoken t of {
-    VARID -> YYAction 192;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction306 t =   case yytoken t of {
-    CONID -> YYAction 157;
-    _ -> (YYAction yyErr);
-  };
-private yyaction307 t = YYAction (-228);
-private yyaction308 t =   case yychar t of {
-  '.' -> YYAction 400;
-  _ ->   case yytoken t of {
-    SOMEOP -> YYAction 399;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction309 t =   case yychar t of {
-  '.' -> YYAction (-226);
-  _ ->   case yytoken t of {
-    VARID -> YYAction 307;
-    SOMEOP -> YYAction (-226);
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction310 t =   case yychar t of {
-  '(' -> YYAction (-252);
-  ')' -> YYAction (-252);
-  ',' -> YYAction (-252);
-  '|' -> YYAction (-252);
-  '[' -> YYAction (-252);
-  _ ->   case yytoken t of {
-    DCOLON -> YYAction 403;
-    VARID -> YYAction (-252);
-    CONID -> YYAction (-252);
-    QUALIFIER -> YYAction (-252);
-    ARROW -> YYAction (-252);
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction311 t =   case yychar t of {
-  ')' -> YYAction 404;
-  _ -> (YYAction yyErr);
-};
-private yyaction312 t = YYAction (-256);
-private yyaction313 t =   case yychar t of {
-  ')' -> YYAction 405;
-  ',' -> YYAction 406;
-  '|' -> YYAction 407;
-  _ -> (YYAction yyErr);
-};
-private yyaction314 t = YYAction (-239);
-private yyaction315 t =   case yychar t of {
-  ';' -> YYAction (-238);
-  '}' -> YYAction (-238);
-  ')' -> YYAction (-238);
-  ',' -> YYAction (-238);
-  '|' -> YYAction (-238);
-  ']' -> YYAction (-238);
-  _ ->   case yytoken t of {
-    ARROW -> YYAction 408;
-    WHERE -> YYAction (-238);
-    CLASS -> YYAction (-238);
-    EARROW -> YYAction (-238);
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction316 t =   case yychar t of {
-  ')' -> YYAction 409;
-  _ -> (YYAction yyErr);
-};
-private yyaction317 t = YYAction (-255);
-private yyaction318 t =   case yychar t of {
-  ']' -> YYAction 410;
-  _ -> (YYAction yyErr);
-};
-private yyaction319 t =   case yychar t of {
-  '(' -> YYAction 200;
-  '[' -> YYAction 201;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 197;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 198;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction320 t =   case yychar t of {
-  '(' -> YYAction 200;
-  '[' -> YYAction 201;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 197;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 198;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction321 t = YYAction (-295);
-private yyaction322 t =   case yychar t of {
-  '?' -> YYAction 415;
-  '=' -> YYAction 416;
-  '}' -> YYAction (-431);
-  ',' -> YYAction (-431);
-  _ ->   case yytoken t of {
-    GETS -> YYAction 414;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction323 t =   case yychar t of {
-  '}' -> YYAction 417;
-  _ -> (YYAction yyErr);
-};
-private yyaction324 t =   case yychar t of {
-  ']' -> YYAction 418;
-  _ -> (YYAction yyErr);
-};
-private yyaction325 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '}' -> YYAction 419;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction326 t =   case yychar t of {
-  '}' -> YYAction 421;
-  _ -> (YYAction yyErr);
-};
-private yyaction327 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '}' -> YYAction 422;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction328 t = YYAction (-393);
-private yyaction329 t =   case yychar t of {
-  '}' -> YYAction (-428);
-  _ ->   case yytoken t of {
-    VARID -> YYAction 424;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction330 t = YYAction (-2);
-private yyaction331 t =   case yychar t of {
-  '(' -> YYAction (-171);
-  _ ->   case yytoken t of {
-    CONID -> YYAction 426;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction332 t =   case yychar t of {
-  '(' -> YYAction 334;
-  ';' -> YYAction (-145);
-  '}' -> YYAction (-145);
-  _ ->   case yytoken t of {
-    VARID -> YYAction 192;
-    PUBLIC -> YYAction 333;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction333 t =   case yychar t of {
-  '(' -> YYAction 334;
-  ';' -> YYAction (-145);
-  '}' -> YYAction (-145);
-  _ ->   case yytoken t of {
-    VARID -> YYAction 192;
-    PUBLIC -> YYAction 333;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction334 t =   case yychar t of {
-  ')' -> YYAction 432;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 429;
-    QUALIFIER -> YYAction 430;
-    PUBLIC -> YYAction 431;
-    SOMEOP -> YYAction 84;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction335 t = YYAction (-142);
-private yyaction336 t =   case yychar t of {
-  '(' -> YYAction 440;
-  _ -> (YYAction yyErr);
-};
-private yyaction337 t =   case yychar t of {
-  '(' -> YYAction 200;
-  '[' -> YYAction 201;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 197;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 198;
-    FORALL -> YYAction 199;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction338 t =   case yytoken t of {
-    CLASS -> YYAction 442;
-    WHERE -> YYAction (-45);
-    _ -> (YYAction yyErr);
-  };
-private yyaction339 t =   case yychar t of {
-  ')' -> YYAction 444;
-  _ -> (YYAction yyErr);
-};
-private yyaction340 t =   case yychar t of {
-  ')' -> YYAction 445;
-  _ -> (YYAction yyErr);
-};
-private yyaction341 t =   case yychar t of {
-  ')' -> YYAction 446;
-  _ -> (YYAction yyErr);
-};
-private yyaction342 t =   case yytoken t of {
-    VARID -> YYAction 447;
-    _ -> (YYAction yyErr);
-  };
-private yyaction343 t =   case yychar t of {
-  '?' -> YYAction 456;
-  '!' -> YYAction 457;
-  _ ->   case yytoken t of {
-    CONID -> YYAction 448;
-    DOCUMENTATION -> YYAction 449;
-    NATIVE -> YYAction 450;
-    PRIVATE -> YYAction 451;
-    PROTECTED -> YYAction 452;
-    PUBLIC -> YYAction 453;
-    PURE -> YYAction 454;
-    MUTABLE -> YYAction 455;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction344 t =   case yychar t of {
-  '(' -> YYAction 342;
-  '=' -> YYAction (-276);
-  _ ->   case yytoken t of {
-    VARID -> YYAction 197;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction345 t =   case yychar t of {
-  '=' -> YYAction 465;
-  _ -> (YYAction yyErr);
-};
-private yyaction346 t =   case yytoken t of {
-    EARROW -> YYAction 466;
-    _ -> (YYAction yyErr);
-  };
-private yyaction347 t =   case yychar t of {
-  ';' -> YYAction (-314);
-  '}' -> YYAction (-314);
-  '(' -> YYAction (-246);
-  '[' -> YYAction (-246);
-  _ ->   case yytoken t of {
-    WHERE -> YYAction 268;
-    VARID -> YYAction (-246);
-    CONID -> YYAction (-246);
-    QUALIFIER -> YYAction (-246);
-    ARROW -> YYAction (-246);
-    EARROW -> YYAction (-246);
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction348 t =   case yychar t of {
-  ';' -> YYAction (-314);
-  '}' -> YYAction (-314);
-  _ ->   case yytoken t of {
-    WHERE -> YYAction 268;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction349 t =   case yychar t of {
-  '(' -> YYAction 200;
-  '[' -> YYAction 201;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 197;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 198;
-    FORALL -> YYAction 199;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction350 t =   case yychar t of {
-  '=' -> YYAction 470;
-  _ -> (YYAction yyErr);
-};
-private yyaction351 t = YYAction (-267);
-private yyaction352 t =   case yychar t of {
-  '-' -> YYAction (-409);
-  '.' -> YYAction (-409);
-  '(' -> YYAction (-409);
-  ',' -> YYAction (-209);
-  '|' -> YYAction (-409);
-  '[' -> YYAction (-409);
-  '?' -> YYAction (-409);
-  '!' -> YYAction (-409);
-  '=' -> YYAction (-409);
-  '_' -> YYAction (-409);
-  _ ->   case yytoken t of {
-    VARID -> YYAction (-409);
-    CONID -> YYAction (-409);
-    QUALIFIER -> YYAction (-409);
-    TRUE -> YYAction (-409);
-    FALSE -> YYAction (-409);
-    DO -> YYAction (-409);
-    INTCONST -> YYAction (-409);
-    STRCONST -> YYAction (-409);
-    LONGCONST -> YYAction (-409);
-    FLTCONST -> YYAction (-409);
-    DBLCONST -> YYAction (-409);
-    CHRCONST -> YYAction (-409);
-    REGEXP -> YYAction (-409);
-    BIGCONST -> YYAction (-409);
-    DCOLON -> YYAction (-209);
-    SOMEOP -> YYAction (-409);
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction353 t =   case yychar t of {
-  '-' -> YYAction (-408);
-  '.' -> YYAction (-408);
-  '(' -> YYAction (-408);
-  ',' -> YYAction (-207);
-  '|' -> YYAction (-408);
-  '[' -> YYAction (-408);
-  '?' -> YYAction (-408);
-  '!' -> YYAction (-408);
-  '=' -> YYAction (-408);
-  '_' -> YYAction (-408);
-  _ ->   case yytoken t of {
-    VARID -> YYAction (-408);
-    CONID -> YYAction (-408);
-    QUALIFIER -> YYAction (-408);
-    TRUE -> YYAction (-408);
-    FALSE -> YYAction (-408);
-    DO -> YYAction (-408);
-    INTCONST -> YYAction (-408);
-    STRCONST -> YYAction (-408);
-    LONGCONST -> YYAction (-408);
-    FLTCONST -> YYAction (-408);
-    DBLCONST -> YYAction (-408);
-    CHRCONST -> YYAction (-408);
-    REGEXP -> YYAction (-408);
-    BIGCONST -> YYAction (-408);
-    DCOLON -> YYAction (-207);
-    SOMEOP -> YYAction (-408);
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction354 t =   case yychar t of {
-  '-' -> YYAction (-407);
-  '.' -> YYAction (-407);
-  '(' -> YYAction (-407);
-  ',' -> YYAction (-208);
-  '|' -> YYAction (-407);
-  '[' -> YYAction (-407);
-  '?' -> YYAction (-407);
-  '!' -> YYAction (-407);
-  '=' -> YYAction (-407);
-  '_' -> YYAction (-407);
-  _ ->   case yytoken t of {
-    VARID -> YYAction (-407);
-    CONID -> YYAction (-407);
-    QUALIFIER -> YYAction (-407);
-    TRUE -> YYAction (-407);
-    FALSE -> YYAction (-407);
-    DO -> YYAction (-407);
-    INTCONST -> YYAction (-407);
-    STRCONST -> YYAction (-407);
-    LONGCONST -> YYAction (-407);
-    FLTCONST -> YYAction (-407);
-    DBLCONST -> YYAction (-407);
-    CHRCONST -> YYAction (-407);
-    REGEXP -> YYAction (-407);
-    BIGCONST -> YYAction (-407);
-    DCOLON -> YYAction (-208);
-    SOMEOP -> YYAction (-407);
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction355 t = YYAction (-29);
-private yyaction356 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '}' -> YYAction 471;
   '(' -> YYAction 124;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
@@ -3510,34 +2916,661 @@ private yyaction356 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction357 t = YYAction (-203);
-private yyaction358 t = YYAction (-205);
-private yyaction359 t = YYAction (-211);
-private yyaction360 t =   case yytoken t of {
-    VARID -> YYAction 260;
-    CONID -> YYAction 261;
-    QUALIFIER -> YYAction 262;
-    STRCONST -> YYAction 263;
+private yyaction291 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
     _ -> (YYAction yyErr);
   };
-private yyaction361 t = YYAction (-8);
+};
+private yyaction292 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction293 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  '}' -> YYAction (-357);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 167;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction294 t = YYAction (-400);
+private yyaction295 t =   case yychar t of {
+  ';' -> YYAction 402;
+  ')' -> YYAction (-451);
+  _ -> (YYAction yyErr);
+};
+private yyaction296 t =   case yychar t of {
+  ')' -> YYAction 403;
+  _ -> (YYAction yyErr);
+};
+private yyaction297 t =   case yychar t of {
+  ',' -> YYAction 184;
+  ')' -> YYAction (-448);
+  ']' -> YYAction (-448);
+  _ ->   case yytoken t of {
+    DOTDOT -> YYAction (-448);
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction298 t =   case yychar t of {
+  ')' -> YYAction 404;
+  _ -> (YYAction yyErr);
+};
+private yyaction299 t = YYAction (-424);
+private yyaction300 t = YYAction (-426);
+private yyaction301 t = YYAction (-425);
+private yyaction302 t = YYAction (-449);
+private yyaction303 t =   case yychar t of {
+  ',' -> YYAction 405;
+  ']' -> YYAction (-353);
+  _ -> (YYAction yyErr);
+};
+private yyaction304 t =   case yychar t of {
+  ']' -> YYAction 406;
+  _ -> (YYAction yyErr);
+};
+private yyaction305 t = YYAction (-432);
+private yyaction306 t =   case yychar t of {
+  ']' -> YYAction 407;
+  _ -> (YYAction yyErr);
+};
+private yyaction307 t = YYAction (-375);
+private yyaction308 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction309 t = YYAction (-418);
+private yyaction310 t =   case yychar t of {
+  '}' -> YYAction (-439);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 192;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction311 t =   case yytoken t of {
+    CONID -> YYAction 157;
+    _ -> (YYAction yyErr);
+  };
+private yyaction312 t = YYAction (-228);
+private yyaction313 t =   case yychar t of {
+  '.' -> YYAction 411;
+  _ ->   case yytoken t of {
+    SOMEOP -> YYAction 410;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction314 t =   case yychar t of {
+  '.' -> YYAction (-226);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 312;
+    SOMEOP -> YYAction (-226);
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction315 t =   case yychar t of {
+  '(' -> YYAction (-252);
+  ')' -> YYAction (-252);
+  ',' -> YYAction (-252);
+  '|' -> YYAction (-252);
+  '[' -> YYAction (-252);
+  _ ->   case yytoken t of {
+    DCOLON -> YYAction 414;
+    VARID -> YYAction (-252);
+    CONID -> YYAction (-252);
+    QUALIFIER -> YYAction (-252);
+    ARROW -> YYAction (-252);
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction316 t =   case yychar t of {
+  ')' -> YYAction 415;
+  _ -> (YYAction yyErr);
+};
+private yyaction317 t = YYAction (-256);
+private yyaction318 t =   case yychar t of {
+  ')' -> YYAction 416;
+  ',' -> YYAction 417;
+  '|' -> YYAction 418;
+  _ -> (YYAction yyErr);
+};
+private yyaction319 t = YYAction (-239);
+private yyaction320 t =   case yychar t of {
+  ';' -> YYAction (-238);
+  '}' -> YYAction (-238);
+  ')' -> YYAction (-238);
+  ',' -> YYAction (-238);
+  '|' -> YYAction (-238);
+  ']' -> YYAction (-238);
+  _ ->   case yytoken t of {
+    ARROW -> YYAction 419;
+    WHERE -> YYAction (-238);
+    CLASS -> YYAction (-238);
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction321 t =   case yychar t of {
+  ')' -> YYAction 420;
+  _ -> (YYAction yyErr);
+};
+private yyaction322 t = YYAction (-255);
+private yyaction323 t =   case yychar t of {
+  ']' -> YYAction 421;
+  _ -> (YYAction yyErr);
+};
+private yyaction324 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction325 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction326 t = YYAction (-309);
+private yyaction327 t =   case yychar t of {
+  '?' -> YYAction 426;
+  '=' -> YYAction 427;
+  '}' -> YYAction (-445);
+  ',' -> YYAction (-445);
+  _ ->   case yytoken t of {
+    GETS -> YYAction 425;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction328 t =   case yychar t of {
+  '}' -> YYAction 428;
+  _ -> (YYAction yyErr);
+};
+private yyaction329 t =   case yychar t of {
+  ']' -> YYAction 429;
+  _ -> (YYAction yyErr);
+};
+private yyaction330 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '}' -> YYAction 430;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction331 t =   case yychar t of {
+  '}' -> YYAction 432;
+  _ -> (YYAction yyErr);
+};
+private yyaction332 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '}' -> YYAction 433;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction333 t = YYAction (-407);
+private yyaction334 t =   case yychar t of {
+  '}' -> YYAction (-442);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 435;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction335 t = YYAction (-2);
+private yyaction336 t =   case yychar t of {
+  '(' -> YYAction (-171);
+  _ ->   case yytoken t of {
+    CONID -> YYAction 437;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction337 t =   case yychar t of {
+  '(' -> YYAction 339;
+  ';' -> YYAction (-145);
+  '}' -> YYAction (-145);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 192;
+    PUBLIC -> YYAction 338;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction338 t =   case yychar t of {
+  '(' -> YYAction 339;
+  ';' -> YYAction (-145);
+  '}' -> YYAction (-145);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 192;
+    PUBLIC -> YYAction 338;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction339 t =   case yychar t of {
+  ')' -> YYAction 443;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 440;
+    QUALIFIER -> YYAction 441;
+    PUBLIC -> YYAction 442;
+    SOMEOP -> YYAction 84;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction340 t = YYAction (-142);
+private yyaction341 t =   case yychar t of {
+  '(' -> YYAction 451;
+  _ -> (YYAction yyErr);
+};
+private yyaction342 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction343 t =   case yytoken t of {
+    CLASS -> YYAction 453;
+    WHERE -> YYAction (-45);
+    _ -> (YYAction yyErr);
+  };
+private yyaction344 t =   case yychar t of {
+  ')' -> YYAction 455;
+  _ -> (YYAction yyErr);
+};
+private yyaction345 t =   case yychar t of {
+  ')' -> YYAction 456;
+  _ -> (YYAction yyErr);
+};
+private yyaction346 t =   case yychar t of {
+  ')' -> YYAction 457;
+  _ -> (YYAction yyErr);
+};
+private yyaction347 t =   case yytoken t of {
+    VARID -> YYAction 458;
+    _ -> (YYAction yyErr);
+  };
+private yyaction348 t =   case yychar t of {
+  '?' -> YYAction 467;
+  '!' -> YYAction 468;
+  _ ->   case yytoken t of {
+    CONID -> YYAction 459;
+    DOCUMENTATION -> YYAction 460;
+    NATIVE -> YYAction 461;
+    PRIVATE -> YYAction 462;
+    PROTECTED -> YYAction 463;
+    PUBLIC -> YYAction 464;
+    PURE -> YYAction 465;
+    MUTABLE -> YYAction 466;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction349 t =   case yychar t of {
+  '(' -> YYAction 347;
+  '=' -> YYAction (-290);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction350 t =   case yychar t of {
+  '=' -> YYAction 476;
+  _ -> (YYAction yyErr);
+};
+private yyaction351 t =   case yychar t of {
+  ',' -> YYAction 477;
+  ')' -> YYAction (-265);
+  _ -> (YYAction yyErr);
+};
+private yyaction352 t =   case yychar t of {
+  ')' -> YYAction 478;
+  _ -> (YYAction yyErr);
+};
+private yyaction353 t = YYAction (-264);
+private yyaction354 t =   case yytoken t of {
+    CONID -> YYAction 479;
+    _ -> (YYAction yyErr);
+  };
+private yyaction355 t = YYAction (-271);
+private yyaction356 t =   case yychar t of {
+  ',' -> YYAction 480;
+  ')' -> YYAction (-273);
+  _ -> (YYAction yyErr);
+};
+private yyaction357 t =   case yychar t of {
+  ')' -> YYAction 481;
+  _ -> (YYAction yyErr);
+};
+private yyaction358 t = YYAction (-272);
+private yyaction359 t =   case yychar t of {
+  '(' -> YYAction 482;
+  '[' -> YYAction 483;
+  _ ->   case yytoken t of {
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction360 t = YYAction (-280);
+private yyaction361 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
+};
 private yyaction362 t =   case yychar t of {
+  '=' -> YYAction 486;
+  _ -> (YYAction yyErr);
+};
+private yyaction363 t =   case yychar t of {
+  '-' -> YYAction (-423);
+  '.' -> YYAction (-423);
+  '(' -> YYAction (-423);
+  ',' -> YYAction (-209);
+  '|' -> YYAction (-423);
+  '[' -> YYAction (-423);
+  '?' -> YYAction (-423);
+  '!' -> YYAction (-423);
+  '=' -> YYAction (-423);
+  '_' -> YYAction (-423);
+  _ ->   case yytoken t of {
+    VARID -> YYAction (-423);
+    CONID -> YYAction (-423);
+    QUALIFIER -> YYAction (-423);
+    TRUE -> YYAction (-423);
+    FALSE -> YYAction (-423);
+    DO -> YYAction (-423);
+    INTCONST -> YYAction (-423);
+    STRCONST -> YYAction (-423);
+    LONGCONST -> YYAction (-423);
+    FLTCONST -> YYAction (-423);
+    DBLCONST -> YYAction (-423);
+    CHRCONST -> YYAction (-423);
+    REGEXP -> YYAction (-423);
+    BIGCONST -> YYAction (-423);
+    DCOLON -> YYAction (-209);
+    SOMEOP -> YYAction (-423);
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction364 t =   case yychar t of {
+  '-' -> YYAction (-422);
+  '.' -> YYAction (-422);
+  '(' -> YYAction (-422);
+  ',' -> YYAction (-207);
+  '|' -> YYAction (-422);
+  '[' -> YYAction (-422);
+  '?' -> YYAction (-422);
+  '!' -> YYAction (-422);
+  '=' -> YYAction (-422);
+  '_' -> YYAction (-422);
+  _ ->   case yytoken t of {
+    VARID -> YYAction (-422);
+    CONID -> YYAction (-422);
+    QUALIFIER -> YYAction (-422);
+    TRUE -> YYAction (-422);
+    FALSE -> YYAction (-422);
+    DO -> YYAction (-422);
+    INTCONST -> YYAction (-422);
+    STRCONST -> YYAction (-422);
+    LONGCONST -> YYAction (-422);
+    FLTCONST -> YYAction (-422);
+    DBLCONST -> YYAction (-422);
+    CHRCONST -> YYAction (-422);
+    REGEXP -> YYAction (-422);
+    BIGCONST -> YYAction (-422);
+    DCOLON -> YYAction (-207);
+    SOMEOP -> YYAction (-422);
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction365 t =   case yychar t of {
+  '-' -> YYAction (-421);
+  '.' -> YYAction (-421);
+  '(' -> YYAction (-421);
+  ',' -> YYAction (-208);
+  '|' -> YYAction (-421);
+  '[' -> YYAction (-421);
+  '?' -> YYAction (-421);
+  '!' -> YYAction (-421);
+  '=' -> YYAction (-421);
+  '_' -> YYAction (-421);
+  _ ->   case yytoken t of {
+    VARID -> YYAction (-421);
+    CONID -> YYAction (-421);
+    QUALIFIER -> YYAction (-421);
+    TRUE -> YYAction (-421);
+    FALSE -> YYAction (-421);
+    DO -> YYAction (-421);
+    INTCONST -> YYAction (-421);
+    STRCONST -> YYAction (-421);
+    LONGCONST -> YYAction (-421);
+    FLTCONST -> YYAction (-421);
+    DBLCONST -> YYAction (-421);
+    CHRCONST -> YYAction (-421);
+    REGEXP -> YYAction (-421);
+    BIGCONST -> YYAction (-421);
+    DCOLON -> YYAction (-208);
+    SOMEOP -> YYAction (-421);
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction366 t = YYAction (-29);
+private yyaction367 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '}' -> YYAction 487;
+  '(' -> YYAction 124;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 107;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction368 t = YYAction (-203);
+private yyaction369 t = YYAction (-205);
+private yyaction370 t = YYAction (-211);
+private yyaction371 t =   case yytoken t of {
+    VARID -> YYAction 265;
+    CONID -> YYAction 266;
+    QUALIFIER -> YYAction 267;
+    STRCONST -> YYAction 268;
+    _ -> (YYAction yyErr);
+  };
+private yyaction372 t = YYAction (-8);
+private yyaction373 t =   case yychar t of {
   ';' -> YYAction (-219);
   '}' -> YYAction (-219);
   '|' -> YYAction (-219);
   _ ->   case yytoken t of {
-    THROWS -> YYAction 474;
+    THROWS -> YYAction 490;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction363 t =   case yychar t of {
-  '|' -> YYAction 475;
+private yyaction374 t =   case yychar t of {
+  '|' -> YYAction 491;
   ';' -> YYAction (-220);
   '}' -> YYAction (-220);
   _ -> (YYAction yyErr);
 };
-private yyaction364 t = YYAction (-222);
-private yyaction365 t =   case yychar t of {
+private yyaction375 t = YYAction (-222);
+private yyaction376 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
@@ -3548,7 +3581,7 @@ private yyaction365 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction366 t =   case yychar t of {
+private yyaction377 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
@@ -3559,7 +3592,7 @@ private yyaction366 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction367 t =   case yychar t of {
+private yyaction378 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
@@ -3570,9 +3603,9 @@ private yyaction367 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction368 t =   case yychar t of {
+private yyaction379 t =   case yychar t of {
   '-' -> YYAction 41;
-  '}' -> YYAction 482;
+  '}' -> YYAction 498;
   '(' -> YYAction 124;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
@@ -3584,16 +3617,16 @@ private yyaction368 t =   case yychar t of {
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
     DOCUMENTATION -> YYAction 108;
-    NATIVE -> YYAction 241;
+    NATIVE -> YYAction 246;
     TRUE -> YYAction 27;
     FALSE -> YYAction 28;
     IF -> YYAction 29;
     CASE -> YYAction 30;
     LET -> YYAction 31;
     DO -> YYAction 32;
-    PRIVATE -> YYAction 479;
-    PROTECTED -> YYAction 480;
-    PUBLIC -> YYAction 481;
+    PRIVATE -> YYAction 495;
+    PROTECTED -> YYAction 496;
+    PUBLIC -> YYAction 497;
     PURE -> YYAction 123;
     INTCONST -> YYAction 33;
     STRCONST -> YYAction 34;
@@ -3606,33 +3639,33 @@ private yyaction368 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction369 t =   case yychar t of {
-  ',' -> YYAction (-345);
-  '=' -> YYAction (-345);
+private yyaction380 t =   case yychar t of {
+  ',' -> YYAction (-359);
+  '=' -> YYAction (-359);
   _ ->   case yytoken t of {
-    GETS -> YYAction 286;
-    ARROW -> YYAction (-345);
+    GETS -> YYAction 291;
+    ARROW -> YYAction (-359);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction370 t =   case yychar t of {
-  ',' -> YYAction 488;
-  '=' -> YYAction (-347);
+private yyaction381 t =   case yychar t of {
+  ',' -> YYAction 504;
+  '=' -> YYAction (-361);
   _ ->   case yytoken t of {
-    ARROW -> YYAction (-347);
+    ARROW -> YYAction (-361);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction371 t =   case yychar t of {
-  '=' -> YYAction 490;
+private yyaction382 t =   case yychar t of {
+  '=' -> YYAction 506;
   _ ->   case yytoken t of {
-    ARROW -> YYAction 489;
+    ARROW -> YYAction 505;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction372 t = YYAction (-319);
-private yyaction373 t = YYAction (-352);
-private yyaction374 t =   case yychar t of {
+private yyaction383 t = YYAction (-333);
+private yyaction384 t = YYAction (-366);
+private yyaction385 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
@@ -3640,110 +3673,23 @@ private yyaction374 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction375 t = YYAction (-190);
-private yyaction376 t = YYAction (-21);
-private yyaction377 t =   case yychar t of {
+private yyaction386 t = YYAction (-190);
+private yyaction387 t = YYAction (-21);
+private yyaction388 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
     VARID -> YYAction 74;
-    QUALIFIER -> YYAction 274;
+    QUALIFIER -> YYAction 279;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction378 t = YYAction (-367);
-private yyaction379 t =   case yytoken t of {
-    ELSE -> YYAction 494;
+private yyaction389 t = YYAction (-381);
+private yyaction390 t =   case yytoken t of {
+    ELSE -> YYAction 510;
     _ -> (YYAction yyErr);
   };
-private yyaction380 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction381 t = YYAction (-333);
-private yyaction382 t =   case yychar t of {
-  '|' -> YYAction 270;
-  '=' -> YYAction 490;
-  _ ->   case yytoken t of {
-    ARROW -> YYAction 489;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction383 t =   case yychar t of {
-  ';' -> YYAction 498;
-  '}' -> YYAction (-356);
-  _ ->   case yytoken t of {
-    WHERE -> YYAction 251;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction384 t =   case yychar t of {
-  '}' -> YYAction 500;
-  _ -> (YYAction yyErr);
-};
-private yyaction385 t = YYAction (-141);
-private yyaction386 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction387 t =   case yychar t of {
-  '}' -> YYAction 502;
-  _ -> (YYAction yyErr);
-};
-private yyaction388 t = YYAction (-346);
-private yyaction389 t = YYAction (-337);
-private yyaction390 t = YYAction (-344);
 private yyaction391 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
@@ -3752,7 +3698,6 @@ private yyaction391 t =   case yychar t of {
   '!' -> YYAction 45;
   '\\' -> YYAction 46;
   '_' -> YYAction 47;
-  ')' -> YYAction (-439);
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
     CONID -> YYAction 25;
@@ -3774,9 +3719,29 @@ private yyaction391 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction392 t = YYAction (-414);
-private yyaction393 t = YYAction (-413);
+private yyaction392 t = YYAction (-347);
+private yyaction393 t =   case yychar t of {
+  '|' -> YYAction 275;
+  '=' -> YYAction 506;
+  _ ->   case yytoken t of {
+    ARROW -> YYAction 505;
+    _ -> (YYAction yyErr);
+  };
+};
 private yyaction394 t =   case yychar t of {
+  ';' -> YYAction 514;
+  '}' -> YYAction (-370);
+  _ ->   case yytoken t of {
+    WHERE -> YYAction 256;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction395 t =   case yychar t of {
+  '}' -> YYAction 516;
+  _ -> (YYAction yyErr);
+};
+private yyaction396 t = YYAction (-141);
+private yyaction397 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -3784,7 +3749,75 @@ private yyaction394 t =   case yychar t of {
   '!' -> YYAction 45;
   '\\' -> YYAction 46;
   '_' -> YYAction 47;
-  ']' -> YYAction (-341);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction398 t =   case yychar t of {
+  '}' -> YYAction 518;
+  _ -> (YYAction yyErr);
+};
+private yyaction399 t = YYAction (-360);
+private yyaction400 t = YYAction (-351);
+private yyaction401 t = YYAction (-358);
+private yyaction402 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  ')' -> YYAction (-453);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction403 t = YYAction (-428);
+private yyaction404 t = YYAction (-427);
+private yyaction405 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  ']' -> YYAction (-355);
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
     CONID -> YYAction 25;
@@ -3806,13 +3839,13 @@ private yyaction394 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction395 t = YYAction (-420);
-private yyaction396 t = YYAction (-419);
-private yyaction397 t = YYAction (-432);
-private yyaction398 t = YYAction (-424);
-private yyaction399 t = YYAction (-233);
-private yyaction400 t = YYAction (-232);
-private yyaction401 t =   case yychar t of {
+private yyaction406 t = YYAction (-434);
+private yyaction407 t = YYAction (-433);
+private yyaction408 t = YYAction (-446);
+private yyaction409 t = YYAction (-438);
+private yyaction410 t = YYAction (-233);
+private yyaction411 t = YYAction (-232);
+private yyaction412 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
@@ -3822,29 +3855,18 @@ private yyaction401 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction402 t = YYAction (-227);
-private yyaction403 t =   case yychar t of {
-  '(' -> YYAction 508;
+private yyaction413 t = YYAction (-227);
+private yyaction414 t =   case yychar t of {
+  '(' -> YYAction 524;
   _ ->   case yytoken t of {
-    VARID -> YYAction 506;
-    SOMEOP -> YYAction 507;
+    VARID -> YYAction 522;
+    SOMEOP -> YYAction 523;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction404 t = YYAction (-258);
-private yyaction405 t = YYAction (-248);
-private yyaction406 t =   case yychar t of {
-  '(' -> YYAction 200;
-  '[' -> YYAction 201;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 197;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 198;
-    FORALL -> YYAction 199;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction407 t =   case yychar t of {
+private yyaction415 t = YYAction (-258);
+private yyaction416 t = YYAction (-248);
+private yyaction417 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
@@ -3855,7 +3877,7 @@ private yyaction407 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction408 t =   case yychar t of {
+private yyaction418 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
@@ -3866,9 +3888,20 @@ private yyaction408 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction409 t = YYAction (-257);
-private yyaction410 t = YYAction (-251);
-private yyaction411 t =   case yychar t of {
+private yyaction419 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction420 t = YYAction (-257);
+private yyaction421 t = YYAction (-251);
+private yyaction422 t =   case yychar t of {
   '-' -> YYAction (-236);
   ';' -> YYAction (-236);
   '}' -> YYAction (-236);
@@ -3878,7 +3911,7 @@ private yyaction411 t =   case yychar t of {
   ']' -> YYAction (-236);
   '=' -> YYAction (-236);
   _ ->   case yytoken t of {
-    ARROW -> YYAction 319;
+    ARROW -> YYAction 324;
     DOCUMENTATION -> YYAction (-236);
     WHERE -> YYAction (-236);
     CLASS -> YYAction (-236);
@@ -3888,17 +3921,16 @@ private yyaction411 t =   case yychar t of {
     THROWS -> YYAction (-236);
     DCOLON -> YYAction (-236);
     GETS -> YYAction (-236);
-    EARROW -> YYAction (-236);
     DOTDOT -> YYAction (-236);
     SOMEOP -> YYAction (-236);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction412 t = YYAction (-237);
-private yyaction413 t = YYAction (-234);
-private yyaction414 t =   case yychar t of {
+private yyaction423 t = YYAction (-237);
+private yyaction424 t = YYAction (-234);
+private yyaction425 t =   case yychar t of {
   '-' -> YYAction 41;
-  '}' -> YYAction 516;
+  '}' -> YYAction 532;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
@@ -3926,13 +3958,13 @@ private yyaction414 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction415 t =   case yychar t of {
-  '}' -> YYAction 517;
+private yyaction426 t =   case yychar t of {
+  '}' -> YYAction 533;
   _ -> (YYAction yyErr);
 };
-private yyaction416 t =   case yychar t of {
+private yyaction427 t =   case yychar t of {
   '-' -> YYAction 41;
-  '}' -> YYAction 518;
+  '}' -> YYAction 534;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
   '?' -> YYAction 44;
@@ -3960,37 +3992,37 @@ private yyaction416 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction417 t = YYAction (-397);
-private yyaction418 t = YYAction (-398);
-private yyaction419 t = YYAction (-392);
-private yyaction420 t = YYAction (-429);
-private yyaction421 t = YYAction (-390);
-private yyaction422 t = YYAction (-391);
-private yyaction423 t = YYAction (-430);
-private yyaction424 t =   case yychar t of {
-  '=' -> YYAction 520;
-  '}' -> YYAction (-431);
-  ',' -> YYAction (-431);
+private yyaction428 t = YYAction (-411);
+private yyaction429 t = YYAction (-412);
+private yyaction430 t = YYAction (-406);
+private yyaction431 t = YYAction (-443);
+private yyaction432 t = YYAction (-404);
+private yyaction433 t = YYAction (-405);
+private yyaction434 t = YYAction (-444);
+private yyaction435 t =   case yychar t of {
+  '=' -> YYAction 536;
+  '}' -> YYAction (-445);
+  ',' -> YYAction (-445);
   _ ->   case yytoken t of {
-    GETS -> YYAction 519;
+    GETS -> YYAction 535;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction425 t = YYAction (-427);
-private yyaction426 t =   case yychar t of {
-  '(' -> YYAction 334;
+private yyaction436 t = YYAction (-441);
+private yyaction437 t =   case yychar t of {
+  '(' -> YYAction 339;
   ';' -> YYAction (-145);
   '}' -> YYAction (-145);
   _ ->   case yytoken t of {
     VARID -> YYAction 192;
-    PUBLIC -> YYAction 333;
+    PUBLIC -> YYAction 338;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction427 t = YYAction (-144);
-private yyaction428 t = YYAction (-149);
-private yyaction429 t =   case yychar t of {
-  '(' -> YYAction 522;
+private yyaction438 t = YYAction (-144);
+private yyaction439 t = YYAction (-149);
+private yyaction440 t =   case yychar t of {
+  '(' -> YYAction 538;
   ')' -> YYAction (-186);
   ',' -> YYAction (-186);
   _ ->   case yytoken t of {
@@ -4000,66 +4032,66 @@ private yyaction429 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction430 t =   case yychar t of {
+private yyaction441 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
     VARID -> YYAction 74;
     CONID -> YYAction 75;
-    QUALIFIER -> YYAction 523;
+    QUALIFIER -> YYAction 539;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction431 t =   case yychar t of {
+private yyaction442 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
-    CONID -> YYAction 429;
-    QUALIFIER -> YYAction 430;
-    PUBLIC -> YYAction 431;
+    CONID -> YYAction 440;
+    QUALIFIER -> YYAction 441;
+    PUBLIC -> YYAction 442;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction432 t = YYAction (-147);
-private yyaction433 t =   case yychar t of {
-  ')' -> YYAction 525;
+private yyaction443 t = YYAction (-147);
+private yyaction444 t =   case yychar t of {
+  ')' -> YYAction 541;
   _ -> (YYAction yyErr);
 };
-private yyaction434 t =   case yychar t of {
-  ',' -> YYAction 526;
+private yyaction445 t =   case yychar t of {
+  ',' -> YYAction 542;
   ')' -> YYAction (-150);
   _ -> (YYAction yyErr);
 };
-private yyaction435 t =   case yychar t of {
+private yyaction446 t =   case yychar t of {
   ')' -> YYAction (-159);
   ',' -> YYAction (-159);
   _ ->   case yytoken t of {
-    VARID -> YYAction 527;
-    CONID -> YYAction 528;
+    VARID -> YYAction 543;
+    CONID -> YYAction 544;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction436 t = YYAction (-153);
-private yyaction437 t = YYAction (-156);
-private yyaction438 t = YYAction (-157);
-private yyaction439 t = YYAction (-158);
-private yyaction440 t =   case yychar t of {
+private yyaction447 t = YYAction (-153);
+private yyaction448 t = YYAction (-156);
+private yyaction449 t = YYAction (-157);
+private yyaction450 t = YYAction (-158);
+private yyaction451 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
-    CONID -> YYAction 429;
-    QUALIFIER -> YYAction 430;
-    PUBLIC -> YYAction 431;
+    CONID -> YYAction 440;
+    QUALIFIER -> YYAction 441;
+    PUBLIC -> YYAction 442;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction441 t = YYAction (-44);
-private yyaction442 t =   case yychar t of {
+private yyaction452 t = YYAction (-44);
+private yyaction453 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
@@ -4067,277 +4099,318 @@ private yyaction442 t =   case yychar t of {
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 198;
     FORALL -> YYAction 199;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction443 t =   case yytoken t of {
-    WHERE -> YYAction 533;
-    _ -> (YYAction yyErr);
-  };
-private yyaction444 t = YYAction (-209);
-private yyaction445 t = YYAction (-207);
-private yyaction446 t = YYAction (-208);
-private yyaction447 t =   case yytoken t of {
-    DCOLON -> YYAction 403;
-    _ -> (YYAction yyErr);
-  };
-private yyaction448 t =   case yychar t of {
-  '{' -> YYAction 535;
-  '(' -> YYAction 200;
-  '[' -> YYAction 201;
-  ';' -> YYAction (-290);
-  '}' -> YYAction (-290);
-  '|' -> YYAction (-290);
-  _ ->   case yytoken t of {
-    VARID -> YYAction 197;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 198;
-    DOCUMENTATION -> YYAction (-290);
-    WHERE -> YYAction (-290);
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction449 t =   case yychar t of {
-  '?' -> YYAction 456;
-  '!' -> YYAction 457;
-  _ ->   case yytoken t of {
-    CONID -> YYAction 448;
-    PRIVATE -> YYAction 451;
-    PROTECTED -> YYAction 452;
-    PUBLIC -> YYAction 453;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction450 t = YYAction (-271);
-private yyaction451 t =   case yychar t of {
-  '?' -> YYAction 456;
-  '!' -> YYAction 457;
-  _ ->   case yytoken t of {
-    CONID -> YYAction 448;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction452 t =   case yychar t of {
-  '?' -> YYAction 456;
-  '!' -> YYAction 457;
-  _ ->   case yytoken t of {
-    CONID -> YYAction 448;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction453 t =   case yychar t of {
-  '?' -> YYAction 456;
-  '!' -> YYAction 457;
-  _ ->   case yytoken t of {
-    CONID -> YYAction 448;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction454 t =   case yytoken t of {
-    NATIVE -> YYAction 542;
+    WHERE -> YYAction 549;
     _ -> (YYAction yyErr);
   };
-private yyaction455 t =   case yytoken t of {
-    NATIVE -> YYAction 543;
-    _ -> (YYAction yyErr);
-  };
-private yyaction456 t =   case yytoken t of {
-    CONID -> YYAction 448;
-    _ -> (YYAction yyErr);
-  };
-private yyaction457 t =   case yytoken t of {
-    CONID -> YYAction 448;
-    _ -> (YYAction yyErr);
-  };
+private yyaction455 t = YYAction (-209);
+private yyaction456 t = YYAction (-207);
+private yyaction457 t = YYAction (-208);
 private yyaction458 t =   case yytoken t of {
-    VARID -> YYAction 260;
-    CONID -> YYAction 261;
-    QUALIFIER -> YYAction 262;
-    STRCONST -> YYAction 263;
+    DCOLON -> YYAction 414;
     _ -> (YYAction yyErr);
   };
-private yyaction459 t = YYAction (-275);
+private yyaction459 t =   case yychar t of {
+  '{' -> YYAction 551;
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  ';' -> YYAction (-304);
+  '}' -> YYAction (-304);
+  '|' -> YYAction (-304);
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    DOCUMENTATION -> YYAction (-304);
+    WHERE -> YYAction (-304);
+    _ -> (YYAction yyErr);
+  };
+};
 private yyaction460 t =   case yychar t of {
-  '|' -> YYAction 547;
-  ';' -> YYAction (-278);
-  '}' -> YYAction (-278);
+  '?' -> YYAction 467;
+  '!' -> YYAction 468;
   _ ->   case yytoken t of {
-    WHERE -> YYAction (-278);
+    CONID -> YYAction 459;
+    PRIVATE -> YYAction 462;
+    PROTECTED -> YYAction 463;
+    PUBLIC -> YYAction 464;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction461 t =   case yychar t of {
-  ';' -> YYAction (-280);
-  '}' -> YYAction (-280);
-  '|' -> YYAction (-280);
+private yyaction461 t = YYAction (-285);
+private yyaction462 t =   case yychar t of {
+  '?' -> YYAction 467;
+  '!' -> YYAction 468;
   _ ->   case yytoken t of {
-    DOCUMENTATION -> YYAction 548;
-    WHERE -> YYAction (-280);
+    CONID -> YYAction 459;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction462 t = YYAction (-283);
-private yyaction463 t = YYAction (-289);
-private yyaction464 t = YYAction (-277);
-private yyaction465 t =   case yychar t of {
-  '?' -> YYAction 456;
-  '!' -> YYAction 457;
+private yyaction463 t =   case yychar t of {
+  '?' -> YYAction 467;
+  '!' -> YYAction 468;
   _ ->   case yytoken t of {
-    CONID -> YYAction 448;
-    DOCUMENTATION -> YYAction 449;
-    NATIVE -> YYAction 450;
-    PRIVATE -> YYAction 451;
-    PROTECTED -> YYAction 452;
-    PUBLIC -> YYAction 453;
-    PURE -> YYAction 454;
-    MUTABLE -> YYAction 455;
+    CONID -> YYAction 459;
     _ -> (YYAction yyErr);
   };
 };
+private yyaction464 t =   case yychar t of {
+  '?' -> YYAction 467;
+  '!' -> YYAction 468;
+  _ ->   case yytoken t of {
+    CONID -> YYAction 459;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction465 t =   case yytoken t of {
+    NATIVE -> YYAction 558;
+    _ -> (YYAction yyErr);
+  };
 private yyaction466 t =   case yytoken t of {
-    VARID -> YYAction 192;
+    NATIVE -> YYAction 559;
     _ -> (YYAction yyErr);
   };
-private yyaction467 t = YYAction (-264);
-private yyaction468 t = YYAction (-266);
-private yyaction469 t = YYAction (-312);
-private yyaction470 t =   case yychar t of {
-  '(' -> YYAction 200;
-  '[' -> YYAction 201;
+private yyaction467 t =   case yytoken t of {
+    CONID -> YYAction 459;
+    _ -> (YYAction yyErr);
+  };
+private yyaction468 t =   case yytoken t of {
+    CONID -> YYAction 459;
+    _ -> (YYAction yyErr);
+  };
+private yyaction469 t =   case yytoken t of {
+    VARID -> YYAction 265;
+    CONID -> YYAction 266;
+    QUALIFIER -> YYAction 267;
+    STRCONST -> YYAction 268;
+    _ -> (YYAction yyErr);
+  };
+private yyaction470 t = YYAction (-289);
+private yyaction471 t =   case yychar t of {
+  '|' -> YYAction 563;
+  ';' -> YYAction (-292);
+  '}' -> YYAction (-292);
   _ ->   case yytoken t of {
-    VARID -> YYAction 197;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 198;
-    FORALL -> YYAction 199;
+    WHERE -> YYAction (-292);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction471 t = YYAction (-317);
 private yyaction472 t =   case yychar t of {
-  '}' -> YYAction 553;
-  _ -> (YYAction yyErr);
-};
-private yyaction473 t = YYAction (-7);
-private yyaction474 t =   case yychar t of {
-  '(' -> YYAction 200;
-  '[' -> YYAction 201;
+  ';' -> YYAction (-294);
+  '}' -> YYAction (-294);
+  '|' -> YYAction (-294);
   _ ->   case yytoken t of {
-    VARID -> YYAction 197;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 198;
-    FORALL -> YYAction 199;
+    DOCUMENTATION -> YYAction 564;
+    WHERE -> YYAction (-294);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction475 t =   case yychar t of {
-  '(' -> YYAction 200;
-  '[' -> YYAction 201;
+private yyaction473 t = YYAction (-297);
+private yyaction474 t = YYAction (-303);
+private yyaction475 t = YYAction (-291);
+private yyaction476 t =   case yychar t of {
+  '?' -> YYAction 467;
+  '!' -> YYAction 468;
   _ ->   case yytoken t of {
-    VARID -> YYAction 197;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 198;
-    FORALL -> YYAction 199;
+    CONID -> YYAction 459;
+    DOCUMENTATION -> YYAction 460;
+    NATIVE -> YYAction 461;
+    PRIVATE -> YYAction 462;
+    PROTECTED -> YYAction 463;
+    PUBLIC -> YYAction 464;
+    PURE -> YYAction 465;
+    MUTABLE -> YYAction 466;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction476 t = YYAction (-223);
-private yyaction477 t = YYAction (-224);
-private yyaction478 t = YYAction (-225);
+private yyaction477 t =   case yychar t of {
+  ')' -> YYAction (-266);
+  _ ->   case yytoken t of {
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction478 t = YYAction (-269);
 private yyaction479 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 124;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
+  '(' -> YYAction 347;
   _ ->   case yytoken t of {
-    VARID -> YYAction 107;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    NATIVE -> YYAction 241;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    PURE -> YYAction 123;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
+    VARID -> YYAction 197;
     _ -> (YYAction yyErr);
   };
 };
 private yyaction480 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 124;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
+  ')' -> YYAction (-274);
   _ ->   case yytoken t of {
-    VARID -> YYAction 107;
     CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    NATIVE -> YYAction 241;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    PURE -> YYAction 123;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
+    QUALIFIER -> YYAction 198;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction481 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 124;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
+private yyaction481 t = YYAction (-277);
+private yyaction482 t =   case yychar t of {
+  ')' -> YYAction 317;
+  ',' -> YYAction 87;
   _ ->   case yytoken t of {
-    VARID -> YYAction 107;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    NATIVE -> YYAction 241;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    PURE -> YYAction 123;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
+    ARROW -> YYAction 316;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction482 t = YYAction (-315);
 private yyaction483 t =   case yychar t of {
+  ']' -> YYAction 322;
+  _ -> (YYAction yyErr);
+};
+private yyaction484 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction485 t = YYAction (-326);
+private yyaction486 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction487 t = YYAction (-331);
+private yyaction488 t =   case yychar t of {
+  '}' -> YYAction 572;
+  _ -> (YYAction yyErr);
+};
+private yyaction489 t = YYAction (-7);
+private yyaction490 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction491 t =   case yychar t of {
+  '(' -> YYAction 200;
+  '[' -> YYAction 201;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 197;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 198;
+    FORALL -> YYAction 199;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction492 t = YYAction (-223);
+private yyaction493 t = YYAction (-224);
+private yyaction494 t = YYAction (-225);
+private yyaction495 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 124;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 107;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    NATIVE -> YYAction 246;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    PURE -> YYAction 123;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction496 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 124;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 107;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    NATIVE -> YYAction 246;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    PURE -> YYAction 123;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction497 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 124;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 107;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    NATIVE -> YYAction 246;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    PURE -> YYAction 123;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction498 t = YYAction (-329);
+private yyaction499 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 124;
   '[' -> YYAction 43;
@@ -4352,16 +4425,16 @@ private yyaction483 t =   case yychar t of {
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
     DOCUMENTATION -> YYAction 108;
-    NATIVE -> YYAction 241;
+    NATIVE -> YYAction 246;
     TRUE -> YYAction 27;
     FALSE -> YYAction 28;
     IF -> YYAction 29;
     CASE -> YYAction 30;
     LET -> YYAction 31;
     DO -> YYAction 32;
-    PRIVATE -> YYAction 479;
-    PROTECTED -> YYAction 480;
-    PUBLIC -> YYAction 481;
+    PRIVATE -> YYAction 495;
+    PROTECTED -> YYAction 496;
+    PUBLIC -> YYAction 497;
     PURE -> YYAction 123;
     INTCONST -> YYAction 33;
     STRCONST -> YYAction 34;
@@ -4374,18 +4447,18 @@ private yyaction483 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction484 t = YYAction (-130);
-private yyaction485 t =   case yychar t of {
-  '}' -> YYAction 560;
+private yyaction500 t = YYAction (-130);
+private yyaction501 t =   case yychar t of {
+  '}' -> YYAction 579;
   _ -> (YYAction yyErr);
 };
-private yyaction486 t =   case yychar t of {
+private yyaction502 t =   case yychar t of {
   ';' -> YYAction 8;
   '}' -> YYAction (-124);
   _ -> (YYAction yyErr);
 };
-private yyaction487 t = YYAction (-136);
-private yyaction488 t =   case yychar t of {
+private yyaction503 t = YYAction (-136);
+private yyaction504 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -4393,7 +4466,7 @@ private yyaction488 t =   case yychar t of {
   '!' -> YYAction 45;
   '\\' -> YYAction 46;
   '_' -> YYAction 47;
-  '=' -> YYAction (-349);
+  '=' -> YYAction (-363);
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
     CONID -> YYAction 25;
@@ -4412,47 +4485,13 @@ private yyaction488 t =   case yychar t of {
     CHRCONST -> YYAction 38;
     REGEXP -> YYAction 39;
     BIGCONST -> YYAction 40;
-    ARROW -> YYAction (-349);
+    ARROW -> YYAction (-363);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction489 t = YYAction (-334);
-private yyaction490 t = YYAction (-335);
-private yyaction491 t =   case yychar t of {
-  '-' -> YYAction 41;
-  '(' -> YYAction 42;
-  '[' -> YYAction 43;
-  '?' -> YYAction 44;
-  '!' -> YYAction 45;
-  '\\' -> YYAction 46;
-  '_' -> YYAction 47;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 24;
-    CONID -> YYAction 25;
-    QUALIFIER -> YYAction 26;
-    TRUE -> YYAction 27;
-    FALSE -> YYAction 28;
-    IF -> YYAction 29;
-    CASE -> YYAction 30;
-    LET -> YYAction 31;
-    DO -> YYAction 32;
-    INTCONST -> YYAction 33;
-    STRCONST -> YYAction 34;
-    LONGCONST -> YYAction 35;
-    FLTCONST -> YYAction 36;
-    DBLCONST -> YYAction 37;
-    CHRCONST -> YYAction 38;
-    REGEXP -> YYAction 39;
-    BIGCONST -> YYAction 40;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction492 t = YYAction (-189);
-private yyaction493 t = YYAction (-180);
-private yyaction494 t = YYAction (-366);
-private yyaction495 t = YYAction (-372);
-private yyaction496 t = YYAction (-354);
-private yyaction497 t =   case yychar t of {
+private yyaction505 t = YYAction (-348);
+private yyaction506 t = YYAction (-349);
+private yyaction507 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -4481,7 +4520,12 @@ private yyaction497 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction498 t =   case yychar t of {
+private yyaction508 t = YYAction (-189);
+private yyaction509 t = YYAction (-180);
+private yyaction510 t = YYAction (-380);
+private yyaction511 t = YYAction (-386);
+private yyaction512 t = YYAction (-368);
+private yyaction513 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -4489,7 +4533,6 @@ private yyaction498 t =   case yychar t of {
   '!' -> YYAction 45;
   '\\' -> YYAction 46;
   '_' -> YYAction 47;
-  '}' -> YYAction (-358);
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
     CONID -> YYAction 25;
@@ -4511,45 +4554,75 @@ private yyaction498 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction499 t = YYAction (-355);
-private yyaction500 t = YYAction (-373);
-private yyaction501 t = YYAction (-374);
-private yyaction502 t =   case yychar t of {
-  ';' -> YYAction (-338);
-  '}' -> YYAction (-338);
-  ',' -> YYAction (-338);
-  ']' -> YYAction (-338);
+private yyaction514 t =   case yychar t of {
+  '-' -> YYAction 41;
+  '(' -> YYAction 42;
+  '[' -> YYAction 43;
+  '?' -> YYAction 44;
+  '!' -> YYAction 45;
+  '\\' -> YYAction 46;
+  '_' -> YYAction 47;
+  '}' -> YYAction (-372);
   _ ->   case yytoken t of {
-    IN -> YYAction 386;
+    VARID -> YYAction 24;
+    CONID -> YYAction 25;
+    QUALIFIER -> YYAction 26;
+    TRUE -> YYAction 27;
+    FALSE -> YYAction 28;
+    IF -> YYAction 29;
+    CASE -> YYAction 30;
+    LET -> YYAction 31;
+    DO -> YYAction 32;
+    INTCONST -> YYAction 33;
+    STRCONST -> YYAction 34;
+    LONGCONST -> YYAction 35;
+    FLTCONST -> YYAction 36;
+    DBLCONST -> YYAction 37;
+    CHRCONST -> YYAction 38;
+    REGEXP -> YYAction 39;
+    BIGCONST -> YYAction 40;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction503 t = YYAction (-438);
-private yyaction504 t = YYAction (-340);
-private yyaction505 t = YYAction (-231);
-private yyaction506 t = YYAction (-262);
-private yyaction507 t = YYAction (-261);
-private yyaction508 t =   case yychar t of {
-  '(' -> YYAction 508;
+private yyaction515 t = YYAction (-369);
+private yyaction516 t = YYAction (-387);
+private yyaction517 t = YYAction (-388);
+private yyaction518 t =   case yychar t of {
+  ';' -> YYAction (-352);
+  '}' -> YYAction (-352);
+  ',' -> YYAction (-352);
+  ']' -> YYAction (-352);
   _ ->   case yytoken t of {
-    VARID -> YYAction 506;
-    SOMEOP -> YYAction 507;
+    IN -> YYAction 397;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction509 t =   case yychar t of {
-  ')' -> YYAction 567;
+private yyaction519 t = YYAction (-452);
+private yyaction520 t = YYAction (-354);
+private yyaction521 t = YYAction (-231);
+private yyaction522 t = YYAction (-262);
+private yyaction523 t = YYAction (-261);
+private yyaction524 t =   case yychar t of {
+  '(' -> YYAction 524;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 522;
+    SOMEOP -> YYAction 523;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction525 t =   case yychar t of {
+  ')' -> YYAction 586;
   _ -> (YYAction yyErr);
 };
-private yyaction510 t =   case yychar t of {
+private yyaction526 t =   case yychar t of {
   ')' -> YYAction (-260);
   _ ->   case yytoken t of {
-    ARROW -> YYAction 568;
+    ARROW -> YYAction 587;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction511 t =   case yychar t of {
-  ',' -> YYAction 569;
+private yyaction527 t =   case yychar t of {
+  ',' -> YYAction 588;
   ';' -> YYAction (-241);
   '}' -> YYAction (-241);
   ')' -> YYAction (-241);
@@ -4559,24 +4632,24 @@ private yyaction511 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction512 t =   case yychar t of {
-  ')' -> YYAction 570;
+private yyaction528 t =   case yychar t of {
+  ')' -> YYAction 589;
   _ -> (YYAction yyErr);
 };
-private yyaction513 t =   case yychar t of {
-  '|' -> YYAction 571;
+private yyaction529 t =   case yychar t of {
+  '|' -> YYAction 590;
   ')' -> YYAction (-243);
   _ -> (YYAction yyErr);
 };
-private yyaction514 t =   case yychar t of {
-  ')' -> YYAction 572;
+private yyaction530 t =   case yychar t of {
+  ')' -> YYAction 591;
   _ -> (YYAction yyErr);
 };
-private yyaction515 t = YYAction (-240);
-private yyaction516 t = YYAction (-396);
-private yyaction517 t = YYAction (-394);
-private yyaction518 t = YYAction (-395);
-private yyaction519 t =   case yychar t of {
+private yyaction531 t = YYAction (-240);
+private yyaction532 t = YYAction (-410);
+private yyaction533 t = YYAction (-408);
+private yyaction534 t = YYAction (-409);
+private yyaction535 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -4605,7 +4678,7 @@ private yyaction519 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction520 t =   case yychar t of {
+private yyaction536 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 42;
   '[' -> YYAction 43;
@@ -4634,18 +4707,18 @@ private yyaction520 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction521 t = YYAction (-143);
-private yyaction522 t =   case yychar t of {
-  ')' -> YYAction 574;
+private yyaction537 t = YYAction (-143);
+private yyaction538 t =   case yychar t of {
+  ')' -> YYAction 593;
   _ ->   case yytoken t of {
-    VARID -> YYAction 527;
-    CONID -> YYAction 528;
-    PUBLIC -> YYAction 573;
+    VARID -> YYAction 543;
+    CONID -> YYAction 544;
+    PUBLIC -> YYAction 592;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction523 t =   case yychar t of {
+private yyaction539 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   _ ->   case yytoken t of {
@@ -4654,96 +4727,99 @@ private yyaction523 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction524 t = YYAction (-161);
-private yyaction525 t = YYAction (-148);
-private yyaction526 t =   case yychar t of {
+private yyaction540 t = YYAction (-161);
+private yyaction541 t = YYAction (-148);
+private yyaction542 t =   case yychar t of {
   '?' -> YYAction 44;
   '!' -> YYAction 45;
   ')' -> YYAction (-151);
   _ ->   case yytoken t of {
     VARID -> YYAction 24;
-    CONID -> YYAction 429;
-    QUALIFIER -> YYAction 430;
-    PUBLIC -> YYAction 431;
+    CONID -> YYAction 440;
+    QUALIFIER -> YYAction 441;
+    PUBLIC -> YYAction 442;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction527 t = YYAction (-168);
-private yyaction528 t = YYAction (-169);
-private yyaction529 t = YYAction (-170);
-private yyaction530 t = YYAction (-160);
-private yyaction531 t =   case yychar t of {
-  ')' -> YYAction 579;
+private yyaction543 t = YYAction (-168);
+private yyaction544 t = YYAction (-169);
+private yyaction545 t = YYAction (-170);
+private yyaction546 t = YYAction (-160);
+private yyaction547 t =   case yychar t of {
+  ')' -> YYAction 598;
   _ -> (YYAction yyErr);
 };
-private yyaction532 t = YYAction (-46);
-private yyaction533 t =   case yychar t of {
-  '{' -> YYAction 580;
+private yyaction548 t = YYAction (-46);
+private yyaction549 t =   case yychar t of {
+  '{' -> YYAction 599;
   _ -> (YYAction yyErr);
 };
-private yyaction534 t = YYAction (-42);
-private yyaction535 t =   case yychar t of {
-  '?' -> YYAction 583;
-  '!' -> YYAction 584;
+private yyaction550 t = YYAction (-42);
+private yyaction551 t =   case yychar t of {
+  '?' -> YYAction 602;
+  '!' -> YYAction 603;
   _ ->   case yytoken t of {
     VARID -> YYAction 192;
     DOCUMENTATION -> YYAction 1;
-    PRIVATE -> YYAction 581;
-    PUBLIC -> YYAction 582;
+    PRIVATE -> YYAction 600;
+    PUBLIC -> YYAction 601;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction536 t = YYAction (-293);
-private yyaction537 t = YYAction (-292);
-private yyaction538 t = YYAction (-282);
-private yyaction539 t = YYAction (-285);
-private yyaction540 t = YYAction (-286);
-private yyaction541 t = YYAction (-284);
-private yyaction542 t = YYAction (-269);
-private yyaction543 t = YYAction (-270);
-private yyaction544 t = YYAction (-288);
-private yyaction545 t = YYAction (-287);
-private yyaction546 t = YYAction (-272);
-private yyaction547 t =   case yychar t of {
-  '?' -> YYAction 456;
-  '!' -> YYAction 457;
+private yyaction552 t = YYAction (-307);
+private yyaction553 t = YYAction (-306);
+private yyaction554 t = YYAction (-296);
+private yyaction555 t = YYAction (-299);
+private yyaction556 t = YYAction (-300);
+private yyaction557 t = YYAction (-298);
+private yyaction558 t = YYAction (-283);
+private yyaction559 t = YYAction (-284);
+private yyaction560 t = YYAction (-302);
+private yyaction561 t = YYAction (-301);
+private yyaction562 t = YYAction (-286);
+private yyaction563 t =   case yychar t of {
+  '?' -> YYAction 467;
+  '!' -> YYAction 468;
   _ ->   case yytoken t of {
-    CONID -> YYAction 448;
-    DOCUMENTATION -> YYAction 449;
-    PRIVATE -> YYAction 451;
-    PROTECTED -> YYAction 452;
-    PUBLIC -> YYAction 453;
+    CONID -> YYAction 459;
+    DOCUMENTATION -> YYAction 460;
+    PRIVATE -> YYAction 462;
+    PROTECTED -> YYAction 463;
+    PUBLIC -> YYAction 464;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction548 t = YYAction (-281);
-private yyaction549 t =   case yytoken t of {
-    VARID -> YYAction 260;
-    CONID -> YYAction 261;
-    QUALIFIER -> YYAction 262;
-    STRCONST -> YYAction 263;
+private yyaction564 t = YYAction (-295);
+private yyaction565 t =   case yytoken t of {
+    VARID -> YYAction 265;
+    CONID -> YYAction 266;
+    QUALIFIER -> YYAction 267;
+    STRCONST -> YYAction 268;
     _ -> (YYAction yyErr);
   };
-private yyaction550 t = YYAction (-274);
-private yyaction551 t =   case yychar t of {
-  ';' -> YYAction (-314);
-  '}' -> YYAction (-314);
+private yyaction566 t = YYAction (-288);
+private yyaction567 t = YYAction (-267);
+private yyaction568 t =   case yychar t of {
+  ';' -> YYAction (-328);
+  '}' -> YYAction (-328);
   _ ->   case yytoken t of {
-    WHERE -> YYAction 268;
+    WHERE -> YYAction 273;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction552 t = YYAction (-313);
-private yyaction553 t = YYAction (-318);
-private yyaction554 t = YYAction (-218);
-private yyaction555 t = YYAction (-221);
-private yyaction556 t = YYAction (-131);
-private yyaction557 t = YYAction (-132);
-private yyaction558 t = YYAction (-133);
-private yyaction559 t = YYAction (-135);
-private yyaction560 t = YYAction (-316);
-private yyaction561 t =   case yychar t of {
+private yyaction569 t = YYAction (-275);
+private yyaction570 t = YYAction (-278);
+private yyaction571 t = YYAction (-327);
+private yyaction572 t = YYAction (-332);
+private yyaction573 t = YYAction (-218);
+private yyaction574 t = YYAction (-221);
+private yyaction575 t = YYAction (-131);
+private yyaction576 t = YYAction (-132);
+private yyaction577 t = YYAction (-133);
+private yyaction578 t = YYAction (-135);
+private yyaction579 t = YYAction (-330);
+private yyaction580 t =   case yychar t of {
   '-' -> YYAction 41;
   '(' -> YYAction 124;
   '[' -> YYAction 43;
@@ -4757,16 +4833,16 @@ private yyaction561 t =   case yychar t of {
     CONID -> YYAction 25;
     QUALIFIER -> YYAction 26;
     DOCUMENTATION -> YYAction 108;
-    NATIVE -> YYAction 241;
+    NATIVE -> YYAction 246;
     TRUE -> YYAction 27;
     FALSE -> YYAction 28;
     IF -> YYAction 29;
     CASE -> YYAction 30;
     LET -> YYAction 31;
     DO -> YYAction 32;
-    PRIVATE -> YYAction 479;
-    PROTECTED -> YYAction 480;
-    PUBLIC -> YYAction 481;
+    PRIVATE -> YYAction 495;
+    PROTECTED -> YYAction 496;
+    PUBLIC -> YYAction 497;
     PURE -> YYAction 123;
     INTCONST -> YYAction 33;
     STRCONST -> YYAction 34;
@@ -4779,24 +4855,24 @@ private yyaction561 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction562 t = YYAction (-348);
-private yyaction563 t = YYAction (-350);
-private yyaction564 t = YYAction (-353);
-private yyaction565 t = YYAction (-357);
-private yyaction566 t =   case yychar t of {
-  ')' -> YYAction 597;
+private yyaction581 t = YYAction (-362);
+private yyaction582 t = YYAction (-364);
+private yyaction583 t = YYAction (-367);
+private yyaction584 t = YYAction (-371);
+private yyaction585 t =   case yychar t of {
+  ')' -> YYAction 616;
   _ -> (YYAction yyErr);
 };
-private yyaction567 t = YYAction (-253);
-private yyaction568 t =   case yychar t of {
-  '(' -> YYAction 508;
+private yyaction586 t = YYAction (-253);
+private yyaction587 t =   case yychar t of {
+  '(' -> YYAction 524;
   _ ->   case yytoken t of {
-    VARID -> YYAction 506;
-    SOMEOP -> YYAction 507;
+    VARID -> YYAction 522;
+    SOMEOP -> YYAction 523;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction569 t =   case yychar t of {
+private yyaction588 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
@@ -4807,8 +4883,8 @@ private yyaction569 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction570 t = YYAction (-249);
-private yyaction571 t =   case yychar t of {
+private yyaction589 t = YYAction (-249);
+private yyaction590 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
@@ -4819,425 +4895,425 @@ private yyaction571 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction572 t = YYAction (-250);
-private yyaction573 t =   case yytoken t of {
-    VARID -> YYAction 527;
-    CONID -> YYAction 528;
-    PUBLIC -> YYAction 573;
+private yyaction591 t = YYAction (-250);
+private yyaction592 t =   case yytoken t of {
+    VARID -> YYAction 543;
+    CONID -> YYAction 544;
+    PUBLIC -> YYAction 592;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
-private yyaction574 t = YYAction (-155);
-private yyaction575 t =   case yychar t of {
-  ')' -> YYAction 602;
+private yyaction593 t = YYAction (-155);
+private yyaction594 t =   case yychar t of {
+  ')' -> YYAction 621;
   _ -> (YYAction yyErr);
 };
-private yyaction576 t =   case yychar t of {
+private yyaction595 t =   case yychar t of {
   ')' -> YYAction (-162);
   ',' -> YYAction (-162);
   _ ->   case yytoken t of {
-    VARID -> YYAction 527;
-    CONID -> YYAction 528;
+    VARID -> YYAction 543;
+    CONID -> YYAction 544;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction577 t =   case yychar t of {
-  ',' -> YYAction 604;
+private yyaction596 t =   case yychar t of {
+  ',' -> YYAction 623;
   ')' -> YYAction (-165);
   _ -> (YYAction yyErr);
 };
-private yyaction578 t = YYAction (-152);
-private yyaction579 t = YYAction (-146);
-private yyaction580 t =   case yychar t of {
-  '-' -> YYAction 654;
-  ';' -> YYAction 655;
-  '{' -> YYAction 656;
-  '}' -> YYAction 657;
-  '.' -> YYAction 658;
-  '(' -> YYAction 659;
-  ')' -> YYAction 660;
-  ',' -> YYAction 661;
-  '|' -> YYAction 662;
-  '[' -> YYAction 663;
-  ']' -> YYAction 664;
-  '?' -> YYAction 665;
-  '!' -> YYAction 666;
-  '=' -> YYAction 667;
-  '\\' -> YYAction 668;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 605;
-    CONID -> YYAction 606;
-    QVARID -> YYAction 607;
-    QCONID -> YYAction 608;
-    QUALIFIER -> YYAction 609;
-    DOCUMENTATION -> YYAction 610;
-    PACKAGE -> YYAction 611;
-    IMPORT -> YYAction 612;
-    INFIX -> YYAction 613;
-    INFIXR -> YYAction 614;
-    INFIXL -> YYAction 615;
-    NATIVE -> YYAction 616;
-    DATA -> YYAction 617;
-    WHERE -> YYAction 618;
-    CLASS -> YYAction 619;
-    INSTANCE -> YYAction 620;
-    ABSTRACT -> YYAction 621;
-    TYPE -> YYAction 622;
-    TRUE -> YYAction 623;
-    FALSE -> YYAction 624;
-    IF -> YYAction 625;
-    THEN -> YYAction 626;
-    ELSE -> YYAction 627;
-    CASE -> YYAction 628;
-    OF -> YYAction 629;
-    DERIVE -> YYAction 630;
-    LET -> YYAction 631;
-    IN -> YYAction 632;
-    DO -> YYAction 633;
-    FORALL -> YYAction 634;
-    PRIVATE -> YYAction 635;
-    PROTECTED -> YYAction 636;
-    PUBLIC -> YYAction 637;
-    PURE -> YYAction 638;
-    THROWS -> YYAction 639;
-    MUTABLE -> YYAction 640;
-    INTCONST -> YYAction 641;
-    STRCONST -> YYAction 642;
-    LONGCONST -> YYAction 643;
-    FLTCONST -> YYAction 644;
-    DBLCONST -> YYAction 645;
-    CHRCONST -> YYAction 646;
-    ARROW -> YYAction 647;
-    DCOLON -> YYAction 648;
-    GETS -> YYAction 649;
-    EARROW -> YYAction 650;
-    DOTDOT -> YYAction 651;
-    SOMEOP -> YYAction 652;
-    INTERPRET -> YYAction 653;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction581 t =   case yychar t of {
-  '?' -> YYAction 583;
-  '!' -> YYAction 584;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 192;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction582 t =   case yychar t of {
-  '?' -> YYAction 583;
-  '!' -> YYAction 584;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 192;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction583 t =   case yytoken t of {
-    VARID -> YYAction 192;
-    _ -> (YYAction yyErr);
-  };
-private yyaction584 t =   case yytoken t of {
-    VARID -> YYAction 192;
-    _ -> (YYAction yyErr);
-  };
-private yyaction585 t =   case yychar t of {
-  '?' -> YYAction 583;
-  '!' -> YYAction 584;
-  _ ->   case yytoken t of {
-    VARID -> YYAction 192;
-    PRIVATE -> YYAction 581;
-    PUBLIC -> YYAction 582;
-    _ -> (YYAction yyErr);
-  };
-};
-private yyaction586 t = YYAction (-311);
-private yyaction587 t =   case yychar t of {
+private yyaction597 t = YYAction (-152);
+private yyaction598 t = YYAction (-146);
+private yyaction599 t =   case yychar t of {
+  '-' -> YYAction 673;
+  ';' -> YYAction 674;
+  '{' -> YYAction 675;
   '}' -> YYAction 676;
+  '.' -> YYAction 677;
+  '(' -> YYAction 678;
+  ')' -> YYAction 679;
+  ',' -> YYAction 680;
+  '|' -> YYAction 681;
+  '[' -> YYAction 682;
+  ']' -> YYAction 683;
+  '?' -> YYAction 684;
+  '!' -> YYAction 685;
+  '=' -> YYAction 686;
+  '\\' -> YYAction 687;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 624;
+    CONID -> YYAction 625;
+    QVARID -> YYAction 626;
+    QCONID -> YYAction 627;
+    QUALIFIER -> YYAction 628;
+    DOCUMENTATION -> YYAction 629;
+    PACKAGE -> YYAction 630;
+    IMPORT -> YYAction 631;
+    INFIX -> YYAction 632;
+    INFIXR -> YYAction 633;
+    INFIXL -> YYAction 634;
+    NATIVE -> YYAction 635;
+    DATA -> YYAction 636;
+    WHERE -> YYAction 637;
+    CLASS -> YYAction 638;
+    INSTANCE -> YYAction 639;
+    ABSTRACT -> YYAction 640;
+    TYPE -> YYAction 641;
+    TRUE -> YYAction 642;
+    FALSE -> YYAction 643;
+    IF -> YYAction 644;
+    THEN -> YYAction 645;
+    ELSE -> YYAction 646;
+    CASE -> YYAction 647;
+    OF -> YYAction 648;
+    DERIVE -> YYAction 649;
+    LET -> YYAction 650;
+    IN -> YYAction 651;
+    DO -> YYAction 652;
+    FORALL -> YYAction 653;
+    PRIVATE -> YYAction 654;
+    PROTECTED -> YYAction 655;
+    PUBLIC -> YYAction 656;
+    PURE -> YYAction 657;
+    THROWS -> YYAction 658;
+    MUTABLE -> YYAction 659;
+    INTCONST -> YYAction 660;
+    STRCONST -> YYAction 661;
+    LONGCONST -> YYAction 662;
+    FLTCONST -> YYAction 663;
+    DBLCONST -> YYAction 664;
+    CHRCONST -> YYAction 665;
+    ARROW -> YYAction 666;
+    DCOLON -> YYAction 667;
+    GETS -> YYAction 668;
+    EARROW -> YYAction 669;
+    DOTDOT -> YYAction 670;
+    SOMEOP -> YYAction 671;
+    INTERPRET -> YYAction 672;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction600 t =   case yychar t of {
+  '?' -> YYAction 602;
+  '!' -> YYAction 603;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 192;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction601 t =   case yychar t of {
+  '?' -> YYAction 602;
+  '!' -> YYAction 603;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 192;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction602 t =   case yytoken t of {
+    VARID -> YYAction 192;
+    _ -> (YYAction yyErr);
+  };
+private yyaction603 t =   case yytoken t of {
+    VARID -> YYAction 192;
+    _ -> (YYAction yyErr);
+  };
+private yyaction604 t =   case yychar t of {
+  '?' -> YYAction 602;
+  '!' -> YYAction 603;
+  _ ->   case yytoken t of {
+    VARID -> YYAction 192;
+    PRIVATE -> YYAction 600;
+    PUBLIC -> YYAction 601;
+    _ -> (YYAction yyErr);
+  };
+};
+private yyaction605 t = YYAction (-325);
+private yyaction606 t =   case yychar t of {
+  '}' -> YYAction 695;
   _ -> (YYAction yyErr);
 };
-private yyaction588 t =   case yychar t of {
-  ',' -> YYAction 678;
-  '}' -> YYAction (-296);
+private yyaction607 t =   case yychar t of {
+  ',' -> YYAction 697;
+  '}' -> YYAction (-310);
   _ ->   case yytoken t of {
-    DOCUMENTATION -> YYAction 677;
+    DOCUMENTATION -> YYAction 696;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction589 t =   case yytoken t of {
-    DCOLON -> YYAction 679;
+private yyaction608 t =   case yytoken t of {
+    DCOLON -> YYAction 698;
     _ -> (YYAction yyErr);
   };
-private yyaction590 t =   case yychar t of {
-  ',' -> YYAction 680;
+private yyaction609 t =   case yychar t of {
+  ',' -> YYAction 699;
   _ ->   case yytoken t of {
-    DCOLON -> YYAction (-303);
+    DCOLON -> YYAction (-317);
     _ -> (YYAction yyErr);
   };
 };
-private yyaction591 t = YYAction (-305);
-private yyaction592 t = YYAction (-308);
-private yyaction593 t = YYAction (-279);
-private yyaction594 t = YYAction (-273);
-private yyaction595 t = YYAction (-265);
-private yyaction596 t = YYAction (-126);
-private yyaction597 t = YYAction (-263);
-private yyaction598 t = YYAction (-259);
-private yyaction599 t = YYAction (-242);
-private yyaction600 t = YYAction (-244);
-private yyaction601 t = YYAction (-164);
-private yyaction602 t = YYAction (-154);
-private yyaction603 t = YYAction (-163);
-private yyaction604 t =   case yychar t of {
+private yyaction610 t = YYAction (-319);
+private yyaction611 t = YYAction (-322);
+private yyaction612 t = YYAction (-293);
+private yyaction613 t = YYAction (-287);
+private yyaction614 t = YYAction (-270);
+private yyaction615 t = YYAction (-126);
+private yyaction616 t = YYAction (-263);
+private yyaction617 t = YYAction (-259);
+private yyaction618 t = YYAction (-242);
+private yyaction619 t = YYAction (-244);
+private yyaction620 t = YYAction (-164);
+private yyaction621 t = YYAction (-154);
+private yyaction622 t = YYAction (-163);
+private yyaction623 t =   case yychar t of {
   ')' -> YYAction (-166);
   _ ->   case yytoken t of {
-    VARID -> YYAction 527;
-    CONID -> YYAction 528;
-    PUBLIC -> YYAction 573;
+    VARID -> YYAction 543;
+    CONID -> YYAction 544;
+    PUBLIC -> YYAction 592;
     SOMEOP -> YYAction 84;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction605 t = YYAction (-49);
-private yyaction606 t = YYAction (-50);
-private yyaction607 t = YYAction (-51);
-private yyaction608 t = YYAction (-52);
-private yyaction609 t = YYAction (-53);
-private yyaction610 t = YYAction (-54);
-private yyaction611 t = YYAction (-55);
-private yyaction612 t = YYAction (-56);
-private yyaction613 t = YYAction (-57);
-private yyaction614 t = YYAction (-58);
-private yyaction615 t = YYAction (-59);
-private yyaction616 t = YYAction (-60);
-private yyaction617 t = YYAction (-61);
-private yyaction618 t = YYAction (-62);
-private yyaction619 t = YYAction (-63);
-private yyaction620 t = YYAction (-64);
-private yyaction621 t = YYAction (-65);
-private yyaction622 t = YYAction (-66);
-private yyaction623 t = YYAction (-67);
-private yyaction624 t = YYAction (-68);
-private yyaction625 t = YYAction (-69);
-private yyaction626 t = YYAction (-70);
-private yyaction627 t = YYAction (-71);
-private yyaction628 t = YYAction (-72);
-private yyaction629 t = YYAction (-73);
-private yyaction630 t = YYAction (-74);
-private yyaction631 t = YYAction (-75);
-private yyaction632 t = YYAction (-76);
-private yyaction633 t = YYAction (-77);
-private yyaction634 t = YYAction (-78);
-private yyaction635 t = YYAction (-79);
-private yyaction636 t = YYAction (-80);
-private yyaction637 t = YYAction (-81);
-private yyaction638 t = YYAction (-82);
-private yyaction639 t = YYAction (-83);
-private yyaction640 t = YYAction (-84);
-private yyaction641 t = YYAction (-85);
-private yyaction642 t = YYAction (-86);
-private yyaction643 t = YYAction (-87);
-private yyaction644 t = YYAction (-88);
-private yyaction645 t = YYAction (-89);
-private yyaction646 t = YYAction (-90);
-private yyaction647 t = YYAction (-91);
-private yyaction648 t = YYAction (-92);
-private yyaction649 t = YYAction (-93);
-private yyaction650 t = YYAction (-94);
-private yyaction651 t = YYAction (-95);
-private yyaction652 t = YYAction (-96);
-private yyaction653 t = YYAction (-97);
-private yyaction654 t = YYAction (-106);
-private yyaction655 t = YYAction (-107);
-private yyaction656 t =   case yychar t of {
-  '-' -> YYAction 654;
-  ';' -> YYAction 655;
-  '{' -> YYAction 656;
-  '}' -> YYAction 682;
-  '.' -> YYAction 658;
-  '(' -> YYAction 659;
-  ')' -> YYAction 660;
-  ',' -> YYAction 661;
-  '|' -> YYAction 662;
-  '[' -> YYAction 663;
-  ']' -> YYAction 664;
-  '?' -> YYAction 665;
-  '!' -> YYAction 666;
-  '=' -> YYAction 667;
-  '\\' -> YYAction 668;
+private yyaction624 t = YYAction (-49);
+private yyaction625 t = YYAction (-50);
+private yyaction626 t = YYAction (-51);
+private yyaction627 t = YYAction (-52);
+private yyaction628 t = YYAction (-53);
+private yyaction629 t = YYAction (-54);
+private yyaction630 t = YYAction (-55);
+private yyaction631 t = YYAction (-56);
+private yyaction632 t = YYAction (-57);
+private yyaction633 t = YYAction (-58);
+private yyaction634 t = YYAction (-59);
+private yyaction635 t = YYAction (-60);
+private yyaction636 t = YYAction (-61);
+private yyaction637 t = YYAction (-62);
+private yyaction638 t = YYAction (-63);
+private yyaction639 t = YYAction (-64);
+private yyaction640 t = YYAction (-65);
+private yyaction641 t = YYAction (-66);
+private yyaction642 t = YYAction (-67);
+private yyaction643 t = YYAction (-68);
+private yyaction644 t = YYAction (-69);
+private yyaction645 t = YYAction (-70);
+private yyaction646 t = YYAction (-71);
+private yyaction647 t = YYAction (-72);
+private yyaction648 t = YYAction (-73);
+private yyaction649 t = YYAction (-74);
+private yyaction650 t = YYAction (-75);
+private yyaction651 t = YYAction (-76);
+private yyaction652 t = YYAction (-77);
+private yyaction653 t = YYAction (-78);
+private yyaction654 t = YYAction (-79);
+private yyaction655 t = YYAction (-80);
+private yyaction656 t = YYAction (-81);
+private yyaction657 t = YYAction (-82);
+private yyaction658 t = YYAction (-83);
+private yyaction659 t = YYAction (-84);
+private yyaction660 t = YYAction (-85);
+private yyaction661 t = YYAction (-86);
+private yyaction662 t = YYAction (-87);
+private yyaction663 t = YYAction (-88);
+private yyaction664 t = YYAction (-89);
+private yyaction665 t = YYAction (-90);
+private yyaction666 t = YYAction (-91);
+private yyaction667 t = YYAction (-92);
+private yyaction668 t = YYAction (-93);
+private yyaction669 t = YYAction (-94);
+private yyaction670 t = YYAction (-95);
+private yyaction671 t = YYAction (-96);
+private yyaction672 t = YYAction (-97);
+private yyaction673 t = YYAction (-106);
+private yyaction674 t = YYAction (-107);
+private yyaction675 t =   case yychar t of {
+  '-' -> YYAction 673;
+  ';' -> YYAction 674;
+  '{' -> YYAction 675;
+  '}' -> YYAction 701;
+  '.' -> YYAction 677;
+  '(' -> YYAction 678;
+  ')' -> YYAction 679;
+  ',' -> YYAction 680;
+  '|' -> YYAction 681;
+  '[' -> YYAction 682;
+  ']' -> YYAction 683;
+  '?' -> YYAction 684;
+  '!' -> YYAction 685;
+  '=' -> YYAction 686;
+  '\\' -> YYAction 687;
   _ ->   case yytoken t of {
-    VARID -> YYAction 605;
-    CONID -> YYAction 606;
-    QVARID -> YYAction 607;
-    QCONID -> YYAction 608;
-    QUALIFIER -> YYAction 609;
-    DOCUMENTATION -> YYAction 610;
-    PACKAGE -> YYAction 611;
-    IMPORT -> YYAction 612;
-    INFIX -> YYAction 613;
-    INFIXR -> YYAction 614;
-    INFIXL -> YYAction 615;
-    NATIVE -> YYAction 616;
-    DATA -> YYAction 617;
-    WHERE -> YYAction 618;
-    CLASS -> YYAction 619;
-    INSTANCE -> YYAction 620;
-    ABSTRACT -> YYAction 621;
-    TYPE -> YYAction 622;
-    TRUE -> YYAction 623;
-    FALSE -> YYAction 624;
-    IF -> YYAction 625;
-    THEN -> YYAction 626;
-    ELSE -> YYAction 627;
-    CASE -> YYAction 628;
-    OF -> YYAction 629;
-    DERIVE -> YYAction 630;
-    LET -> YYAction 631;
-    IN -> YYAction 632;
-    DO -> YYAction 633;
-    FORALL -> YYAction 634;
-    PRIVATE -> YYAction 635;
-    PROTECTED -> YYAction 636;
-    PUBLIC -> YYAction 637;
-    PURE -> YYAction 638;
-    THROWS -> YYAction 639;
-    MUTABLE -> YYAction 640;
-    INTCONST -> YYAction 641;
-    STRCONST -> YYAction 642;
-    LONGCONST -> YYAction 643;
-    FLTCONST -> YYAction 644;
-    DBLCONST -> YYAction 645;
-    CHRCONST -> YYAction 646;
-    ARROW -> YYAction 647;
-    DCOLON -> YYAction 648;
-    GETS -> YYAction 649;
-    EARROW -> YYAction 650;
-    DOTDOT -> YYAction 651;
-    SOMEOP -> YYAction 652;
-    INTERPRET -> YYAction 653;
+    VARID -> YYAction 624;
+    CONID -> YYAction 625;
+    QVARID -> YYAction 626;
+    QCONID -> YYAction 627;
+    QUALIFIER -> YYAction 628;
+    DOCUMENTATION -> YYAction 629;
+    PACKAGE -> YYAction 630;
+    IMPORT -> YYAction 631;
+    INFIX -> YYAction 632;
+    INFIXR -> YYAction 633;
+    INFIXL -> YYAction 634;
+    NATIVE -> YYAction 635;
+    DATA -> YYAction 636;
+    WHERE -> YYAction 637;
+    CLASS -> YYAction 638;
+    INSTANCE -> YYAction 639;
+    ABSTRACT -> YYAction 640;
+    TYPE -> YYAction 641;
+    TRUE -> YYAction 642;
+    FALSE -> YYAction 643;
+    IF -> YYAction 644;
+    THEN -> YYAction 645;
+    ELSE -> YYAction 646;
+    CASE -> YYAction 647;
+    OF -> YYAction 648;
+    DERIVE -> YYAction 649;
+    LET -> YYAction 650;
+    IN -> YYAction 651;
+    DO -> YYAction 652;
+    FORALL -> YYAction 653;
+    PRIVATE -> YYAction 654;
+    PROTECTED -> YYAction 655;
+    PUBLIC -> YYAction 656;
+    PURE -> YYAction 657;
+    THROWS -> YYAction 658;
+    MUTABLE -> YYAction 659;
+    INTCONST -> YYAction 660;
+    STRCONST -> YYAction 661;
+    LONGCONST -> YYAction 662;
+    FLTCONST -> YYAction 663;
+    DBLCONST -> YYAction 664;
+    CHRCONST -> YYAction 665;
+    ARROW -> YYAction 666;
+    DCOLON -> YYAction 667;
+    GETS -> YYAction 668;
+    EARROW -> YYAction 669;
+    DOTDOT -> YYAction 670;
+    SOMEOP -> YYAction 671;
+    INTERPRET -> YYAction 672;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction657 t = YYAction (-48);
-private yyaction658 t = YYAction (-104);
-private yyaction659 t = YYAction (-102);
-private yyaction660 t = YYAction (-103);
-private yyaction661 t = YYAction (-98);
-private yyaction662 t = YYAction (-99);
-private yyaction663 t = YYAction (-100);
-private yyaction664 t = YYAction (-101);
-private yyaction665 t = YYAction (-105);
-private yyaction666 t = YYAction (-108);
-private yyaction667 t = YYAction (-109);
-private yyaction668 t = YYAction (-110);
-private yyaction669 t =   case yychar t of {
-  '}' -> YYAction 684;
+private yyaction676 t = YYAction (-48);
+private yyaction677 t = YYAction (-104);
+private yyaction678 t = YYAction (-102);
+private yyaction679 t = YYAction (-103);
+private yyaction680 t = YYAction (-98);
+private yyaction681 t = YYAction (-99);
+private yyaction682 t = YYAction (-100);
+private yyaction683 t = YYAction (-101);
+private yyaction684 t = YYAction (-105);
+private yyaction685 t = YYAction (-108);
+private yyaction686 t = YYAction (-109);
+private yyaction687 t = YYAction (-110);
+private yyaction688 t =   case yychar t of {
+  '}' -> YYAction 703;
   _ -> (YYAction yyErr);
 };
-private yyaction670 t =   case yychar t of {
-  '-' -> YYAction 654;
-  ';' -> YYAction 655;
-  '{' -> YYAction 656;
-  '.' -> YYAction 658;
-  '(' -> YYAction 659;
-  ')' -> YYAction 660;
-  ',' -> YYAction 661;
-  '|' -> YYAction 662;
-  '[' -> YYAction 663;
-  ']' -> YYAction 664;
-  '?' -> YYAction 665;
-  '!' -> YYAction 666;
-  '=' -> YYAction 667;
-  '\\' -> YYAction 668;
+private yyaction689 t =   case yychar t of {
+  '-' -> YYAction 673;
+  ';' -> YYAction 674;
+  '{' -> YYAction 675;
+  '.' -> YYAction 677;
+  '(' -> YYAction 678;
+  ')' -> YYAction 679;
+  ',' -> YYAction 680;
+  '|' -> YYAction 681;
+  '[' -> YYAction 682;
+  ']' -> YYAction 683;
+  '?' -> YYAction 684;
+  '!' -> YYAction 685;
+  '=' -> YYAction 686;
+  '\\' -> YYAction 687;
   '}' -> YYAction (-111);
   _ ->   case yytoken t of {
-    VARID -> YYAction 605;
-    CONID -> YYAction 606;
-    QVARID -> YYAction 607;
-    QCONID -> YYAction 608;
-    QUALIFIER -> YYAction 609;
-    DOCUMENTATION -> YYAction 610;
-    PACKAGE -> YYAction 611;
-    IMPORT -> YYAction 612;
-    INFIX -> YYAction 613;
-    INFIXR -> YYAction 614;
-    INFIXL -> YYAction 615;
-    NATIVE -> YYAction 616;
-    DATA -> YYAction 617;
-    WHERE -> YYAction 618;
-    CLASS -> YYAction 619;
-    INSTANCE -> YYAction 620;
-    ABSTRACT -> YYAction 621;
-    TYPE -> YYAction 622;
-    TRUE -> YYAction 623;
-    FALSE -> YYAction 624;
-    IF -> YYAction 625;
-    THEN -> YYAction 626;
-    ELSE -> YYAction 627;
-    CASE -> YYAction 628;
-    OF -> YYAction 629;
-    DERIVE -> YYAction 630;
-    LET -> YYAction 631;
-    IN -> YYAction 632;
-    DO -> YYAction 633;
-    FORALL -> YYAction 634;
-    PRIVATE -> YYAction 635;
-    PROTECTED -> YYAction 636;
-    PUBLIC -> YYAction 637;
-    PURE -> YYAction 638;
-    THROWS -> YYAction 639;
-    MUTABLE -> YYAction 640;
-    INTCONST -> YYAction 641;
-    STRCONST -> YYAction 642;
-    LONGCONST -> YYAction 643;
-    FLTCONST -> YYAction 644;
-    DBLCONST -> YYAction 645;
-    CHRCONST -> YYAction 646;
-    ARROW -> YYAction 647;
-    DCOLON -> YYAction 648;
-    GETS -> YYAction 649;
-    EARROW -> YYAction 650;
-    DOTDOT -> YYAction 651;
-    SOMEOP -> YYAction 652;
-    INTERPRET -> YYAction 653;
+    VARID -> YYAction 624;
+    CONID -> YYAction 625;
+    QVARID -> YYAction 626;
+    QCONID -> YYAction 627;
+    QUALIFIER -> YYAction 628;
+    DOCUMENTATION -> YYAction 629;
+    PACKAGE -> YYAction 630;
+    IMPORT -> YYAction 631;
+    INFIX -> YYAction 632;
+    INFIXR -> YYAction 633;
+    INFIXL -> YYAction 634;
+    NATIVE -> YYAction 635;
+    DATA -> YYAction 636;
+    WHERE -> YYAction 637;
+    CLASS -> YYAction 638;
+    INSTANCE -> YYAction 639;
+    ABSTRACT -> YYAction 640;
+    TYPE -> YYAction 641;
+    TRUE -> YYAction 642;
+    FALSE -> YYAction 643;
+    IF -> YYAction 644;
+    THEN -> YYAction 645;
+    ELSE -> YYAction 646;
+    CASE -> YYAction 647;
+    OF -> YYAction 648;
+    DERIVE -> YYAction 649;
+    LET -> YYAction 650;
+    IN -> YYAction 651;
+    DO -> YYAction 652;
+    FORALL -> YYAction 653;
+    PRIVATE -> YYAction 654;
+    PROTECTED -> YYAction 655;
+    PUBLIC -> YYAction 656;
+    PURE -> YYAction 657;
+    THROWS -> YYAction 658;
+    MUTABLE -> YYAction 659;
+    INTCONST -> YYAction 660;
+    STRCONST -> YYAction 661;
+    LONGCONST -> YYAction 662;
+    FLTCONST -> YYAction 663;
+    DBLCONST -> YYAction 664;
+    CHRCONST -> YYAction 665;
+    ARROW -> YYAction 666;
+    DCOLON -> YYAction 667;
+    GETS -> YYAction 668;
+    EARROW -> YYAction 669;
+    DOTDOT -> YYAction 670;
+    SOMEOP -> YYAction 671;
+    INTERPRET -> YYAction 672;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction671 t = YYAction (-307);
-private yyaction672 t = YYAction (-306);
-private yyaction673 t = YYAction (-310);
-private yyaction674 t = YYAction (-309);
-private yyaction675 t =   case yytoken t of {
-    DCOLON -> YYAction 686;
+private yyaction690 t = YYAction (-321);
+private yyaction691 t = YYAction (-320);
+private yyaction692 t = YYAction (-324);
+private yyaction693 t = YYAction (-323);
+private yyaction694 t =   case yytoken t of {
+    DCOLON -> YYAction 705;
     _ -> (YYAction yyErr);
   };
-private yyaction676 t = YYAction (-291);
-private yyaction677 t =   case yychar t of {
-  '?' -> YYAction 583;
-  '!' -> YYAction 584;
-  '}' -> YYAction (-298);
+private yyaction695 t = YYAction (-305);
+private yyaction696 t =   case yychar t of {
+  '?' -> YYAction 602;
+  '!' -> YYAction 603;
+  '}' -> YYAction (-312);
   _ ->   case yytoken t of {
     VARID -> YYAction 192;
     DOCUMENTATION -> YYAction 1;
-    PRIVATE -> YYAction 581;
-    PUBLIC -> YYAction 582;
+    PRIVATE -> YYAction 600;
+    PUBLIC -> YYAction 601;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction678 t =   case yychar t of {
-  '?' -> YYAction 583;
-  '!' -> YYAction 584;
-  '}' -> YYAction (-297);
+private yyaction697 t =   case yychar t of {
+  '?' -> YYAction 602;
+  '!' -> YYAction 603;
+  '}' -> YYAction (-311);
   _ ->   case yytoken t of {
     VARID -> YYAction 192;
     DOCUMENTATION -> YYAction 1;
-    PRIVATE -> YYAction 581;
-    PUBLIC -> YYAction 582;
+    PRIVATE -> YYAction 600;
+    PUBLIC -> YYAction 601;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction679 t =   case yychar t of {
+private yyaction698 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
@@ -5248,93 +5324,93 @@ private yyaction679 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction680 t =   case yychar t of {
-  '?' -> YYAction 583;
-  '!' -> YYAction 584;
+private yyaction699 t =   case yychar t of {
+  '?' -> YYAction 602;
+  '!' -> YYAction 603;
   _ ->   case yytoken t of {
     VARID -> YYAction 192;
-    PRIVATE -> YYAction 581;
-    PUBLIC -> YYAction 582;
+    PRIVATE -> YYAction 600;
+    PUBLIC -> YYAction 601;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction681 t = YYAction (-167);
-private yyaction682 t =   case yychar t of {
-  '-' -> YYAction 654;
-  ';' -> YYAction 655;
-  '{' -> YYAction 656;
-  '.' -> YYAction 658;
-  '(' -> YYAction 659;
-  ')' -> YYAction 660;
-  ',' -> YYAction 661;
-  '|' -> YYAction 662;
-  '[' -> YYAction 663;
-  ']' -> YYAction 664;
-  '?' -> YYAction 665;
-  '!' -> YYAction 666;
-  '=' -> YYAction 667;
-  '\\' -> YYAction 668;
+private yyaction700 t = YYAction (-167);
+private yyaction701 t =   case yychar t of {
+  '-' -> YYAction 673;
+  ';' -> YYAction 674;
+  '{' -> YYAction 675;
+  '.' -> YYAction 677;
+  '(' -> YYAction 678;
+  ')' -> YYAction 679;
+  ',' -> YYAction 680;
+  '|' -> YYAction 681;
+  '[' -> YYAction 682;
+  ']' -> YYAction 683;
+  '?' -> YYAction 684;
+  '!' -> YYAction 685;
+  '=' -> YYAction 686;
+  '\\' -> YYAction 687;
   '}' -> YYAction (-115);
   _ ->   case yytoken t of {
-    VARID -> YYAction 605;
-    CONID -> YYAction 606;
-    QVARID -> YYAction 607;
-    QCONID -> YYAction 608;
-    QUALIFIER -> YYAction 609;
-    DOCUMENTATION -> YYAction 610;
-    PACKAGE -> YYAction 611;
-    IMPORT -> YYAction 612;
-    INFIX -> YYAction 613;
-    INFIXR -> YYAction 614;
-    INFIXL -> YYAction 615;
-    NATIVE -> YYAction 616;
-    DATA -> YYAction 617;
-    WHERE -> YYAction 618;
-    CLASS -> YYAction 619;
-    INSTANCE -> YYAction 620;
-    ABSTRACT -> YYAction 621;
-    TYPE -> YYAction 622;
-    TRUE -> YYAction 623;
-    FALSE -> YYAction 624;
-    IF -> YYAction 625;
-    THEN -> YYAction 626;
-    ELSE -> YYAction 627;
-    CASE -> YYAction 628;
-    OF -> YYAction 629;
-    DERIVE -> YYAction 630;
-    LET -> YYAction 631;
-    IN -> YYAction 632;
-    DO -> YYAction 633;
-    FORALL -> YYAction 634;
-    PRIVATE -> YYAction 635;
-    PROTECTED -> YYAction 636;
-    PUBLIC -> YYAction 637;
-    PURE -> YYAction 638;
-    THROWS -> YYAction 639;
-    MUTABLE -> YYAction 640;
-    INTCONST -> YYAction 641;
-    STRCONST -> YYAction 642;
-    LONGCONST -> YYAction 643;
-    FLTCONST -> YYAction 644;
-    DBLCONST -> YYAction 645;
-    CHRCONST -> YYAction 646;
-    ARROW -> YYAction 647;
-    DCOLON -> YYAction 648;
-    GETS -> YYAction 649;
-    EARROW -> YYAction 650;
-    DOTDOT -> YYAction 651;
-    SOMEOP -> YYAction 652;
-    INTERPRET -> YYAction 653;
+    VARID -> YYAction 624;
+    CONID -> YYAction 625;
+    QVARID -> YYAction 626;
+    QCONID -> YYAction 627;
+    QUALIFIER -> YYAction 628;
+    DOCUMENTATION -> YYAction 629;
+    PACKAGE -> YYAction 630;
+    IMPORT -> YYAction 631;
+    INFIX -> YYAction 632;
+    INFIXR -> YYAction 633;
+    INFIXL -> YYAction 634;
+    NATIVE -> YYAction 635;
+    DATA -> YYAction 636;
+    WHERE -> YYAction 637;
+    CLASS -> YYAction 638;
+    INSTANCE -> YYAction 639;
+    ABSTRACT -> YYAction 640;
+    TYPE -> YYAction 641;
+    TRUE -> YYAction 642;
+    FALSE -> YYAction 643;
+    IF -> YYAction 644;
+    THEN -> YYAction 645;
+    ELSE -> YYAction 646;
+    CASE -> YYAction 647;
+    OF -> YYAction 648;
+    DERIVE -> YYAction 649;
+    LET -> YYAction 650;
+    IN -> YYAction 651;
+    DO -> YYAction 652;
+    FORALL -> YYAction 653;
+    PRIVATE -> YYAction 654;
+    PROTECTED -> YYAction 655;
+    PUBLIC -> YYAction 656;
+    PURE -> YYAction 657;
+    THROWS -> YYAction 658;
+    MUTABLE -> YYAction 659;
+    INTCONST -> YYAction 660;
+    STRCONST -> YYAction 661;
+    LONGCONST -> YYAction 662;
+    FLTCONST -> YYAction 663;
+    DBLCONST -> YYAction 664;
+    CHRCONST -> YYAction 665;
+    ARROW -> YYAction 666;
+    DCOLON -> YYAction 667;
+    GETS -> YYAction 668;
+    EARROW -> YYAction 669;
+    DOTDOT -> YYAction 670;
+    SOMEOP -> YYAction 671;
+    INTERPRET -> YYAction 672;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction683 t =   case yychar t of {
-  '}' -> YYAction 692;
+private yyaction702 t =   case yychar t of {
+  '}' -> YYAction 711;
   _ -> (YYAction yyErr);
 };
-private yyaction684 t = YYAction (-47);
-private yyaction685 t = YYAction (-112);
-private yyaction686 t =   case yychar t of {
+private yyaction703 t = YYAction (-47);
+private yyaction704 t = YYAction (-112);
+private yyaction705 t =   case yychar t of {
   '(' -> YYAction 200;
   '[' -> YYAction 201;
   _ ->   case yytoken t of {
@@ -5345,82 +5421,82 @@ private yyaction686 t =   case yychar t of {
     _ -> (YYAction yyErr);
   };
 };
-private yyaction687 t = YYAction (-300);
-private yyaction688 t = YYAction (-299);
-private yyaction689 t = YYAction (-301);
-private yyaction690 t = YYAction (-304);
-private yyaction691 t = YYAction (-116);
-private yyaction692 t =   case yychar t of {
-  '-' -> YYAction 654;
-  ';' -> YYAction 655;
-  '{' -> YYAction 656;
-  '.' -> YYAction 658;
-  '(' -> YYAction 659;
-  ')' -> YYAction 660;
-  ',' -> YYAction 661;
-  '|' -> YYAction 662;
-  '[' -> YYAction 663;
-  ']' -> YYAction 664;
-  '?' -> YYAction 665;
-  '!' -> YYAction 666;
-  '=' -> YYAction 667;
-  '\\' -> YYAction 668;
+private yyaction706 t = YYAction (-314);
+private yyaction707 t = YYAction (-313);
+private yyaction708 t = YYAction (-315);
+private yyaction709 t = YYAction (-318);
+private yyaction710 t = YYAction (-116);
+private yyaction711 t =   case yychar t of {
+  '-' -> YYAction 673;
+  ';' -> YYAction 674;
+  '{' -> YYAction 675;
+  '.' -> YYAction 677;
+  '(' -> YYAction 678;
+  ')' -> YYAction 679;
+  ',' -> YYAction 680;
+  '|' -> YYAction 681;
+  '[' -> YYAction 682;
+  ']' -> YYAction 683;
+  '?' -> YYAction 684;
+  '!' -> YYAction 685;
+  '=' -> YYAction 686;
+  '\\' -> YYAction 687;
   '}' -> YYAction (-113);
   _ ->   case yytoken t of {
-    VARID -> YYAction 605;
-    CONID -> YYAction 606;
-    QVARID -> YYAction 607;
-    QCONID -> YYAction 608;
-    QUALIFIER -> YYAction 609;
-    DOCUMENTATION -> YYAction 610;
-    PACKAGE -> YYAction 611;
-    IMPORT -> YYAction 612;
-    INFIX -> YYAction 613;
-    INFIXR -> YYAction 614;
-    INFIXL -> YYAction 615;
-    NATIVE -> YYAction 616;
-    DATA -> YYAction 617;
-    WHERE -> YYAction 618;
-    CLASS -> YYAction 619;
-    INSTANCE -> YYAction 620;
-    ABSTRACT -> YYAction 621;
-    TYPE -> YYAction 622;
-    TRUE -> YYAction 623;
-    FALSE -> YYAction 624;
-    IF -> YYAction 625;
-    THEN -> YYAction 626;
-    ELSE -> YYAction 627;
-    CASE -> YYAction 628;
-    OF -> YYAction 629;
-    DERIVE -> YYAction 630;
-    LET -> YYAction 631;
-    IN -> YYAction 632;
-    DO -> YYAction 633;
-    FORALL -> YYAction 634;
-    PRIVATE -> YYAction 635;
-    PROTECTED -> YYAction 636;
-    PUBLIC -> YYAction 637;
-    PURE -> YYAction 638;
-    THROWS -> YYAction 639;
-    MUTABLE -> YYAction 640;
-    INTCONST -> YYAction 641;
-    STRCONST -> YYAction 642;
-    LONGCONST -> YYAction 643;
-    FLTCONST -> YYAction 644;
-    DBLCONST -> YYAction 645;
-    CHRCONST -> YYAction 646;
-    ARROW -> YYAction 647;
-    DCOLON -> YYAction 648;
-    GETS -> YYAction 649;
-    EARROW -> YYAction 650;
-    DOTDOT -> YYAction 651;
-    SOMEOP -> YYAction 652;
-    INTERPRET -> YYAction 653;
+    VARID -> YYAction 624;
+    CONID -> YYAction 625;
+    QVARID -> YYAction 626;
+    QCONID -> YYAction 627;
+    QUALIFIER -> YYAction 628;
+    DOCUMENTATION -> YYAction 629;
+    PACKAGE -> YYAction 630;
+    IMPORT -> YYAction 631;
+    INFIX -> YYAction 632;
+    INFIXR -> YYAction 633;
+    INFIXL -> YYAction 634;
+    NATIVE -> YYAction 635;
+    DATA -> YYAction 636;
+    WHERE -> YYAction 637;
+    CLASS -> YYAction 638;
+    INSTANCE -> YYAction 639;
+    ABSTRACT -> YYAction 640;
+    TYPE -> YYAction 641;
+    TRUE -> YYAction 642;
+    FALSE -> YYAction 643;
+    IF -> YYAction 644;
+    THEN -> YYAction 645;
+    ELSE -> YYAction 646;
+    CASE -> YYAction 647;
+    OF -> YYAction 648;
+    DERIVE -> YYAction 649;
+    LET -> YYAction 650;
+    IN -> YYAction 651;
+    DO -> YYAction 652;
+    FORALL -> YYAction 653;
+    PRIVATE -> YYAction 654;
+    PROTECTED -> YYAction 655;
+    PUBLIC -> YYAction 656;
+    PURE -> YYAction 657;
+    THROWS -> YYAction 658;
+    MUTABLE -> YYAction 659;
+    INTCONST -> YYAction 660;
+    STRCONST -> YYAction 661;
+    LONGCONST -> YYAction 662;
+    FLTCONST -> YYAction 663;
+    DBLCONST -> YYAction 664;
+    CHRCONST -> YYAction 665;
+    ARROW -> YYAction 666;
+    DCOLON -> YYAction 667;
+    GETS -> YYAction 668;
+    EARROW -> YYAction 669;
+    DOTDOT -> YYAction 670;
+    SOMEOP -> YYAction 671;
+    INTERPRET -> YYAction 672;
     _ -> (YYAction yyErr);
   };
 };
-private yyaction693 t = YYAction (-302);
-private yyaction694 t = YYAction (-114);
+private yyaction712 t = YYAction (-316);
+private yyaction713 t = YYAction (-114);
 private reduce1 =  \(a,d,p)\w\b     -> do {
                                                         changeST Global.{sub <- SubSt.{
                                                             thisPos = p}};
@@ -5855,92 +5931,154 @@ private reduce262 =  \v -> do
 ;
 private reduce263 =  \_\b\_ -> b 
 ;
-private reduce264 = 
-        \_\i\(tv::TauS)\defs -> ClaDcl {pos = yyline i, vis = Public, name = Token.value i,
-                        clvar=tv, supers=[], defs = defs, doc = Nothing}
+private reduce264 =  \c\v -> Ctx {pos=Pos (SName.id c) v.pos.last, cname=c, tau=v} 
+;
+private reduce265 =  single 
+;
+private reduce266 =  \c\_ -> [c] 
+;
+private reduce267 =  liste  
+;
+private reduce268 =  single 
+;
+private reduce269 =  \_\x\_ -> x 
+;
+private reduce270 = 
+        \_\ctxs\_\c\v\defs -> do
+            sups <- classContext (Token.value c) ctxs (v::TauS).var
+            return ClaDcl{
+                    pos = yyline c, 
+                    vis = Public,
+                    name = Token.value c,
+                    clvar = v,
+                    supers = sups,
+                    defs,
+                    doc = Nothing}
     
 ;
-private reduce265 = 
-        \_\i\tau\_\v\defs -> do
-            ctxs <- tauToCtx tau
-            sups <- classContext (Token.value i) ctxs (v.value)
-            YYM.return (ClaDcl {pos = yyline i, vis = Public, name = Token.value i,
-                             clvar = TVar (yyline v) KVar v.value,
-                             supers = sups, defs = defs, doc = Nothing})
+private reduce271 = 
+        \kw\ctxs\defs -> case ctxs of
+            Ctx{pos,cname,tau}:rest -> do
+                unless (null rest) 
+                    (yyerror (yyline kw) "classname missing after contexts")
+                when (SName.{ty?} cname)
+                    (yyerror (yyline cname.id) "classname must not be qualified") 
+                return ClaDcl {pos, vis = Public, name=cname.id.value,
+                               clvar = tau, supers = [],
+                               defs, doc = Nothing}
+            _ -> Prelude.error "fatal: empty ccontext (cannot happen)" 
     
 ;
-private reduce266 = 
-        \ins\t\r\defs -> InsDcl {pos = yyline ins, vis = Public, clas=t, typ=r, defs=defs, doc=Nothing}
+private reduce272 =  \c\t -> Ctx {pos=Pos (SName.id c) t.getpos.last, cname=c, tau=t} 
+;
+private reduce273 =  single 
+;
+private reduce274 =  \c\_ -> [c] 
+;
+private reduce275 =  liste  
+;
+private reduce276 =  single 
+;
+private reduce277 =  \_\x\_ -> x 
+;
+private reduce278 = 
+        \ctxs\ea\cls\tau -> InsDcl {
+            pos = yyline ea,
+            vis = Public,
+            clas = cls,
+            typ = ForAll [] (RhoTau ctxs tau),
+            defs = [],
+            doc = Nothing}
     
 ;
-private reduce267 =  \d\t\r -> DrvDcl {pos = yyline d, vis = Public, clas=t, typ=r, doc=Nothing}
+private reduce279 = 
+        \ctxs -> case ctxs of
+            Ctx{pos, cname, tau}:rest -> do
+                unless (null rest) 
+                        (yyerror pos "classname missing after instance contexts")
+                return InsDcl {
+                    pos, vis = Public, clas = cname,
+                    typ = ForAll [] (RhoTau [] tau),
+                    defs = [],
+                    doc = Nothing,
+                    }
+            _ -> Prelude.error "fatal: empty instance context"
+    
 ;
-private reduce268 =  \def\defs -> (def::Def).{defs = defs} 
+private reduce280 = 
+        \ins\head\defs -> (head::Def).{defs, pos = yyline ins}
+    
 ;
-private reduce269 =  \_\_ -> (true, false)  
+private reduce281 =  
+        \d\(i::Def) -> DrvDcl {pos = yyline d, vis = Public, clas=i.clas, typ=i.typ, doc=Nothing}
+    
 ;
-private reduce270 =  \_\_ -> (false, true)  
+private reduce282 =  \def\defs -> (def::Def).{defs = defs} 
 ;
-private reduce271 =  \_   -> (false, false) 
+private reduce283 =  \_\_ -> (true, false)  
 ;
-private reduce272 = 
+private reduce284 =  \_\_ -> (false, true)  
+;
+private reduce285 =  \_   -> (false, false) 
+;
+private reduce286 = 
         \dat\d\docu\pur\jt -> JavDcl {pos=yyline d, vis=Public, name=Token.value d,
                                     jclas=jt, vars=[], defs=[], 
                                     isPure = fst pur, isMutable = snd pur, 
                                     doc=Nothing}
     
 ;
-private reduce273 = 
+private reduce287 = 
         \dat\d\ds\docu\pur\jt -> JavDcl {pos=yyline d, vis=Public, name=Token.value d,
                                     jclas=jt, vars=ds, defs=[], 
                                     isPure = fst pur, isMutable = snd pur,
                                     doc=Nothing}
     
 ;
-private reduce274 = 
+private reduce288 = 
         \dat\d\ds\docu\alts -> DatDcl {pos=yyline d, vis=Public, name=Token.value d,
                                        vars=ds, ctrs=alts, defs=[], doc=Nothing}
     
 ;
-private reduce275 = 
+private reduce289 = 
         \dat\d\docu\alts -> DatDcl {pos=yyline d, vis=Public, name=Token.value d,
                                     vars=[], ctrs=alts, defs=[], doc=Nothing}
     
 ;
-private reduce276 =  single 
+private reduce290 =  single 
 ;
-private reduce277 =  (:) 
+private reduce291 =  (:) 
 ;
-private reduce278 =  single 
+private reduce292 =  single 
 ;
-private reduce279 =  liste  
+private reduce293 =  liste  
 ;
-private reduce281 =  \dc\doc -> (dc::DConS).{doc = Just (Token.value doc)} 
+private reduce295 =  \dc\doc -> (dc::DConS).{doc = Just (Token.value doc)} 
 ;
-private reduce282 =  \doc\dc -> (dc::DConS).{doc = Just (Token.value doc)} 
+private reduce296 =  \doc\dc -> (dc::DConS).{doc = Just (Token.value doc)} 
 ;
-private reduce284 =  \_\dc -> (dc::DConS).{vis = Public}    
+private reduce298 =  \_\dc -> (dc::DConS).{vis = Public}    
 ;
-private reduce285 =  \_\dc -> (dc::DConS).{vis = Private}   
+private reduce299 =  \_\dc -> (dc::DConS).{vis = Private}   
 ;
-private reduce286 =  \_\dc -> (dc::DConS).{vis = Protected} 
+private reduce300 =  \_\dc -> (dc::DConS).{vis = Protected} 
 ;
-private reduce287 =  \_\dcon ->  DCon.{ -- strict=true,
+private reduce301 =  \_\dcon ->  DCon.{ -- strict=true,
                                                     flds <-map ConField.{strict=true}}  dcon 
 ;
-private reduce288 =  \_\dcon ->  DCon.{ -- strict=false,
+private reduce302 =  \_\dcon ->  DCon.{ -- strict=false,
                                                     flds <-map ConField.{strict=false}} dcon 
 ;
-private reduce290 =  \c        -> DCon {pos=yyline c, vis=Public, -- strict=false,
+private reduce304 =  \c        -> DCon {pos=yyline c, vis=Public, -- strict=false,
                                                 name=Token.value c, flds=[], doc=Nothing } 
 ;
-private reduce291 =  \c\_\fs\_ -> DCon {pos=yyline c, vis=Public, -- strict=false,
+private reduce305 =  \c\_\fs\_ -> DCon {pos=yyline c, vis=Public, -- strict=false,
                                                 name=Token.value c, flds=fs, doc=Nothing } 
 ;
-private reduce292 =  \c\fs     -> DCon {pos=yyline c, vis=Public, -- strict=false,
+private reduce306 =  \c\fs     -> DCon {pos=yyline c, vis=Public, -- strict=false,
                                                 name=Token.value c, flds=fs, doc=Nothing } 
 ;
-private reduce293 =  \taus -> do
+private reduce307 =  \taus -> do
                                     g <- getST
                                     let field  = Field Position.null Nothing Nothing Public false
                                                     • toSig
@@ -5949,74 +6087,74 @@ private reduce293 =  \taus -> do
                                     return (map field taus)
                                 
 ;
-private reduce294 =  single 
+private reduce308 =  single 
 ;
-private reduce295 =  (:) 
+private reduce309 =  (:) 
 ;
-private reduce297 =  const 
+private reduce311 =  const 
 ;
-private reduce298 =  \cs\(d::Token) -> map ConField.{doc <- addDoc d.value} cs 
+private reduce312 =  \cs\(d::Token) -> map ConField.{doc <- addDoc d.value} cs 
 ;
-private reduce299 =  \as\c\ls -> as ++ ls 
+private reduce313 =  \as\c\ls -> as ++ ls 
 ;
-private reduce300 =  \as\(d::Token)\ls -> map ConField.{doc <- addDoc d.value} as ++ ls 
+private reduce314 =  \as\(d::Token)\ls -> map ConField.{doc <- addDoc d.value} as ++ ls 
 ;
-private reduce301 =  \vs\_\t -> [Field pos (Just name) Nothing vis strict t |
+private reduce315 =  \vs\_\t -> [Field pos (Just name) Nothing vis strict t |
                                                 (pos,name,vis,strict) <- vs ]
                                   
 ;
-private reduce302 =  \(d::String)\vs\_\t ->
+private reduce316 =  \(d::String)\vs\_\t ->
                                         map ConField.{doc=Just d}
                                             [Field pos (Just name) Nothing vis strict t |
                                                 (pos,name,vis,strict) <- vs ]
                                   
 ;
-private reduce303 =  single 
+private reduce317 =  single 
 ;
-private reduce304 =  liste  
+private reduce318 =  liste  
 ;
-private reduce306 =  \_ \(pos,name,vis,strict) -> (pos,name,Public, strict) 
+private reduce320 =  \_ \(pos,name,vis,strict) -> (pos,name,Public, strict) 
 ;
-private reduce307 =  \_ \(pos,name,vis,strict) -> (pos,name,Private,strict) 
+private reduce321 =  \_ \(pos,name,vis,strict) -> (pos,name,Private,strict) 
 ;
-private reduce309 =  \_ \(pos,name,vis,strict) -> (pos,name,vis, true) 
+private reduce323 =  \_ \(pos,name,vis,strict) -> (pos,name,vis, true) 
 ;
-private reduce310 =  \_ \(pos,name,vis,strict) -> (pos,name,vis, false) 
+private reduce324 =  \_ \(pos,name,vis,strict) -> (pos,name,vis, false) 
 ;
-private reduce311 =  \v -> do
+private reduce325 =  \v -> do
                                     g <- getST
                                     return (yyline v, v.value, Public, false)
                                 
 ;
-private reduce312 =  \t\i   \_\r -> TypDcl {pos=yyline i, 
+private reduce326 =  \t\i   \_\r -> TypDcl {pos=yyline i, 
                                                             vis=Public, 
                                                             name=Token.value i, 
                                                             vars=[], 
                                                             typ = r, 
                                                             doc=Nothing}
 ;
-private reduce313 =  \t\i\vs\_\r -> TypDcl {pos=yyline i, 
+private reduce327 =  \t\i\vs\_\r -> TypDcl {pos=yyline i, 
                                                             vis=Public, 
                                                             name=Token.value i, 
                                                             vars=vs, 
                                                             typ = r, 
                                                             doc=Nothing}
 ;
-private reduce314 =  [] 
+private reduce328 =  [] 
 ;
-private reduce315 =  \_\_\_ -> []
+private reduce329 =  \_\_\_ -> []
 ;
-private reduce316 =  \_\_\defs\_ -> defs
+private reduce330 =  \_\_\defs\_ -> defs
 ;
-private reduce317 =  \_\_\_ -> []
+private reduce331 =  \_\_\_ -> []
 ;
-private reduce318 =  \_\_\defs\_ -> defs
+private reduce332 =  \_\_\defs\_ -> defs
 ;
-private reduce319 =  \(ex,pats)\eq\expr -> fundef ex pats expr 
+private reduce333 =  \(ex,pats)\eq\expr -> fundef ex pats expr 
 ;
-private reduce320 =  \(ex,pats)\gds -> fungds ex pats gds 
+private reduce334 =  \(ex,pats)\gds -> fungds ex pats gds 
 ;
-private reduce321 =  \fdefs\defs ->
+private reduce335 =  \fdefs\defs ->
         case fdefs of
             [fd@FunDcl {expr=x}] -> YYM.return [fd.{expr = nx}] where
                                 nx = Let defs x
@@ -6025,134 +6163,134 @@ private reduce321 =  \fdefs\defs ->
                 YYM.return fdefs
     
 ;
-private reduce322 =  \x -> do
+private reduce336 =  \x -> do
                                             x <- funhead x
                                             YYM.return x
                                     
 ;
-private reduce323 =  \x ->  Lit (yyline x) LBool "true" 
+private reduce337 =  \x ->  Lit (yyline x) LBool "true" 
 ;
-private reduce324 =  \x ->  Lit (yyline x) LBool "false"
+private reduce338 =  \x ->  Lit (yyline x) LBool "false"
 ;
-private reduce325 =  \x ->  do litchar x 
+private reduce339 =  \x ->  do litchar x 
 ;
-private reduce326 =  \x ->  Lit (yyline x) LString (Token.value x) 
+private reduce340 =  \x ->  Lit (yyline x) LString (Token.value x) 
 ;
-private reduce327 =  \x ->  Lit (yyline x) LInt    (Token.value x) 
+private reduce341 =  \x ->  Lit (yyline x) LInt    (Token.value x) 
 ;
-private reduce328 =  \x ->  Lit (yyline x) LBig    (bignum x)      
+private reduce342 =  \x ->  Lit (yyline x) LBig    (bignum x)      
 ;
-private reduce329 =  \x ->  Lit (yyline x) LLong   (Token.value x) 
+private reduce343 =  \x ->  Lit (yyline x) LLong   (Token.value x) 
 ;
-private reduce330 =  \x ->  Lit (yyline x) LFloat  (Token.value x) 
+private reduce344 =  \x ->  Lit (yyline x) LFloat  (Token.value x) 
 ;
-private reduce331 =  \x ->  Lit (yyline x) LDouble (Token.value x) 
+private reduce345 =  \x ->  Lit (yyline x) LDouble (Token.value x) 
 ;
-private reduce332 =  \x ->  do litregexp x 
+private reduce346 =  \x ->  do litregexp x 
 ;
-private reduce337 =  \e\t\x -> do { (ex,pat) <- funhead e; YYM.return (Right (fundef ex pat x)) }
+private reduce351 =  \e\t\x -> do { (ex,pat) <- funhead e; YYM.return (Right (fundef ex pat x)) }
 ;
-private reduce338 =  \_\_\ds\_ -> Right ds 
+private reduce352 =  \_\_\ds\_ -> Right ds 
 ;
-private reduce339 =  single 
+private reduce353 =  single 
 ;
-private reduce340 =  liste  
+private reduce354 =  liste  
 ;
-private reduce341 =  (const . single) 
+private reduce355 =  (const . single) 
 ;
-private reduce342 =  single 
+private reduce356 =  single 
 ;
-private reduce343 =  (const . single) 
+private reduce357 =  (const . single) 
 ;
-private reduce344 =  liste 
+private reduce358 =  liste 
 ;
-private reduce345 =  \e     ->  Left (Nothing, e) 
+private reduce359 =  \e     ->  Left (Nothing, e) 
 ;
-private reduce346 =  \p\g\e ->  Left (Just p,  e) 
+private reduce360 =  \p\g\e ->  Left (Just p,  e) 
 ;
-private reduce347 =  single 
+private reduce361 =  single 
 ;
-private reduce348 =  liste  
+private reduce362 =  liste  
 ;
-private reduce349 =  (const . single) 
+private reduce363 =  (const . single) 
 ;
-private reduce350 =  \a\qs\_\x  -> (yyline a, qs, x) 
+private reduce364 =  \a\qs\_\x  -> (yyline a, qs, x) 
 ;
-private reduce351 =  single 
+private reduce365 =  single 
 ;
-private reduce352 =  (:) 
+private reduce366 =  (:) 
 ;
-private reduce353 =  \p\a\e ->
+private reduce367 =  \p\a\e ->
                                         CAlt {pat=p, ex=e}
 ;
-private reduce354 =  \p\gs -> guardedalt p gs
+private reduce368 =  \p\gs -> guardedalt p gs
 ;
-private reduce355 = \(calt::CAltS)\defs ->
+private reduce369 = \(calt::CAltS)\defs ->
                                         let
                                             nx = Let defs calt.ex;
                                         in calt.{ ex = nx } 
 ;
-private reduce356 =  single 
+private reduce370 =  single 
 ;
-private reduce357 =  liste  
+private reduce371 =  liste  
 ;
-private reduce358 =  \a\_    ->  [a] 
+private reduce372 =  \a\_    ->  [a] 
 ;
-private reduce359 =  \_\ps\b  -> foldr (\p\x -> Lam p x false) b ps 
+private reduce373 =  \_\ps\b  -> foldr (\p\x -> Lam p x false) b ps 
 ;
-private reduce361 =  \_\x -> x 
+private reduce375 =  \_\x -> x 
 ;
-private reduce362 =  \x\_\t  -> Ann {ex = x, typ=t} 
+private reduce376 =  \x\_\t  -> Ann {ex = x, typ=t} 
 ;
-private reduce364 =  flip const 
+private reduce378 =  flip const 
 ;
-private reduce366 =  flip const 
+private reduce380 =  flip const 
 ;
-private reduce368 =  mkapp 
+private reduce382 =  mkapp 
 ;
-private reduce369 =  mkapp 
+private reduce383 =  mkapp 
 ;
-private reduce370 =  \m\x -> nApp (Vbl (contextName m "negate")) x
+private reduce384 =  \m\x -> nApp (Vbl (contextName m "negate")) x
 ;
-private reduce372 =  \_\c\_\t\_\e  -> Ifte c t e
+private reduce386 =  \_\c\_\t\_\e  -> Ifte c t e
 ;
-private reduce373 =  \_\e\_\_\as\_ -> Case CNormal e as
+private reduce387 =  \_\e\_\_\as\_ -> Case CNormal e as
 ;
-private reduce374 =  \_\_\ds\_\_\e -> Let ds e
+private reduce388 =  \_\_\ds\_\_\e -> Let ds e
 ;
-private reduce376 =  underscore 
+private reduce390 =  underscore 
 ;
-private reduce378 =  nApp 
+private reduce392 =  nApp 
 ;
-private reduce380 =  \u\p -> nApp (Vbl {name=Simple u}) p
+private reduce394 =  \u\p -> nApp (Vbl {name=Simple u}) p
 ;
-private reduce381 =  single 
+private reduce395 =  single 
 ;
-private reduce382 =  (:) 
+private reduce396 =  (:) 
 ;
-private reduce383 =  With1 
+private reduce397 =  With1 
 ;
-private reduce384 =  With2 
+private reduce398 =  With2 
 ;
-private reduce386 =  \d\_\defs\_   -> do mkMonad (yyline d) defs 
+private reduce400 =  \d\_\defs\_   -> do mkMonad (yyline d) defs 
 ;
-private reduce387 =  \p\_\(v::Token) -> umem p v id
+private reduce401 =  \p\_\(v::Token) -> umem p v id
 ;
-private reduce388 =  \p\_\v -> do {v <- unqualified v;
+private reduce402 =  \p\_\v -> do {v <- unqualified v;
                                                     YYM.return (umem p v id)}
 ;
-private reduce389 =  \p\_\v -> umem p v id
+private reduce403 =  \p\_\v -> umem p v id
 ;
-private reduce390 =  \q\_\(v::Token)\_\_ ->
+private reduce404 =  \q\_\(v::Token)\_\_ ->
                                             Vbl  (q v.{value <- ("has$" ++)}) 
 ;
-private reduce391 =  \q\_\(v::Token)\_\_ ->
+private reduce405 =  \q\_\(v::Token)\_\_ ->
                                             Vbl  (q v.{value <- ("upd$" ++)}) 
 ;
-private reduce392 =  \q\_\(v::Token)\_\_ ->
+private reduce406 =  \q\_\(v::Token)\_\_ ->
                                             Vbl  (q v.{value <- ("chg$" ++)}) 
 ;
-private reduce393 =  \q\(p::Token)\fs\_ -> let {
+private reduce407 =  \q\(p::Token)\fs\_ -> let {
                         -- n   = Simple q;
                         flp = Vbl (wellKnown p "flip");
                         bul = Vbl (contextName p "•");
@@ -6164,93 +6302,93 @@ private reduce393 =  \q\(p::Token)\fs\_ -> let {
                             chup (r, false, e) = flp `nApp` Vbl  (q r.{value <- ("upd$"++)}) `nApp` e;
                                       }} in c fs 
 ;
-private reduce394 =  \p\_\_\(v::Token)\_\_ -> umem p v.{value <- ("has$"++)} id
+private reduce408 =  \p\_\_\(v::Token)\_\_ -> umem p v.{value <- ("has$"++)} id
 ;
-private reduce395 =  \p\_\_\(v::Token)\_\_ -> umem p v.{value <- ("upd$"++)} id
+private reduce409 =  \p\_\_\(v::Token)\_\_ -> umem p v.{value <- ("upd$"++)} id
 ;
-private reduce396 = \p\_\_\(v::Token)\_\_ -> umem p v.{value <- ("chg$"++)} id
+private reduce410 = \p\_\_\(v::Token)\_\_ -> umem p v.{value <- ("chg$"++)} id
 ;
-private reduce397 =  \x\(p::Token)\_\fs\_ ->
+private reduce411 =  \x\(p::Token)\_\fs\_ ->
                                 let {
                         u x [] = x;
                         u x ((r::Token, true , e):xs) = u (umem x r.{value <- ("chg$" ++)} (`nApp` e))  xs;
                         u x ((r::Token, false, e):xs) = u (umem x r.{value <- ("upd$" ++)} (`nApp` e))  xs;
                                 } in u x fs
 ;
-private reduce398 =  \p\t\_\v\_  ->
+private reduce412 =  \p\t\_\v\_  ->
                                         let elem = t.{tokid = VARID, value = "elemAt"}
                                         in Vbl {name=Simple elem}
                                             `nApp` p
                                             `nApp` v
 ;
-private reduce399 =  \x   -> Vbl {name=x} 
+private reduce413 =  \x   -> Vbl {name=x} 
 ;
-private reduce401 =  \t   -> Vbl {name = Simple t.{tokid=VARID, value="_"}} 
+private reduce415 =  \t   -> Vbl {name = Simple t.{tokid=VARID, value="_"}} 
 ;
-private reduce402 =  \qc  -> Con {name=qc} 
+private reduce416 =  \qc  -> Con {name=qc} 
 ;
-private reduce403 =  \qc\_\z    -> ConFS {name=qc, fields=[]}
+private reduce417 =  \qc\_\z    -> ConFS {name=qc, fields=[]}
 ;
-private reduce404 =  \qc\_\fs\z -> ConFS {name=qc, fields=fs}
+private reduce418 =  \qc\_\fs\z -> ConFS {name=qc, fields=fs}
 ;
-private reduce405 =  \z\_   -> Con (With1 baseToken z.{tokid=CONID, value="()"})
+private reduce419 =  \z\_   -> Con (With1 baseToken z.{tokid=CONID, value="()"})
 ;
-private reduce406 =  \z\n\_ -> Con (With1 baseToken z.{tokid=CONID, value=tuple (n+1)})
+private reduce420 =  \z\n\_ -> Con (With1 baseToken z.{tokid=CONID, value=tuple (n+1)})
 ;
-private reduce407 =  \_\x\_ -> Vbl {name=Simple x} 
+private reduce421 =  \_\x\_ -> Vbl {name=Simple x} 
 ;
-private reduce408 =  \_\o\_ -> (varcon o) (opSname o)
+private reduce422 =  \_\o\_ -> (varcon o) (opSname o)
 ;
-private reduce409 =  \_\m\_ -> (Vbl (With1 baseToken m)) 
+private reduce423 =  \_\m\_ -> (Vbl (With1 baseToken m)) 
 ;
-private reduce410 =  \z\o\x\_ ->  let -- (+1) --> flip (+) 1
+private reduce424 =  \z\o\x\_ ->  let -- (+1) --> flip (+) 1
                                         flp = Vbl (contextName z "flip") 
                                         op  = (varcon o) (opSname o)
                                         ex = nApp (nApp flp op) x
                                     in ex
 ;
-private reduce411 =  \_\x\o\_ ->  -- (1+) --> (+) 1
+private reduce425 =  \_\x\o\_ ->  -- (1+) --> (+) 1
                                         nApp ((varcon o) (opSname o)) x
 ;
-private reduce412 =  \_\x\o\_ ->  -- (1+) --> (+) 1
+private reduce426 =  \_\x\o\_ ->  -- (1+) --> (+) 1
                                         nApp ((varcon o) (Simple o)) x
 ;
-private reduce413 =  \a\e\x\es\_ -> fold nApp (Con 
+private reduce427 =  \a\e\x\es\_ -> fold nApp (Con 
                                                                    (With1 baseToken x.{tokid=CONID, value=tuple (1+length es)})
                                                                    )
                                                               (e:es)
 ;
-private reduce414 =  \a\e\(x::Token)\es\_ -> fold nApp (Vbl 
+private reduce428 =  \a\e\(x::Token)\es\_ -> fold nApp (Vbl 
                                                                    (With1 baseToken x.{tokid=VARID, value="strictTuple" ++ show (1+length es)})
                                                                     )
                                                               (e:es)
 ;
-private reduce415 =  \_\x\_ -> Term x 
+private reduce429 =  \_\x\_ -> Term x 
 ;
-private reduce416 =  \a\z ->  Con (With1 baseToken z.{tokid=CONID, value="[]"})
+private reduce430 =  \a\z ->  Con (With1 baseToken z.{tokid=CONID, value="[]"})
 ;
-private reduce417 =  \b\es\z -> 
+private reduce431 =  \b\es\z -> 
                                                 foldr (\a\as -> nApp (nApp (Con (With1 baseToken b.{tokid=CONID, value=":"})) a) as)
                                                        (Con (With1 baseToken z.{tokid=CONID, value="[]"}))
                                                        es
 ;
-private reduce418 =  \a\b\c\d   -> do mkEnumFrom   a b c d
+private reduce432 =  \a\b\c\d   -> do mkEnumFrom   a b c d
 ;
-private reduce419 =  \a\b\c\d\e -> do mkEnumFromTo a b c d e
+private reduce433 =  \a\b\c\d\e -> do mkEnumFromTo a b c d e
 ;
-private reduce420 =  \(a::Token)\e\b\qs\(z::Token) -> do {
+private reduce434 =  \(a::Token)\e\b\qs\(z::Token) -> do {
                 let {nil = z.{tokid=CONID, value="[]"}};
                 listComprehension (yyline b) e qs
                                             (Con {name = With1 baseToken nil})
                                     }
 ;
-private reduce421 =  const 1 
+private reduce435 =  const 1 
 ;
-private reduce422 =  ((+) . const 1) 
+private reduce436 =  ((+) . const 1) 
 ;
-private reduce423 =  single 
+private reduce437 =  single 
 ;
-private reduce424 =  \a\c\ls ->
+private reduce438 =  \a\c\ls ->
                                         if elemBy (using fst) a ls then do {
                                                 E.warn (yyline c) (msgdoc ("field `" ++ fst a
                                                     ++ "` should appear only once."));
@@ -6259,35 +6397,35 @@ private reduce424 =  \a\c\ls ->
                                                 YYM.return (a:ls)
                                     
 ;
-private reduce425 =  (const . single) 
-;
-private reduce426 =  single 
-;
-private reduce427 =  liste  
-;
-private reduce428 =  (const . single) 
-;
-private reduce429 =  \s\_\x ->  (s, true,  x) 
-;
-private reduce430 =  \s\_\x ->  (s, false, x) 
-;
-private reduce431 =  \s     ->  (s, false, Vbl (Simple s)) 
-;
-private reduce432 =  \s\_\x ->  (Token.value s, x) 
-;
-private reduce433 =  \s     ->  (s.value, Vbl (Simple s)) 
-;
-private reduce434 =  single 
-;
-private reduce435 =  liste  
-;
-private reduce436 =  (const . single) 
-;
-private reduce437 =  single 
-;
-private reduce438 =  liste 
-;
 private reduce439 =  (const . single) 
+;
+private reduce440 =  single 
+;
+private reduce441 =  liste  
+;
+private reduce442 =  (const . single) 
+;
+private reduce443 =  \s\_\x ->  (s, true,  x) 
+;
+private reduce444 =  \s\_\x ->  (s, false, x) 
+;
+private reduce445 =  \s     ->  (s, false, Vbl (Simple s)) 
+;
+private reduce446 =  \s\_\x ->  (Token.value s, x) 
+;
+private reduce447 =  \s     ->  (s.value, Vbl (Simple s)) 
+;
+private reduce448 =  single 
+;
+private reduce449 =  liste  
+;
+private reduce450 =  (const . single) 
+;
+private reduce451 =  single 
+;
+private reduce452 =  liste 
+;
+private reduce453 =  (const . single) 
 ;
 yyrule 1 = "package: packageclause ';' definitions";
 yyrule 2 = "package: packageclause WHERE '{' definitions '}'";
@@ -6552,182 +6690,196 @@ yyrule 260 = "kind: simplekind";
 yyrule 261 = "simplekind: SOMEOP";
 yyrule 262 = "simplekind: VARID";
 yyrule 263 = "simplekind: '(' kind ')'";
-yyrule 264 = "classdef: CLASS CONID tyvar wheredef";
-yyrule 265 = "classdef: CLASS CONID tau EARROW varid wheredef";
-yyrule 266 = "instdef: INSTANCE tyname sigma wheredef";
-yyrule 267 = "derivedef: DERIVE tyname sigma";
-yyrule 268 = "datadef: datainit wheredef";
-yyrule 269 = "nativepur: PURE NATIVE";
-yyrule 270 = "nativepur: MUTABLE NATIVE";
-yyrule 271 = "nativepur: NATIVE";
-yyrule 272 = "datainit: DATA CONID '=' nativepur nativename";
-yyrule 273 = "datainit: DATA CONID dvars '=' nativepur nativename";
-yyrule 274 = "datainit: DATA CONID dvars '=' dalts";
-yyrule 275 = "datainit: DATA CONID '=' dalts";
-yyrule 276 = "dvars: tyvar";
-yyrule 277 = "dvars: tyvar dvars";
-yyrule 278 = "dalts: dalt";
-yyrule 279 = "dalts: dalt '|' dalts";
-yyrule 280 = "dalt: visdalt";
-yyrule 281 = "dalt: visdalt DOCUMENTATION";
-yyrule 282 = "dalt: DOCUMENTATION visdalt";
-yyrule 283 = "visdalt: strictdalt";
-yyrule 284 = "visdalt: PUBLIC strictdalt";
-yyrule 285 = "visdalt: PRIVATE strictdalt";
-yyrule 286 = "visdalt: PROTECTED strictdalt";
-yyrule 287 = "strictdalt: '!' simpledalt";
-yyrule 288 = "strictdalt: '?' simpledalt";
-yyrule 289 = "strictdalt: simpledalt";
-yyrule 290 = "simpledalt: CONID";
-yyrule 291 = "simpledalt: CONID '{' conflds '}'";
-yyrule 292 = "simpledalt: CONID contypes";
-yyrule 293 = "contypes: simpletypes";
-yyrule 294 = "simpletypes: simpletype";
-yyrule 295 = "simpletypes: simpletype simpletypes";
-yyrule 296 = "conflds: confld";
-yyrule 297 = "conflds: confld ','";
-yyrule 298 = "conflds: confld DOCUMENTATION";
-yyrule 299 = "conflds: confld ',' conflds";
-yyrule 300 = "conflds: confld DOCUMENTATION conflds";
-yyrule 301 = "confld: fldids DCOLON sigma";
-yyrule 302 = "confld: docs fldids DCOLON sigma";
-yyrule 303 = "fldids: fldid";
-yyrule 304 = "fldids: fldid ',' fldids";
-yyrule 305 = "fldid: strictfldid";
-yyrule 306 = "fldid: PUBLIC strictfldid";
-yyrule 307 = "fldid: PRIVATE strictfldid";
-yyrule 308 = "strictfldid: plainfldid";
-yyrule 309 = "strictfldid: '!' plainfldid";
-yyrule 310 = "strictfldid: '?' plainfldid";
-yyrule 311 = "plainfldid: varid";
-yyrule 312 = "typedef: TYPE CONID '=' sigma";
-yyrule 313 = "typedef: TYPE CONID dvars '=' sigma";
-yyrule 314 = "wheredef: <empty>";
-yyrule 315 = "wheredef: WHERE '{' '}'";
-yyrule 316 = "wheredef: WHERE '{' localdefs '}'";
-yyrule 317 = "wherelet: WHERE '{' '}'";
-yyrule 318 = "wherelet: WHERE '{' letdefs '}'";
-yyrule 319 = "fundef: funhead '=' expr";
-yyrule 320 = "fundef: funhead guards";
-yyrule 321 = "fundef: fundef wherelet";
-yyrule 322 = "funhead: binex";
-yyrule 323 = "literal: TRUE";
-yyrule 324 = "literal: FALSE";
-yyrule 325 = "literal: CHRCONST";
-yyrule 326 = "literal: STRCONST";
-yyrule 327 = "literal: INTCONST";
-yyrule 328 = "literal: BIGCONST";
-yyrule 329 = "literal: LONGCONST";
-yyrule 330 = "literal: FLTCONST";
-yyrule 331 = "literal: DBLCONST";
-yyrule 332 = "literal: REGEXP";
-yyrule 333 = "pattern: expr";
-yyrule 334 = "aeq: ARROW";
-yyrule 335 = "aeq: '='";
-yyrule 336 = "lcqual: gqual";
-yyrule 337 = "lcqual: expr '=' expr";
-yyrule 338 = "lcqual: LET '{' letdefs '}'";
-yyrule 339 = "lcquals: lcqual";
-yyrule 340 = "lcquals: lcqual ',' lcquals";
-yyrule 341 = "lcquals: lcqual ','";
-yyrule 342 = "dodefs: lcqual";
-yyrule 343 = "dodefs: lcqual semicoli";
-yyrule 344 = "dodefs: lcqual semicoli dodefs";
-yyrule 345 = "gqual: expr";
-yyrule 346 = "gqual: expr GETS expr";
-yyrule 347 = "gquals: gqual";
-yyrule 348 = "gquals: gqual ',' gquals";
-yyrule 349 = "gquals: gqual ','";
-yyrule 350 = "guard: '|' gquals aeq expr";
-yyrule 351 = "guards: guard";
-yyrule 352 = "guards: guard guards";
-yyrule 353 = "calt: pattern aeq expr";
-yyrule 354 = "calt: pattern guards";
-yyrule 355 = "calt: calt wherelet";
-yyrule 356 = "calts: calt";
-yyrule 357 = "calts: calt ';' calts";
-yyrule 358 = "calts: calt ';'";
-yyrule 359 = "lambda: '\\' apats lambdabody";
-yyrule 360 = "lambdabody: lambda";
-yyrule 361 = "lambdabody: ARROW expr";
-yyrule 362 = "expr: binex DCOLON sigma";
-yyrule 363 = "expr: binex";
-yyrule 364 = "thenx: ';' THEN";
-yyrule 365 = "thenx: THEN";
-yyrule 366 = "elsex: ';' ELSE";
-yyrule 367 = "elsex: ELSE";
-yyrule 368 = "binex: binex SOMEOP binex";
-yyrule 369 = "binex: binex '-' binex";
-yyrule 370 = "binex: '-' topex";
-yyrule 371 = "binex: topex";
-yyrule 372 = "topex: IF expr thenx expr elsex expr";
-yyrule 373 = "topex: CASE expr OF '{' calts '}'";
-yyrule 374 = "topex: LET '{' letdefs '}' IN expr";
-yyrule 375 = "topex: lambda";
-yyrule 376 = "topex: appex";
-yyrule 377 = "appex: unex";
-yyrule 378 = "appex: appex unex";
-yyrule 379 = "unex: primary";
-yyrule 380 = "unex: unop unex";
-yyrule 381 = "apats: unex";
-yyrule 382 = "apats: unex apats";
-yyrule 383 = "qualifiers: QUALIFIER";
-yyrule 384 = "qualifiers: QUALIFIER QUALIFIER";
-yyrule 385 = "primary: term";
-yyrule 386 = "primary: DO '{' dodefs '}'";
-yyrule 387 = "primary: primary '.' VARID";
-yyrule 388 = "primary: primary '.' operator";
-yyrule 389 = "primary: primary '.' unop";
-yyrule 390 = "primary: qualifiers '{' VARID '?' '}'";
-yyrule 391 = "primary: qualifiers '{' VARID '=' '}'";
-yyrule 392 = "primary: qualifiers '{' VARID GETS '}'";
-yyrule 393 = "primary: qualifiers '{' getfields '}'";
-yyrule 394 = "primary: primary '.' '{' VARID '?' '}'";
-yyrule 395 = "primary: primary '.' '{' VARID '=' '}'";
-yyrule 396 = "primary: primary '.' '{' VARID GETS '}'";
-yyrule 397 = "primary: primary '.' '{' getfields '}'";
-yyrule 398 = "primary: primary '.' '[' expr ']'";
-yyrule 399 = "term: qvarid";
-yyrule 400 = "term: literal";
-yyrule 401 = "term: '_'";
-yyrule 402 = "term: qconid";
-yyrule 403 = "term: qconid '{' '}'";
-yyrule 404 = "term: qconid '{' fields '}'";
-yyrule 405 = "term: '(' ')'";
-yyrule 406 = "term: '(' commata ')'";
-yyrule 407 = "term: '(' unop ')'";
-yyrule 408 = "term: '(' operator ')'";
-yyrule 409 = "term: '(' '-' ')'";
-yyrule 410 = "term: '(' operator expr ')'";
-yyrule 411 = "term: '(' binex operator ')'";
-yyrule 412 = "term: '(' binex '-' ')'";
-yyrule 413 = "term: '(' expr ',' exprSC ')'";
-yyrule 414 = "term: '(' expr ';' exprSS ')'";
-yyrule 415 = "term: '(' expr ')'";
-yyrule 416 = "term: '[' ']'";
-yyrule 417 = "term: '[' exprSC ']'";
-yyrule 418 = "term: '[' exprSC DOTDOT ']'";
-yyrule 419 = "term: '[' exprSC DOTDOT expr ']'";
-yyrule 420 = "term: '[' expr '|' lcquals ']'";
-yyrule 421 = "commata: ','";
-yyrule 422 = "commata: ',' commata";
-yyrule 423 = "fields: field";
-yyrule 424 = "fields: field ',' fields";
-yyrule 425 = "fields: field ','";
-yyrule 426 = "getfields: getfield";
-yyrule 427 = "getfields: getfield ',' getfields";
-yyrule 428 = "getfields: getfield ','";
-yyrule 429 = "getfield: VARID GETS expr";
-yyrule 430 = "getfield: VARID '=' expr";
-yyrule 431 = "getfield: VARID";
-yyrule 432 = "field: varid '=' expr";
-yyrule 433 = "field: varid";
-yyrule 434 = "exprSC: expr";
-yyrule 435 = "exprSC: expr ',' exprSC";
-yyrule 436 = "exprSC: expr ','";
-yyrule 437 = "exprSS: expr";
-yyrule 438 = "exprSS: expr ';' exprSS";
-yyrule 439 = "exprSS: expr ';'";
+yyrule 264 = "scontext: qconid tyvar";
+yyrule 265 = "scontexts: scontext";
+yyrule 266 = "scontexts: scontext ','";
+yyrule 267 = "scontexts: scontext ',' scontexts";
+yyrule 268 = "ccontext: scontext";
+yyrule 269 = "ccontext: '(' scontexts ')'";
+yyrule 270 = "classdef: CLASS ccontext EARROW CONID tyvar wheredef";
+yyrule 271 = "classdef: CLASS ccontext wheredef";
+yyrule 272 = "sicontext: qconid simpletype";
+yyrule 273 = "sicontexts: sicontext";
+yyrule 274 = "sicontexts: sicontext ','";
+yyrule 275 = "sicontexts: sicontext ',' sicontexts";
+yyrule 276 = "icontext: sicontext";
+yyrule 277 = "icontext: '(' sicontexts ')'";
+yyrule 278 = "insthead: icontext EARROW tyname simpletype";
+yyrule 279 = "insthead: icontext";
+yyrule 280 = "instdef: INSTANCE insthead wheredef";
+yyrule 281 = "derivedef: DERIVE insthead";
+yyrule 282 = "datadef: datainit wheredef";
+yyrule 283 = "nativepur: PURE NATIVE";
+yyrule 284 = "nativepur: MUTABLE NATIVE";
+yyrule 285 = "nativepur: NATIVE";
+yyrule 286 = "datainit: DATA CONID '=' nativepur nativename";
+yyrule 287 = "datainit: DATA CONID dvars '=' nativepur nativename";
+yyrule 288 = "datainit: DATA CONID dvars '=' dalts";
+yyrule 289 = "datainit: DATA CONID '=' dalts";
+yyrule 290 = "dvars: tyvar";
+yyrule 291 = "dvars: tyvar dvars";
+yyrule 292 = "dalts: dalt";
+yyrule 293 = "dalts: dalt '|' dalts";
+yyrule 294 = "dalt: visdalt";
+yyrule 295 = "dalt: visdalt DOCUMENTATION";
+yyrule 296 = "dalt: DOCUMENTATION visdalt";
+yyrule 297 = "visdalt: strictdalt";
+yyrule 298 = "visdalt: PUBLIC strictdalt";
+yyrule 299 = "visdalt: PRIVATE strictdalt";
+yyrule 300 = "visdalt: PROTECTED strictdalt";
+yyrule 301 = "strictdalt: '!' simpledalt";
+yyrule 302 = "strictdalt: '?' simpledalt";
+yyrule 303 = "strictdalt: simpledalt";
+yyrule 304 = "simpledalt: CONID";
+yyrule 305 = "simpledalt: CONID '{' conflds '}'";
+yyrule 306 = "simpledalt: CONID contypes";
+yyrule 307 = "contypes: simpletypes";
+yyrule 308 = "simpletypes: simpletype";
+yyrule 309 = "simpletypes: simpletype simpletypes";
+yyrule 310 = "conflds: confld";
+yyrule 311 = "conflds: confld ','";
+yyrule 312 = "conflds: confld DOCUMENTATION";
+yyrule 313 = "conflds: confld ',' conflds";
+yyrule 314 = "conflds: confld DOCUMENTATION conflds";
+yyrule 315 = "confld: fldids DCOLON sigma";
+yyrule 316 = "confld: docs fldids DCOLON sigma";
+yyrule 317 = "fldids: fldid";
+yyrule 318 = "fldids: fldid ',' fldids";
+yyrule 319 = "fldid: strictfldid";
+yyrule 320 = "fldid: PUBLIC strictfldid";
+yyrule 321 = "fldid: PRIVATE strictfldid";
+yyrule 322 = "strictfldid: plainfldid";
+yyrule 323 = "strictfldid: '!' plainfldid";
+yyrule 324 = "strictfldid: '?' plainfldid";
+yyrule 325 = "plainfldid: varid";
+yyrule 326 = "typedef: TYPE CONID '=' sigma";
+yyrule 327 = "typedef: TYPE CONID dvars '=' sigma";
+yyrule 328 = "wheredef: <empty>";
+yyrule 329 = "wheredef: WHERE '{' '}'";
+yyrule 330 = "wheredef: WHERE '{' localdefs '}'";
+yyrule 331 = "wherelet: WHERE '{' '}'";
+yyrule 332 = "wherelet: WHERE '{' letdefs '}'";
+yyrule 333 = "fundef: funhead '=' expr";
+yyrule 334 = "fundef: funhead guards";
+yyrule 335 = "fundef: fundef wherelet";
+yyrule 336 = "funhead: binex";
+yyrule 337 = "literal: TRUE";
+yyrule 338 = "literal: FALSE";
+yyrule 339 = "literal: CHRCONST";
+yyrule 340 = "literal: STRCONST";
+yyrule 341 = "literal: INTCONST";
+yyrule 342 = "literal: BIGCONST";
+yyrule 343 = "literal: LONGCONST";
+yyrule 344 = "literal: FLTCONST";
+yyrule 345 = "literal: DBLCONST";
+yyrule 346 = "literal: REGEXP";
+yyrule 347 = "pattern: expr";
+yyrule 348 = "aeq: ARROW";
+yyrule 349 = "aeq: '='";
+yyrule 350 = "lcqual: gqual";
+yyrule 351 = "lcqual: expr '=' expr";
+yyrule 352 = "lcqual: LET '{' letdefs '}'";
+yyrule 353 = "lcquals: lcqual";
+yyrule 354 = "lcquals: lcqual ',' lcquals";
+yyrule 355 = "lcquals: lcqual ','";
+yyrule 356 = "dodefs: lcqual";
+yyrule 357 = "dodefs: lcqual semicoli";
+yyrule 358 = "dodefs: lcqual semicoli dodefs";
+yyrule 359 = "gqual: expr";
+yyrule 360 = "gqual: expr GETS expr";
+yyrule 361 = "gquals: gqual";
+yyrule 362 = "gquals: gqual ',' gquals";
+yyrule 363 = "gquals: gqual ','";
+yyrule 364 = "guard: '|' gquals aeq expr";
+yyrule 365 = "guards: guard";
+yyrule 366 = "guards: guard guards";
+yyrule 367 = "calt: pattern aeq expr";
+yyrule 368 = "calt: pattern guards";
+yyrule 369 = "calt: calt wherelet";
+yyrule 370 = "calts: calt";
+yyrule 371 = "calts: calt ';' calts";
+yyrule 372 = "calts: calt ';'";
+yyrule 373 = "lambda: '\\' apats lambdabody";
+yyrule 374 = "lambdabody: lambda";
+yyrule 375 = "lambdabody: ARROW expr";
+yyrule 376 = "expr: binex DCOLON sigma";
+yyrule 377 = "expr: binex";
+yyrule 378 = "thenx: ';' THEN";
+yyrule 379 = "thenx: THEN";
+yyrule 380 = "elsex: ';' ELSE";
+yyrule 381 = "elsex: ELSE";
+yyrule 382 = "binex: binex SOMEOP binex";
+yyrule 383 = "binex: binex '-' binex";
+yyrule 384 = "binex: '-' topex";
+yyrule 385 = "binex: topex";
+yyrule 386 = "topex: IF expr thenx expr elsex expr";
+yyrule 387 = "topex: CASE expr OF '{' calts '}'";
+yyrule 388 = "topex: LET '{' letdefs '}' IN expr";
+yyrule 389 = "topex: lambda";
+yyrule 390 = "topex: appex";
+yyrule 391 = "appex: unex";
+yyrule 392 = "appex: appex unex";
+yyrule 393 = "unex: primary";
+yyrule 394 = "unex: unop unex";
+yyrule 395 = "apats: unex";
+yyrule 396 = "apats: unex apats";
+yyrule 397 = "qualifiers: QUALIFIER";
+yyrule 398 = "qualifiers: QUALIFIER QUALIFIER";
+yyrule 399 = "primary: term";
+yyrule 400 = "primary: DO '{' dodefs '}'";
+yyrule 401 = "primary: primary '.' VARID";
+yyrule 402 = "primary: primary '.' operator";
+yyrule 403 = "primary: primary '.' unop";
+yyrule 404 = "primary: qualifiers '{' VARID '?' '}'";
+yyrule 405 = "primary: qualifiers '{' VARID '=' '}'";
+yyrule 406 = "primary: qualifiers '{' VARID GETS '}'";
+yyrule 407 = "primary: qualifiers '{' getfields '}'";
+yyrule 408 = "primary: primary '.' '{' VARID '?' '}'";
+yyrule 409 = "primary: primary '.' '{' VARID '=' '}'";
+yyrule 410 = "primary: primary '.' '{' VARID GETS '}'";
+yyrule 411 = "primary: primary '.' '{' getfields '}'";
+yyrule 412 = "primary: primary '.' '[' expr ']'";
+yyrule 413 = "term: qvarid";
+yyrule 414 = "term: literal";
+yyrule 415 = "term: '_'";
+yyrule 416 = "term: qconid";
+yyrule 417 = "term: qconid '{' '}'";
+yyrule 418 = "term: qconid '{' fields '}'";
+yyrule 419 = "term: '(' ')'";
+yyrule 420 = "term: '(' commata ')'";
+yyrule 421 = "term: '(' unop ')'";
+yyrule 422 = "term: '(' operator ')'";
+yyrule 423 = "term: '(' '-' ')'";
+yyrule 424 = "term: '(' operator expr ')'";
+yyrule 425 = "term: '(' binex operator ')'";
+yyrule 426 = "term: '(' binex '-' ')'";
+yyrule 427 = "term: '(' expr ',' exprSC ')'";
+yyrule 428 = "term: '(' expr ';' exprSS ')'";
+yyrule 429 = "term: '(' expr ')'";
+yyrule 430 = "term: '[' ']'";
+yyrule 431 = "term: '[' exprSC ']'";
+yyrule 432 = "term: '[' exprSC DOTDOT ']'";
+yyrule 433 = "term: '[' exprSC DOTDOT expr ']'";
+yyrule 434 = "term: '[' expr '|' lcquals ']'";
+yyrule 435 = "commata: ','";
+yyrule 436 = "commata: ',' commata";
+yyrule 437 = "fields: field";
+yyrule 438 = "fields: field ',' fields";
+yyrule 439 = "fields: field ','";
+yyrule 440 = "getfields: getfield";
+yyrule 441 = "getfields: getfield ',' getfields";
+yyrule 442 = "getfields: getfield ','";
+yyrule 443 = "getfield: VARID GETS expr";
+yyrule 444 = "getfield: VARID '=' expr";
+yyrule 445 = "getfield: VARID";
+yyrule 446 = "field: varid '=' expr";
+yyrule 447 = "field: varid";
+yyrule 448 = "exprSC: expr";
+yyrule 449 = "exprSC: expr ',' exprSC";
+yyrule 450 = "exprSC: expr ','";
+yyrule 451 = "exprSS: expr";
+yyrule 452 = "exprSS: expr ';' exprSS";
+yyrule 453 = "exprSS: expr ';'";
 yyrule _ = "<unknown rule>";
 
 private yyprod1 ((_, (YYNTdefinitions yy3)):(_, (YYTok yy2)):(_, (YYNTpackageclause yy1)):yyvs) =  do { yyr <- reduce1 yy1 yy2 yy3 ;YYM.return (YYNTpackage yyr, yyvs)};
@@ -7253,359 +7405,387 @@ private yyprod262 ((_, (YYTok yy1)):yyvs) =  do { yyr <- reduce262 yy1 ;YYM.retu
 private yyprod262 yyvals = yybadprod 262 yyvals;
 private yyprod263 ((_, (YYTok yy3)):(_, (YYNTkind yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce263 yy1 yy2 yy3}; YYM.return (YYNTsimplekind yyr, yyvs)};
 private yyprod263 yyvals = yybadprod 263 yyvals;
-private yyprod264 ((_, (YYNTwheredef yy4)):(_, (YYNTtyvar yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce264 yy1 yy2 yy3 yy4}; YYM.return (YYNTclassdef yyr, yyvs)};
+private yyprod264 ((_, (YYNTtyvar yy2)):(_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce264 yy1 yy2}; YYM.return (YYNTscontext yyr, yyvs)};
 private yyprod264 yyvals = yybadprod 264 yyvals;
-private yyprod265 ((_, (YYNTwheredef yy6)):(_, (YYNTvarid yy5)):(_, (YYTok yy4)):(_, (YYNTtau yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce265 yy1 yy2 yy3 yy4 yy5 yy6 ;YYM.return (YYNTclassdef yyr, yyvs)};
+private yyprod265 ((_, (YYNTscontext yy1)):yyvs) =  do { let {!yyr = reduce265 yy1}; YYM.return (YYNTscontexts yyr, yyvs)};
 private yyprod265 yyvals = yybadprod 265 yyvals;
-private yyprod266 ((_, (YYNTwheredef yy4)):(_, (YYNTsigma yy3)):(_, (YYNTtyname yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce266 yy1 yy2 yy3 yy4}; YYM.return (YYNTinstdef yyr, yyvs)};
+private yyprod266 ((_, (YYTok yy2)):(_, (YYNTscontext yy1)):yyvs) =  do { let {!yyr = reduce266 yy1 yy2}; YYM.return (YYNTscontexts yyr, yyvs)};
 private yyprod266 yyvals = yybadprod 266 yyvals;
-private yyprod267 ((_, (YYNTsigma yy3)):(_, (YYNTtyname yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce267 yy1 yy2 yy3}; YYM.return (YYNTderivedef yyr, yyvs)};
+private yyprod267 ((_, (YYNTscontexts yy3)):(_, (YYTok yy2)):(_, (YYNTscontext yy1)):yyvs) =  do { let {!yyr = reduce267 yy1 yy2 yy3}; YYM.return (YYNTscontexts yyr, yyvs)};
 private yyprod267 yyvals = yybadprod 267 yyvals;
-private yyprod268 ((_, (YYNTwheredef yy2)):(_, (YYNTdatainit yy1)):yyvs) =  do { let {!yyr = reduce268 yy1 yy2}; YYM.return (YYNTdatadef yyr, yyvs)};
+private yyprod268 ((_, (YYNTscontext yy1)):yyvs) =  do { let {!yyr = reduce268 yy1}; YYM.return (YYNTccontext yyr, yyvs)};
 private yyprod268 yyvals = yybadprod 268 yyvals;
-private yyprod269 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce269 yy1 yy2}; YYM.return (YYNTnativepur yyr, yyvs)};
+private yyprod269 ((_, (YYTok yy3)):(_, (YYNTscontexts yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce269 yy1 yy2 yy3}; YYM.return (YYNTccontext yyr, yyvs)};
 private yyprod269 yyvals = yybadprod 269 yyvals;
-private yyprod270 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce270 yy1 yy2}; YYM.return (YYNTnativepur yyr, yyvs)};
+private yyprod270 ((_, (YYNTwheredef yy6)):(_, (YYNTtyvar yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYNTccontext yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce270 yy1 yy2 yy3 yy4 yy5 yy6 ;YYM.return (YYNTclassdef yyr, yyvs)};
 private yyprod270 yyvals = yybadprod 270 yyvals;
-private yyprod271 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce271 yy1}; YYM.return (YYNTnativepur yyr, yyvs)};
+private yyprod271 ((_, (YYNTwheredef yy3)):(_, (YYNTccontext yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce271 yy1 yy2 yy3 ;YYM.return (YYNTclassdef yyr, yyvs)};
 private yyprod271 yyvals = yybadprod 271 yyvals;
-private yyprod272 ((_, (YYNTnativename yy5)):(_, (YYNTnativepur yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce272 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTdatainit yyr, yyvs)};
+private yyprod272 ((_, (YYNTsimpletype yy2)):(_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce272 yy1 yy2}; YYM.return (YYNTsicontext yyr, yyvs)};
 private yyprod272 yyvals = yybadprod 272 yyvals;
-private yyprod273 ((_, (YYNTnativename yy6)):(_, (YYNTnativepur yy5)):(_, (YYTok yy4)):(_, (YYNTdvars yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce273 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTdatainit yyr, yyvs)};
+private yyprod273 ((_, (YYNTsicontext yy1)):yyvs) =  do { let {!yyr = reduce273 yy1}; YYM.return (YYNTsicontexts yyr, yyvs)};
 private yyprod273 yyvals = yybadprod 273 yyvals;
-private yyprod274 ((_, (YYNTdalts yy5)):(_, (YYTok yy4)):(_, (YYNTdvars yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce274 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTdatainit yyr, yyvs)};
+private yyprod274 ((_, (YYTok yy2)):(_, (YYNTsicontext yy1)):yyvs) =  do { let {!yyr = reduce274 yy1 yy2}; YYM.return (YYNTsicontexts yyr, yyvs)};
 private yyprod274 yyvals = yybadprod 274 yyvals;
-private yyprod275 ((_, (YYNTdalts yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce275 yy1 yy2 yy3 yy4}; YYM.return (YYNTdatainit yyr, yyvs)};
+private yyprod275 ((_, (YYNTsicontexts yy3)):(_, (YYTok yy2)):(_, (YYNTsicontext yy1)):yyvs) =  do { let {!yyr = reduce275 yy1 yy2 yy3}; YYM.return (YYNTsicontexts yyr, yyvs)};
 private yyprod275 yyvals = yybadprod 275 yyvals;
-private yyprod276 ((_, (YYNTtyvar yy1)):yyvs) =  do { let {!yyr = reduce276 yy1}; YYM.return (YYNTdvars yyr, yyvs)};
+private yyprod276 ((_, (YYNTsicontext yy1)):yyvs) =  do { let {!yyr = reduce276 yy1}; YYM.return (YYNTicontext yyr, yyvs)};
 private yyprod276 yyvals = yybadprod 276 yyvals;
-private yyprod277 ((_, (YYNTdvars yy2)):(_, (YYNTtyvar yy1)):yyvs) =  do { let {!yyr = reduce277 yy1 yy2}; YYM.return (YYNTdvars yyr, yyvs)};
+private yyprod277 ((_, (YYTok yy3)):(_, (YYNTsicontexts yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce277 yy1 yy2 yy3}; YYM.return (YYNTicontext yyr, yyvs)};
 private yyprod277 yyvals = yybadprod 277 yyvals;
-private yyprod278 ((_, (YYNTdalt yy1)):yyvs) =  do { let {!yyr = reduce278 yy1}; YYM.return (YYNTdalts yyr, yyvs)};
+private yyprod278 ((_, (YYNTsimpletype yy4)):(_, (YYNTtyname yy3)):(_, (YYTok yy2)):(_, (YYNTicontext yy1)):yyvs) =  do { let {!yyr = reduce278 yy1 yy2 yy3 yy4}; YYM.return (YYNTinsthead yyr, yyvs)};
 private yyprod278 yyvals = yybadprod 278 yyvals;
-private yyprod279 ((_, (YYNTdalts yy3)):(_, (YYTok yy2)):(_, (YYNTdalt yy1)):yyvs) =  do { let {!yyr = reduce279 yy1 yy2 yy3}; YYM.return (YYNTdalts yyr, yyvs)};
+private yyprod279 ((_, (YYNTicontext yy1)):yyvs) =  do { yyr <- reduce279 yy1 ;YYM.return (YYNTinsthead yyr, yyvs)};
 private yyprod279 yyvals = yybadprod 279 yyvals;
-private yyprod280 ((_, (YYNTvisdalt yy1)):yyvs) = YYM.return (YYNTdalt (yy1), yyvs);
+private yyprod280 ((_, (YYNTwheredef yy3)):(_, (YYNTinsthead yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce280 yy1 yy2 yy3}; YYM.return (YYNTinstdef yyr, yyvs)};
 private yyprod280 yyvals = yybadprod 280 yyvals;
-private yyprod281 ((_, (YYTok yy2)):(_, (YYNTvisdalt yy1)):yyvs) =  do { let {!yyr = reduce281 yy1 yy2}; YYM.return (YYNTdalt yyr, yyvs)};
+private yyprod281 ((_, (YYNTinsthead yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce281 yy1 yy2}; YYM.return (YYNTderivedef yyr, yyvs)};
 private yyprod281 yyvals = yybadprod 281 yyvals;
-private yyprod282 ((_, (YYNTvisdalt yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce282 yy1 yy2}; YYM.return (YYNTdalt yyr, yyvs)};
+private yyprod282 ((_, (YYNTwheredef yy2)):(_, (YYNTdatainit yy1)):yyvs) =  do { let {!yyr = reduce282 yy1 yy2}; YYM.return (YYNTdatadef yyr, yyvs)};
 private yyprod282 yyvals = yybadprod 282 yyvals;
-private yyprod283 ((_, (YYNTstrictdalt yy1)):yyvs) = YYM.return (YYNTvisdalt (yy1), yyvs);
+private yyprod283 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce283 yy1 yy2}; YYM.return (YYNTnativepur yyr, yyvs)};
 private yyprod283 yyvals = yybadprod 283 yyvals;
-private yyprod284 ((_, (YYNTstrictdalt yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce284 yy1 yy2}; YYM.return (YYNTvisdalt yyr, yyvs)};
+private yyprod284 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce284 yy1 yy2}; YYM.return (YYNTnativepur yyr, yyvs)};
 private yyprod284 yyvals = yybadprod 284 yyvals;
-private yyprod285 ((_, (YYNTstrictdalt yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce285 yy1 yy2}; YYM.return (YYNTvisdalt yyr, yyvs)};
+private yyprod285 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce285 yy1}; YYM.return (YYNTnativepur yyr, yyvs)};
 private yyprod285 yyvals = yybadprod 285 yyvals;
-private yyprod286 ((_, (YYNTstrictdalt yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce286 yy1 yy2}; YYM.return (YYNTvisdalt yyr, yyvs)};
+private yyprod286 ((_, (YYNTnativename yy5)):(_, (YYNTnativepur yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce286 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTdatainit yyr, yyvs)};
 private yyprod286 yyvals = yybadprod 286 yyvals;
-private yyprod287 ((_, (YYNTsimpledalt yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce287 yy1 yy2}; YYM.return (YYNTstrictdalt yyr, yyvs)};
+private yyprod287 ((_, (YYNTnativename yy6)):(_, (YYNTnativepur yy5)):(_, (YYTok yy4)):(_, (YYNTdvars yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce287 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTdatainit yyr, yyvs)};
 private yyprod287 yyvals = yybadprod 287 yyvals;
-private yyprod288 ((_, (YYNTsimpledalt yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce288 yy1 yy2}; YYM.return (YYNTstrictdalt yyr, yyvs)};
+private yyprod288 ((_, (YYNTdalts yy5)):(_, (YYTok yy4)):(_, (YYNTdvars yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce288 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTdatainit yyr, yyvs)};
 private yyprod288 yyvals = yybadprod 288 yyvals;
-private yyprod289 ((_, (YYNTsimpledalt yy1)):yyvs) = YYM.return (YYNTstrictdalt (yy1), yyvs);
+private yyprod289 ((_, (YYNTdalts yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce289 yy1 yy2 yy3 yy4}; YYM.return (YYNTdatainit yyr, yyvs)};
 private yyprod289 yyvals = yybadprod 289 yyvals;
-private yyprod290 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce290 yy1}; YYM.return (YYNTsimpledalt yyr, yyvs)};
+private yyprod290 ((_, (YYNTtyvar yy1)):yyvs) =  do { let {!yyr = reduce290 yy1}; YYM.return (YYNTdvars yyr, yyvs)};
 private yyprod290 yyvals = yybadprod 290 yyvals;
-private yyprod291 ((_, (YYTok yy4)):(_, (YYNTconflds yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce291 yy1 yy2 yy3 yy4}; YYM.return (YYNTsimpledalt yyr, yyvs)};
+private yyprod291 ((_, (YYNTdvars yy2)):(_, (YYNTtyvar yy1)):yyvs) =  do { let {!yyr = reduce291 yy1 yy2}; YYM.return (YYNTdvars yyr, yyvs)};
 private yyprod291 yyvals = yybadprod 291 yyvals;
-private yyprod292 ((_, (YYNTcontypes yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce292 yy1 yy2}; YYM.return (YYNTsimpledalt yyr, yyvs)};
+private yyprod292 ((_, (YYNTdalt yy1)):yyvs) =  do { let {!yyr = reduce292 yy1}; YYM.return (YYNTdalts yyr, yyvs)};
 private yyprod292 yyvals = yybadprod 292 yyvals;
-private yyprod293 ((_, (YYNTsimpletypes yy1)):yyvs) =  do { yyr <- reduce293 yy1 ;YYM.return (YYNTcontypes yyr, yyvs)};
+private yyprod293 ((_, (YYNTdalts yy3)):(_, (YYTok yy2)):(_, (YYNTdalt yy1)):yyvs) =  do { let {!yyr = reduce293 yy1 yy2 yy3}; YYM.return (YYNTdalts yyr, yyvs)};
 private yyprod293 yyvals = yybadprod 293 yyvals;
-private yyprod294 ((_, (YYNTsimpletype yy1)):yyvs) =  do { let {!yyr = reduce294 yy1}; YYM.return (YYNTsimpletypes yyr, yyvs)};
+private yyprod294 ((_, (YYNTvisdalt yy1)):yyvs) = YYM.return (YYNTdalt (yy1), yyvs);
 private yyprod294 yyvals = yybadprod 294 yyvals;
-private yyprod295 ((_, (YYNTsimpletypes yy2)):(_, (YYNTsimpletype yy1)):yyvs) =  do { let {!yyr = reduce295 yy1 yy2}; YYM.return (YYNTsimpletypes yyr, yyvs)};
+private yyprod295 ((_, (YYTok yy2)):(_, (YYNTvisdalt yy1)):yyvs) =  do { let {!yyr = reduce295 yy1 yy2}; YYM.return (YYNTdalt yyr, yyvs)};
 private yyprod295 yyvals = yybadprod 295 yyvals;
-private yyprod296 ((_, (YYNTconfld yy1)):yyvs) = YYM.return (YYNTconflds (yy1), yyvs);
+private yyprod296 ((_, (YYNTvisdalt yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce296 yy1 yy2}; YYM.return (YYNTdalt yyr, yyvs)};
 private yyprod296 yyvals = yybadprod 296 yyvals;
-private yyprod297 ((_, (YYTok yy2)):(_, (YYNTconfld yy1)):yyvs) =  do { let {!yyr = reduce297 yy1 yy2}; YYM.return (YYNTconflds yyr, yyvs)};
+private yyprod297 ((_, (YYNTstrictdalt yy1)):yyvs) = YYM.return (YYNTvisdalt (yy1), yyvs);
 private yyprod297 yyvals = yybadprod 297 yyvals;
-private yyprod298 ((_, (YYTok yy2)):(_, (YYNTconfld yy1)):yyvs) =  do { let {!yyr = reduce298 yy1 yy2}; YYM.return (YYNTconflds yyr, yyvs)};
+private yyprod298 ((_, (YYNTstrictdalt yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce298 yy1 yy2}; YYM.return (YYNTvisdalt yyr, yyvs)};
 private yyprod298 yyvals = yybadprod 298 yyvals;
-private yyprod299 ((_, (YYNTconflds yy3)):(_, (YYTok yy2)):(_, (YYNTconfld yy1)):yyvs) =  do { let {!yyr = reduce299 yy1 yy2 yy3}; YYM.return (YYNTconflds yyr, yyvs)};
+private yyprod299 ((_, (YYNTstrictdalt yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce299 yy1 yy2}; YYM.return (YYNTvisdalt yyr, yyvs)};
 private yyprod299 yyvals = yybadprod 299 yyvals;
-private yyprod300 ((_, (YYNTconflds yy3)):(_, (YYTok yy2)):(_, (YYNTconfld yy1)):yyvs) =  do { let {!yyr = reduce300 yy1 yy2 yy3}; YYM.return (YYNTconflds yyr, yyvs)};
+private yyprod300 ((_, (YYNTstrictdalt yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce300 yy1 yy2}; YYM.return (YYNTvisdalt yyr, yyvs)};
 private yyprod300 yyvals = yybadprod 300 yyvals;
-private yyprod301 ((_, (YYNTsigma yy3)):(_, (YYTok yy2)):(_, (YYNTfldids yy1)):yyvs) =  do { let {!yyr = reduce301 yy1 yy2 yy3}; YYM.return (YYNTconfld yyr, yyvs)};
+private yyprod301 ((_, (YYNTsimpledalt yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce301 yy1 yy2}; YYM.return (YYNTstrictdalt yyr, yyvs)};
 private yyprod301 yyvals = yybadprod 301 yyvals;
-private yyprod302 ((_, (YYNTsigma yy4)):(_, (YYTok yy3)):(_, (YYNTfldids yy2)):(_, (YYNTdocs yy1)):yyvs) =  do { let {!yyr = reduce302 yy1 yy2 yy3 yy4}; YYM.return (YYNTconfld yyr, yyvs)};
+private yyprod302 ((_, (YYNTsimpledalt yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce302 yy1 yy2}; YYM.return (YYNTstrictdalt yyr, yyvs)};
 private yyprod302 yyvals = yybadprod 302 yyvals;
-private yyprod303 ((_, (YYNTfldid yy1)):yyvs) =  do { let {!yyr = reduce303 yy1}; YYM.return (YYNTfldids yyr, yyvs)};
+private yyprod303 ((_, (YYNTsimpledalt yy1)):yyvs) = YYM.return (YYNTstrictdalt (yy1), yyvs);
 private yyprod303 yyvals = yybadprod 303 yyvals;
-private yyprod304 ((_, (YYNTfldids yy3)):(_, (YYTok yy2)):(_, (YYNTfldid yy1)):yyvs) =  do { let {!yyr = reduce304 yy1 yy2 yy3}; YYM.return (YYNTfldids yyr, yyvs)};
+private yyprod304 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce304 yy1}; YYM.return (YYNTsimpledalt yyr, yyvs)};
 private yyprod304 yyvals = yybadprod 304 yyvals;
-private yyprod305 ((_, (YYNTstrictfldid yy1)):yyvs) = YYM.return (YYNTfldid (yy1), yyvs);
+private yyprod305 ((_, (YYTok yy4)):(_, (YYNTconflds yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce305 yy1 yy2 yy3 yy4}; YYM.return (YYNTsimpledalt yyr, yyvs)};
 private yyprod305 yyvals = yybadprod 305 yyvals;
-private yyprod306 ((_, (YYNTstrictfldid yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce306 yy1 yy2}; YYM.return (YYNTfldid yyr, yyvs)};
+private yyprod306 ((_, (YYNTcontypes yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce306 yy1 yy2}; YYM.return (YYNTsimpledalt yyr, yyvs)};
 private yyprod306 yyvals = yybadprod 306 yyvals;
-private yyprod307 ((_, (YYNTstrictfldid yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce307 yy1 yy2}; YYM.return (YYNTfldid yyr, yyvs)};
+private yyprod307 ((_, (YYNTsimpletypes yy1)):yyvs) =  do { yyr <- reduce307 yy1 ;YYM.return (YYNTcontypes yyr, yyvs)};
 private yyprod307 yyvals = yybadprod 307 yyvals;
-private yyprod308 ((_, (YYNTplainfldid yy1)):yyvs) = YYM.return (YYNTstrictfldid (yy1), yyvs);
+private yyprod308 ((_, (YYNTsimpletype yy1)):yyvs) =  do { let {!yyr = reduce308 yy1}; YYM.return (YYNTsimpletypes yyr, yyvs)};
 private yyprod308 yyvals = yybadprod 308 yyvals;
-private yyprod309 ((_, (YYNTplainfldid yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce309 yy1 yy2}; YYM.return (YYNTstrictfldid yyr, yyvs)};
+private yyprod309 ((_, (YYNTsimpletypes yy2)):(_, (YYNTsimpletype yy1)):yyvs) =  do { let {!yyr = reduce309 yy1 yy2}; YYM.return (YYNTsimpletypes yyr, yyvs)};
 private yyprod309 yyvals = yybadprod 309 yyvals;
-private yyprod310 ((_, (YYNTplainfldid yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce310 yy1 yy2}; YYM.return (YYNTstrictfldid yyr, yyvs)};
+private yyprod310 ((_, (YYNTconfld yy1)):yyvs) = YYM.return (YYNTconflds (yy1), yyvs);
 private yyprod310 yyvals = yybadprod 310 yyvals;
-private yyprod311 ((_, (YYNTvarid yy1)):yyvs) =  do { yyr <- reduce311 yy1 ;YYM.return (YYNTplainfldid yyr, yyvs)};
+private yyprod311 ((_, (YYTok yy2)):(_, (YYNTconfld yy1)):yyvs) =  do { let {!yyr = reduce311 yy1 yy2}; YYM.return (YYNTconflds yyr, yyvs)};
 private yyprod311 yyvals = yybadprod 311 yyvals;
-private yyprod312 ((_, (YYNTsigma yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce312 yy1 yy2 yy3 yy4}; YYM.return (YYNTtypedef yyr, yyvs)};
+private yyprod312 ((_, (YYTok yy2)):(_, (YYNTconfld yy1)):yyvs) =  do { let {!yyr = reduce312 yy1 yy2}; YYM.return (YYNTconflds yyr, yyvs)};
 private yyprod312 yyvals = yybadprod 312 yyvals;
-private yyprod313 ((_, (YYNTsigma yy5)):(_, (YYTok yy4)):(_, (YYNTdvars yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce313 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTtypedef yyr, yyvs)};
+private yyprod313 ((_, (YYNTconflds yy3)):(_, (YYTok yy2)):(_, (YYNTconfld yy1)):yyvs) =  do { let {!yyr = reduce313 yy1 yy2 yy3}; YYM.return (YYNTconflds yyr, yyvs)};
 private yyprod313 yyvals = yybadprod 313 yyvals;
-private yyprod314 yyvs =  do { let {!yyr = reduce314 }; YYM.return (YYNTwheredef yyr, yyvs)};
-private yyprod315 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce315 yy1 yy2 yy3}; YYM.return (YYNTwheredef yyr, yyvs)};
+private yyprod314 ((_, (YYNTconflds yy3)):(_, (YYTok yy2)):(_, (YYNTconfld yy1)):yyvs) =  do { let {!yyr = reduce314 yy1 yy2 yy3}; YYM.return (YYNTconflds yyr, yyvs)};
+private yyprod314 yyvals = yybadprod 314 yyvals;
+private yyprod315 ((_, (YYNTsigma yy3)):(_, (YYTok yy2)):(_, (YYNTfldids yy1)):yyvs) =  do { let {!yyr = reduce315 yy1 yy2 yy3}; YYM.return (YYNTconfld yyr, yyvs)};
 private yyprod315 yyvals = yybadprod 315 yyvals;
-private yyprod316 ((_, (YYTok yy4)):(_, (YYNTlocaldefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce316 yy1 yy2 yy3 yy4}; YYM.return (YYNTwheredef yyr, yyvs)};
+private yyprod316 ((_, (YYNTsigma yy4)):(_, (YYTok yy3)):(_, (YYNTfldids yy2)):(_, (YYNTdocs yy1)):yyvs) =  do { let {!yyr = reduce316 yy1 yy2 yy3 yy4}; YYM.return (YYNTconfld yyr, yyvs)};
 private yyprod316 yyvals = yybadprod 316 yyvals;
-private yyprod317 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce317 yy1 yy2 yy3}; YYM.return (YYNTwherelet yyr, yyvs)};
+private yyprod317 ((_, (YYNTfldid yy1)):yyvs) =  do { let {!yyr = reduce317 yy1}; YYM.return (YYNTfldids yyr, yyvs)};
 private yyprod317 yyvals = yybadprod 317 yyvals;
-private yyprod318 ((_, (YYTok yy4)):(_, (YYNTletdefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce318 yy1 yy2 yy3 yy4}; YYM.return (YYNTwherelet yyr, yyvs)};
+private yyprod318 ((_, (YYNTfldids yy3)):(_, (YYTok yy2)):(_, (YYNTfldid yy1)):yyvs) =  do { let {!yyr = reduce318 yy1 yy2 yy3}; YYM.return (YYNTfldids yyr, yyvs)};
 private yyprod318 yyvals = yybadprod 318 yyvals;
-private yyprod319 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYNTfunhead yy1)):yyvs) =  do { let {!yyr = reduce319 yy1 yy2 yy3}; YYM.return (YYNTfundef yyr, yyvs)};
+private yyprod319 ((_, (YYNTstrictfldid yy1)):yyvs) = YYM.return (YYNTfldid (yy1), yyvs);
 private yyprod319 yyvals = yybadprod 319 yyvals;
-private yyprod320 ((_, (YYNTguards yy2)):(_, (YYNTfunhead yy1)):yyvs) =  do { let {!yyr = reduce320 yy1 yy2}; YYM.return (YYNTfundef yyr, yyvs)};
+private yyprod320 ((_, (YYNTstrictfldid yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce320 yy1 yy2}; YYM.return (YYNTfldid yyr, yyvs)};
 private yyprod320 yyvals = yybadprod 320 yyvals;
-private yyprod321 ((_, (YYNTwherelet yy2)):(_, (YYNTfundef yy1)):yyvs) =  do { yyr <- reduce321 yy1 yy2 ;YYM.return (YYNTfundef yyr, yyvs)};
+private yyprod321 ((_, (YYNTstrictfldid yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce321 yy1 yy2}; YYM.return (YYNTfldid yyr, yyvs)};
 private yyprod321 yyvals = yybadprod 321 yyvals;
-private yyprod322 ((_, (YYNTbinex yy1)):yyvs) =  do { yyr <- reduce322 yy1 ;YYM.return (YYNTfunhead yyr, yyvs)};
+private yyprod322 ((_, (YYNTplainfldid yy1)):yyvs) = YYM.return (YYNTstrictfldid (yy1), yyvs);
 private yyprod322 yyvals = yybadprod 322 yyvals;
-private yyprod323 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce323 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
+private yyprod323 ((_, (YYNTplainfldid yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce323 yy1 yy2}; YYM.return (YYNTstrictfldid yyr, yyvs)};
 private yyprod323 yyvals = yybadprod 323 yyvals;
-private yyprod324 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce324 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
+private yyprod324 ((_, (YYNTplainfldid yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce324 yy1 yy2}; YYM.return (YYNTstrictfldid yyr, yyvs)};
 private yyprod324 yyvals = yybadprod 324 yyvals;
-private yyprod325 ((_, (YYTok yy1)):yyvs) =  do { yyr <- reduce325 yy1 ;YYM.return (YYNTliteral yyr, yyvs)};
+private yyprod325 ((_, (YYNTvarid yy1)):yyvs) =  do { yyr <- reduce325 yy1 ;YYM.return (YYNTplainfldid yyr, yyvs)};
 private yyprod325 yyvals = yybadprod 325 yyvals;
-private yyprod326 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce326 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
+private yyprod326 ((_, (YYNTsigma yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce326 yy1 yy2 yy3 yy4}; YYM.return (YYNTtypedef yyr, yyvs)};
 private yyprod326 yyvals = yybadprod 326 yyvals;
-private yyprod327 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce327 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
+private yyprod327 ((_, (YYNTsigma yy5)):(_, (YYTok yy4)):(_, (YYNTdvars yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce327 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTtypedef yyr, yyvs)};
 private yyprod327 yyvals = yybadprod 327 yyvals;
-private yyprod328 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce328 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
-private yyprod328 yyvals = yybadprod 328 yyvals;
-private yyprod329 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce329 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
+private yyprod328 yyvs =  do { let {!yyr = reduce328 }; YYM.return (YYNTwheredef yyr, yyvs)};
+private yyprod329 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce329 yy1 yy2 yy3}; YYM.return (YYNTwheredef yyr, yyvs)};
 private yyprod329 yyvals = yybadprod 329 yyvals;
-private yyprod330 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce330 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
+private yyprod330 ((_, (YYTok yy4)):(_, (YYNTlocaldefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce330 yy1 yy2 yy3 yy4}; YYM.return (YYNTwheredef yyr, yyvs)};
 private yyprod330 yyvals = yybadprod 330 yyvals;
-private yyprod331 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce331 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
+private yyprod331 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce331 yy1 yy2 yy3}; YYM.return (YYNTwherelet yyr, yyvs)};
 private yyprod331 yyvals = yybadprod 331 yyvals;
-private yyprod332 ((_, (YYTok yy1)):yyvs) =  do { yyr <- reduce332 yy1 ;YYM.return (YYNTliteral yyr, yyvs)};
+private yyprod332 ((_, (YYTok yy4)):(_, (YYNTletdefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce332 yy1 yy2 yy3 yy4}; YYM.return (YYNTwherelet yyr, yyvs)};
 private yyprod332 yyvals = yybadprod 332 yyvals;
-private yyprod333 ((_, (YYNTexpr yy1)):yyvs) = YYM.return (YYNTpattern (yy1), yyvs);
+private yyprod333 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYNTfunhead yy1)):yyvs) =  do { let {!yyr = reduce333 yy1 yy2 yy3}; YYM.return (YYNTfundef yyr, yyvs)};
 private yyprod333 yyvals = yybadprod 333 yyvals;
-private yyprod334 ((_, (YYTok yy1)):yyvs) = YYM.return (YYNTaeq (yy1), yyvs);
+private yyprod334 ((_, (YYNTguards yy2)):(_, (YYNTfunhead yy1)):yyvs) =  do { let {!yyr = reduce334 yy1 yy2}; YYM.return (YYNTfundef yyr, yyvs)};
 private yyprod334 yyvals = yybadprod 334 yyvals;
-private yyprod335 ((_, (YYTok yy1)):yyvs) = YYM.return (YYNTaeq (yy1), yyvs);
+private yyprod335 ((_, (YYNTwherelet yy2)):(_, (YYNTfundef yy1)):yyvs) =  do { yyr <- reduce335 yy1 yy2 ;YYM.return (YYNTfundef yyr, yyvs)};
 private yyprod335 yyvals = yybadprod 335 yyvals;
-private yyprod336 ((_, (YYNTgqual yy1)):yyvs) = YYM.return (YYNTlcqual (yy1), yyvs);
+private yyprod336 ((_, (YYNTbinex yy1)):yyvs) =  do { yyr <- reduce336 yy1 ;YYM.return (YYNTfunhead yyr, yyvs)};
 private yyprod336 yyvals = yybadprod 336 yyvals;
-private yyprod337 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { yyr <- reduce337 yy1 yy2 yy3 ;YYM.return (YYNTlcqual yyr, yyvs)};
+private yyprod337 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce337 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
 private yyprod337 yyvals = yybadprod 337 yyvals;
-private yyprod338 ((_, (YYTok yy4)):(_, (YYNTletdefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce338 yy1 yy2 yy3 yy4}; YYM.return (YYNTlcqual yyr, yyvs)};
+private yyprod338 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce338 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
 private yyprod338 yyvals = yybadprod 338 yyvals;
-private yyprod339 ((_, (YYNTlcqual yy1)):yyvs) =  do { let {!yyr = reduce339 yy1}; YYM.return (YYNTlcquals yyr, yyvs)};
+private yyprod339 ((_, (YYTok yy1)):yyvs) =  do { yyr <- reduce339 yy1 ;YYM.return (YYNTliteral yyr, yyvs)};
 private yyprod339 yyvals = yybadprod 339 yyvals;
-private yyprod340 ((_, (YYNTlcquals yy3)):(_, (YYTok yy2)):(_, (YYNTlcqual yy1)):yyvs) =  do { let {!yyr = reduce340 yy1 yy2 yy3}; YYM.return (YYNTlcquals yyr, yyvs)};
+private yyprod340 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce340 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
 private yyprod340 yyvals = yybadprod 340 yyvals;
-private yyprod341 ((_, (YYTok yy2)):(_, (YYNTlcqual yy1)):yyvs) =  do { let {!yyr = reduce341 yy1 yy2}; YYM.return (YYNTlcquals yyr, yyvs)};
+private yyprod341 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce341 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
 private yyprod341 yyvals = yybadprod 341 yyvals;
-private yyprod342 ((_, (YYNTlcqual yy1)):yyvs) =  do { let {!yyr = reduce342 yy1}; YYM.return (YYNTdodefs yyr, yyvs)};
+private yyprod342 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce342 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
 private yyprod342 yyvals = yybadprod 342 yyvals;
-private yyprod343 ((_, (YYNTsemicoli yy2)):(_, (YYNTlcqual yy1)):yyvs) =  do { let {!yyr = reduce343 yy1 yy2}; YYM.return (YYNTdodefs yyr, yyvs)};
+private yyprod343 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce343 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
 private yyprod343 yyvals = yybadprod 343 yyvals;
-private yyprod344 ((_, (YYNTdodefs yy3)):(_, (YYNTsemicoli yy2)):(_, (YYNTlcqual yy1)):yyvs) =  do { let {!yyr = reduce344 yy1 yy2 yy3}; YYM.return (YYNTdodefs yyr, yyvs)};
+private yyprod344 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce344 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
 private yyprod344 yyvals = yybadprod 344 yyvals;
-private yyprod345 ((_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce345 yy1}; YYM.return (YYNTgqual yyr, yyvs)};
+private yyprod345 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce345 yy1}; YYM.return (YYNTliteral yyr, yyvs)};
 private yyprod345 yyvals = yybadprod 345 yyvals;
-private yyprod346 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce346 yy1 yy2 yy3}; YYM.return (YYNTgqual yyr, yyvs)};
+private yyprod346 ((_, (YYTok yy1)):yyvs) =  do { yyr <- reduce346 yy1 ;YYM.return (YYNTliteral yyr, yyvs)};
 private yyprod346 yyvals = yybadprod 346 yyvals;
-private yyprod347 ((_, (YYNTgqual yy1)):yyvs) =  do { let {!yyr = reduce347 yy1}; YYM.return (YYNTgquals yyr, yyvs)};
+private yyprod347 ((_, (YYNTexpr yy1)):yyvs) = YYM.return (YYNTpattern (yy1), yyvs);
 private yyprod347 yyvals = yybadprod 347 yyvals;
-private yyprod348 ((_, (YYNTgquals yy3)):(_, (YYTok yy2)):(_, (YYNTgqual yy1)):yyvs) =  do { let {!yyr = reduce348 yy1 yy2 yy3}; YYM.return (YYNTgquals yyr, yyvs)};
+private yyprod348 ((_, (YYTok yy1)):yyvs) = YYM.return (YYNTaeq (yy1), yyvs);
 private yyprod348 yyvals = yybadprod 348 yyvals;
-private yyprod349 ((_, (YYTok yy2)):(_, (YYNTgqual yy1)):yyvs) =  do { let {!yyr = reduce349 yy1 yy2}; YYM.return (YYNTgquals yyr, yyvs)};
+private yyprod349 ((_, (YYTok yy1)):yyvs) = YYM.return (YYNTaeq (yy1), yyvs);
 private yyprod349 yyvals = yybadprod 349 yyvals;
-private yyprod350 ((_, (YYNTexpr yy4)):(_, (YYNTaeq yy3)):(_, (YYNTgquals yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce350 yy1 yy2 yy3 yy4}; YYM.return (YYNTguard yyr, yyvs)};
+private yyprod350 ((_, (YYNTgqual yy1)):yyvs) = YYM.return (YYNTlcqual (yy1), yyvs);
 private yyprod350 yyvals = yybadprod 350 yyvals;
-private yyprod351 ((_, (YYNTguard yy1)):yyvs) =  do { let {!yyr = reduce351 yy1}; YYM.return (YYNTguards yyr, yyvs)};
+private yyprod351 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { yyr <- reduce351 yy1 yy2 yy3 ;YYM.return (YYNTlcqual yyr, yyvs)};
 private yyprod351 yyvals = yybadprod 351 yyvals;
-private yyprod352 ((_, (YYNTguards yy2)):(_, (YYNTguard yy1)):yyvs) =  do { let {!yyr = reduce352 yy1 yy2}; YYM.return (YYNTguards yyr, yyvs)};
+private yyprod352 ((_, (YYTok yy4)):(_, (YYNTletdefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce352 yy1 yy2 yy3 yy4}; YYM.return (YYNTlcqual yyr, yyvs)};
 private yyprod352 yyvals = yybadprod 352 yyvals;
-private yyprod353 ((_, (YYNTexpr yy3)):(_, (YYNTaeq yy2)):(_, (YYNTpattern yy1)):yyvs) =  do { let {!yyr = reduce353 yy1 yy2 yy3}; YYM.return (YYNTcalt yyr, yyvs)};
+private yyprod353 ((_, (YYNTlcqual yy1)):yyvs) =  do { let {!yyr = reduce353 yy1}; YYM.return (YYNTlcquals yyr, yyvs)};
 private yyprod353 yyvals = yybadprod 353 yyvals;
-private yyprod354 ((_, (YYNTguards yy2)):(_, (YYNTpattern yy1)):yyvs) =  do { let {!yyr = reduce354 yy1 yy2}; YYM.return (YYNTcalt yyr, yyvs)};
+private yyprod354 ((_, (YYNTlcquals yy3)):(_, (YYTok yy2)):(_, (YYNTlcqual yy1)):yyvs) =  do { let {!yyr = reduce354 yy1 yy2 yy3}; YYM.return (YYNTlcquals yyr, yyvs)};
 private yyprod354 yyvals = yybadprod 354 yyvals;
-private yyprod355 ((_, (YYNTwherelet yy2)):(_, (YYNTcalt yy1)):yyvs) =  do { let {!yyr = reduce355 yy1 yy2}; YYM.return (YYNTcalt yyr, yyvs)};
+private yyprod355 ((_, (YYTok yy2)):(_, (YYNTlcqual yy1)):yyvs) =  do { let {!yyr = reduce355 yy1 yy2}; YYM.return (YYNTlcquals yyr, yyvs)};
 private yyprod355 yyvals = yybadprod 355 yyvals;
-private yyprod356 ((_, (YYNTcalt yy1)):yyvs) =  do { let {!yyr = reduce356 yy1}; YYM.return (YYNTcalts yyr, yyvs)};
+private yyprod356 ((_, (YYNTlcqual yy1)):yyvs) =  do { let {!yyr = reduce356 yy1}; YYM.return (YYNTdodefs yyr, yyvs)};
 private yyprod356 yyvals = yybadprod 356 yyvals;
-private yyprod357 ((_, (YYNTcalts yy3)):(_, (YYTok yy2)):(_, (YYNTcalt yy1)):yyvs) =  do { let {!yyr = reduce357 yy1 yy2 yy3}; YYM.return (YYNTcalts yyr, yyvs)};
+private yyprod357 ((_, (YYNTsemicoli yy2)):(_, (YYNTlcqual yy1)):yyvs) =  do { let {!yyr = reduce357 yy1 yy2}; YYM.return (YYNTdodefs yyr, yyvs)};
 private yyprod357 yyvals = yybadprod 357 yyvals;
-private yyprod358 ((_, (YYTok yy2)):(_, (YYNTcalt yy1)):yyvs) =  do { let {!yyr = reduce358 yy1 yy2}; YYM.return (YYNTcalts yyr, yyvs)};
+private yyprod358 ((_, (YYNTdodefs yy3)):(_, (YYNTsemicoli yy2)):(_, (YYNTlcqual yy1)):yyvs) =  do { let {!yyr = reduce358 yy1 yy2 yy3}; YYM.return (YYNTdodefs yyr, yyvs)};
 private yyprod358 yyvals = yybadprod 358 yyvals;
-private yyprod359 ((_, (YYNTlambdabody yy3)):(_, (YYNTapats yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce359 yy1 yy2 yy3}; YYM.return (YYNTlambda yyr, yyvs)};
+private yyprod359 ((_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce359 yy1}; YYM.return (YYNTgqual yyr, yyvs)};
 private yyprod359 yyvals = yybadprod 359 yyvals;
-private yyprod360 ((_, (YYNTlambda yy1)):yyvs) = YYM.return (YYNTlambdabody (yy1), yyvs);
+private yyprod360 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce360 yy1 yy2 yy3}; YYM.return (YYNTgqual yyr, yyvs)};
 private yyprod360 yyvals = yybadprod 360 yyvals;
-private yyprod361 ((_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce361 yy1 yy2}; YYM.return (YYNTlambdabody yyr, yyvs)};
+private yyprod361 ((_, (YYNTgqual yy1)):yyvs) =  do { let {!yyr = reduce361 yy1}; YYM.return (YYNTgquals yyr, yyvs)};
 private yyprod361 yyvals = yybadprod 361 yyvals;
-private yyprod362 ((_, (YYNTsigma yy3)):(_, (YYTok yy2)):(_, (YYNTbinex yy1)):yyvs) =  do { let {!yyr = reduce362 yy1 yy2 yy3}; YYM.return (YYNTexpr yyr, yyvs)};
+private yyprod362 ((_, (YYNTgquals yy3)):(_, (YYTok yy2)):(_, (YYNTgqual yy1)):yyvs) =  do { let {!yyr = reduce362 yy1 yy2 yy3}; YYM.return (YYNTgquals yyr, yyvs)};
 private yyprod362 yyvals = yybadprod 362 yyvals;
-private yyprod363 ((_, (YYNTbinex yy1)):yyvs) = YYM.return (YYNTexpr (yy1), yyvs);
+private yyprod363 ((_, (YYTok yy2)):(_, (YYNTgqual yy1)):yyvs) =  do { let {!yyr = reduce363 yy1 yy2}; YYM.return (YYNTgquals yyr, yyvs)};
 private yyprod363 yyvals = yybadprod 363 yyvals;
-private yyprod364 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce364 yy1 yy2}; YYM.return (YYNTthenx yyr, yyvs)};
+private yyprod364 ((_, (YYNTexpr yy4)):(_, (YYNTaeq yy3)):(_, (YYNTgquals yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce364 yy1 yy2 yy3 yy4}; YYM.return (YYNTguard yyr, yyvs)};
 private yyprod364 yyvals = yybadprod 364 yyvals;
-private yyprod365 ((_, (YYTok yy1)):yyvs) = YYM.return (YYNTthenx (yy1), yyvs);
+private yyprod365 ((_, (YYNTguard yy1)):yyvs) =  do { let {!yyr = reduce365 yy1}; YYM.return (YYNTguards yyr, yyvs)};
 private yyprod365 yyvals = yybadprod 365 yyvals;
-private yyprod366 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce366 yy1 yy2}; YYM.return (YYNTelsex yyr, yyvs)};
+private yyprod366 ((_, (YYNTguards yy2)):(_, (YYNTguard yy1)):yyvs) =  do { let {!yyr = reduce366 yy1 yy2}; YYM.return (YYNTguards yyr, yyvs)};
 private yyprod366 yyvals = yybadprod 366 yyvals;
-private yyprod367 ((_, (YYTok yy1)):yyvs) = YYM.return (YYNTelsex (yy1), yyvs);
+private yyprod367 ((_, (YYNTexpr yy3)):(_, (YYNTaeq yy2)):(_, (YYNTpattern yy1)):yyvs) =  do { let {!yyr = reduce367 yy1 yy2 yy3}; YYM.return (YYNTcalt yyr, yyvs)};
 private yyprod367 yyvals = yybadprod 367 yyvals;
-private yyprod368 ((_, (YYNTbinex yy3)):(_, (YYTok yy2)):(_, (YYNTbinex yy1)):yyvs) =  do { let {!yyr = reduce368 yy1 yy2 yy3}; YYM.return (YYNTbinex yyr, yyvs)};
-private yyprod368 ((_, (YYNTbinex yy1)):yyvs) = YYM.return (YYNTbinex (yy1), yyvs);
+private yyprod368 ((_, (YYNTguards yy2)):(_, (YYNTpattern yy1)):yyvs) =  do { let {!yyr = reduce368 yy1 yy2}; YYM.return (YYNTcalt yyr, yyvs)};
 private yyprod368 yyvals = yybadprod 368 yyvals;
-private yyprod369 ((_, (YYNTbinex yy3)):(_, (YYTok yy2)):(_, (YYNTbinex yy1)):yyvs) =  do { let {!yyr = reduce369 yy1 yy2 yy3}; YYM.return (YYNTbinex yyr, yyvs)};
-private yyprod369 ((_, (YYNTbinex yy1)):yyvs) = YYM.return (YYNTbinex (yy1), yyvs);
+private yyprod369 ((_, (YYNTwherelet yy2)):(_, (YYNTcalt yy1)):yyvs) =  do { let {!yyr = reduce369 yy1 yy2}; YYM.return (YYNTcalt yyr, yyvs)};
 private yyprod369 yyvals = yybadprod 369 yyvals;
-private yyprod370 ((_, (YYNTtopex yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce370 yy1 yy2}; YYM.return (YYNTbinex yyr, yyvs)};
+private yyprod370 ((_, (YYNTcalt yy1)):yyvs) =  do { let {!yyr = reduce370 yy1}; YYM.return (YYNTcalts yyr, yyvs)};
 private yyprod370 yyvals = yybadprod 370 yyvals;
-private yyprod371 ((_, (YYNTtopex yy1)):yyvs) = YYM.return (YYNTbinex (yy1), yyvs);
+private yyprod371 ((_, (YYNTcalts yy3)):(_, (YYTok yy2)):(_, (YYNTcalt yy1)):yyvs) =  do { let {!yyr = reduce371 yy1 yy2 yy3}; YYM.return (YYNTcalts yyr, yyvs)};
 private yyprod371 yyvals = yybadprod 371 yyvals;
-private yyprod372 ((_, (YYNTexpr yy6)):(_, (YYNTelsex yy5)):(_, (YYNTexpr yy4)):(_, (YYNTthenx yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce372 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTtopex yyr, yyvs)};
+private yyprod372 ((_, (YYTok yy2)):(_, (YYNTcalt yy1)):yyvs) =  do { let {!yyr = reduce372 yy1 yy2}; YYM.return (YYNTcalts yyr, yyvs)};
 private yyprod372 yyvals = yybadprod 372 yyvals;
-private yyprod373 ((_, (YYTok yy6)):(_, (YYNTcalts yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce373 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTtopex yyr, yyvs)};
+private yyprod373 ((_, (YYNTlambdabody yy3)):(_, (YYNTapats yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce373 yy1 yy2 yy3}; YYM.return (YYNTlambda yyr, yyvs)};
 private yyprod373 yyvals = yybadprod 373 yyvals;
-private yyprod374 ((_, (YYNTexpr yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYNTletdefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce374 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTtopex yyr, yyvs)};
+private yyprod374 ((_, (YYNTlambda yy1)):yyvs) = YYM.return (YYNTlambdabody (yy1), yyvs);
 private yyprod374 yyvals = yybadprod 374 yyvals;
-private yyprod375 ((_, (YYNTlambda yy1)):yyvs) = YYM.return (YYNTtopex (yy1), yyvs);
+private yyprod375 ((_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce375 yy1 yy2}; YYM.return (YYNTlambdabody yyr, yyvs)};
 private yyprod375 yyvals = yybadprod 375 yyvals;
-private yyprod376 ((_, (YYNTappex yy1)):yyvs) =  do { let {!yyr = reduce376 yy1}; YYM.return (YYNTtopex yyr, yyvs)};
+private yyprod376 ((_, (YYNTsigma yy3)):(_, (YYTok yy2)):(_, (YYNTbinex yy1)):yyvs) =  do { let {!yyr = reduce376 yy1 yy2 yy3}; YYM.return (YYNTexpr yyr, yyvs)};
 private yyprod376 yyvals = yybadprod 376 yyvals;
-private yyprod377 ((_, (YYNTunex yy1)):yyvs) = YYM.return (YYNTappex (yy1), yyvs);
+private yyprod377 ((_, (YYNTbinex yy1)):yyvs) = YYM.return (YYNTexpr (yy1), yyvs);
 private yyprod377 yyvals = yybadprod 377 yyvals;
-private yyprod378 ((_, (YYNTunex yy2)):(_, (YYNTappex yy1)):yyvs) =  do { let {!yyr = reduce378 yy1 yy2}; YYM.return (YYNTappex yyr, yyvs)};
+private yyprod378 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce378 yy1 yy2}; YYM.return (YYNTthenx yyr, yyvs)};
 private yyprod378 yyvals = yybadprod 378 yyvals;
-private yyprod379 ((_, (YYNTprimary yy1)):yyvs) = YYM.return (YYNTunex (yy1), yyvs);
+private yyprod379 ((_, (YYTok yy1)):yyvs) = YYM.return (YYNTthenx (yy1), yyvs);
 private yyprod379 yyvals = yybadprod 379 yyvals;
-private yyprod380 ((_, (YYNTunex yy2)):(_, (YYNTunop yy1)):yyvs) =  do { let {!yyr = reduce380 yy1 yy2}; YYM.return (YYNTunex yyr, yyvs)};
+private yyprod380 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce380 yy1 yy2}; YYM.return (YYNTelsex yyr, yyvs)};
 private yyprod380 yyvals = yybadprod 380 yyvals;
-private yyprod381 ((_, (YYNTunex yy1)):yyvs) =  do { let {!yyr = reduce381 yy1}; YYM.return (YYNTapats yyr, yyvs)};
+private yyprod381 ((_, (YYTok yy1)):yyvs) = YYM.return (YYNTelsex (yy1), yyvs);
 private yyprod381 yyvals = yybadprod 381 yyvals;
-private yyprod382 ((_, (YYNTapats yy2)):(_, (YYNTunex yy1)):yyvs) =  do { let {!yyr = reduce382 yy1 yy2}; YYM.return (YYNTapats yyr, yyvs)};
+private yyprod382 ((_, (YYNTbinex yy3)):(_, (YYTok yy2)):(_, (YYNTbinex yy1)):yyvs) =  do { let {!yyr = reduce382 yy1 yy2 yy3}; YYM.return (YYNTbinex yyr, yyvs)};
+private yyprod382 ((_, (YYNTbinex yy1)):yyvs) = YYM.return (YYNTbinex (yy1), yyvs);
 private yyprod382 yyvals = yybadprod 382 yyvals;
-private yyprod383 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce383 yy1}; YYM.return (YYNTqualifiers yyr, yyvs)};
+private yyprod383 ((_, (YYNTbinex yy3)):(_, (YYTok yy2)):(_, (YYNTbinex yy1)):yyvs) =  do { let {!yyr = reduce383 yy1 yy2 yy3}; YYM.return (YYNTbinex yyr, yyvs)};
+private yyprod383 ((_, (YYNTbinex yy1)):yyvs) = YYM.return (YYNTbinex (yy1), yyvs);
 private yyprod383 yyvals = yybadprod 383 yyvals;
-private yyprod384 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce384 yy1 yy2}; YYM.return (YYNTqualifiers yyr, yyvs)};
+private yyprod384 ((_, (YYNTtopex yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce384 yy1 yy2}; YYM.return (YYNTbinex yyr, yyvs)};
 private yyprod384 yyvals = yybadprod 384 yyvals;
-private yyprod385 ((_, (YYNTterm yy1)):yyvs) = YYM.return (YYNTprimary (yy1), yyvs);
+private yyprod385 ((_, (YYNTtopex yy1)):yyvs) = YYM.return (YYNTbinex (yy1), yyvs);
 private yyprod385 yyvals = yybadprod 385 yyvals;
-private yyprod386 ((_, (YYTok yy4)):(_, (YYNTdodefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce386 yy1 yy2 yy3 yy4 ;YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod386 ((_, (YYNTexpr yy6)):(_, (YYNTelsex yy5)):(_, (YYNTexpr yy4)):(_, (YYNTthenx yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce386 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTtopex yyr, yyvs)};
 private yyprod386 yyvals = yybadprod 386 yyvals;
-private yyprod387 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce387 yy1 yy2 yy3}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod387 ((_, (YYTok yy6)):(_, (YYNTcalts yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce387 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTtopex yyr, yyvs)};
 private yyprod387 yyvals = yybadprod 387 yyvals;
-private yyprod388 ((_, (YYNToperator yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { yyr <- reduce388 yy1 yy2 yy3 ;YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod388 ((_, (YYNTexpr yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYNTletdefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce388 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTtopex yyr, yyvs)};
 private yyprod388 yyvals = yybadprod 388 yyvals;
-private yyprod389 ((_, (YYNTunop yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce389 yy1 yy2 yy3}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod389 ((_, (YYNTlambda yy1)):yyvs) = YYM.return (YYNTtopex (yy1), yyvs);
 private yyprod389 yyvals = yybadprod 389 yyvals;
-private yyprod390 ((_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce390 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod390 ((_, (YYNTappex yy1)):yyvs) =  do { let {!yyr = reduce390 yy1}; YYM.return (YYNTtopex yyr, yyvs)};
 private yyprod390 yyvals = yybadprod 390 yyvals;
-private yyprod391 ((_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce391 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod391 ((_, (YYNTunex yy1)):yyvs) = YYM.return (YYNTappex (yy1), yyvs);
 private yyprod391 yyvals = yybadprod 391 yyvals;
-private yyprod392 ((_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce392 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod392 ((_, (YYNTunex yy2)):(_, (YYNTappex yy1)):yyvs) =  do { let {!yyr = reduce392 yy1 yy2}; YYM.return (YYNTappex yyr, yyvs)};
 private yyprod392 yyvals = yybadprod 392 yyvals;
-private yyprod393 ((_, (YYTok yy4)):(_, (YYNTgetfields yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce393 yy1 yy2 yy3 yy4}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod393 ((_, (YYNTprimary yy1)):yyvs) = YYM.return (YYNTunex (yy1), yyvs);
 private yyprod393 yyvals = yybadprod 393 yyvals;
-private yyprod394 ((_, (YYTok yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce394 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod394 ((_, (YYNTunex yy2)):(_, (YYNTunop yy1)):yyvs) =  do { let {!yyr = reduce394 yy1 yy2}; YYM.return (YYNTunex yyr, yyvs)};
 private yyprod394 yyvals = yybadprod 394 yyvals;
-private yyprod395 ((_, (YYTok yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce395 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod395 ((_, (YYNTunex yy1)):yyvs) =  do { let {!yyr = reduce395 yy1}; YYM.return (YYNTapats yyr, yyvs)};
 private yyprod395 yyvals = yybadprod 395 yyvals;
-private yyprod396 ((_, (YYTok yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce396 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod396 ((_, (YYNTapats yy2)):(_, (YYNTunex yy1)):yyvs) =  do { let {!yyr = reduce396 yy1 yy2}; YYM.return (YYNTapats yyr, yyvs)};
 private yyprod396 yyvals = yybadprod 396 yyvals;
-private yyprod397 ((_, (YYTok yy5)):(_, (YYNTgetfields yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce397 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod397 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce397 yy1}; YYM.return (YYNTqualifiers yyr, yyvs)};
 private yyprod397 yyvals = yybadprod 397 yyvals;
-private yyprod398 ((_, (YYTok yy5)):(_, (YYNTexpr yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce398 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
+private yyprod398 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce398 yy1 yy2}; YYM.return (YYNTqualifiers yyr, yyvs)};
 private yyprod398 yyvals = yybadprod 398 yyvals;
-private yyprod399 ((_, (YYNTqvarid yy1)):yyvs) =  do { let {!yyr = reduce399 yy1}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod399 ((_, (YYNTterm yy1)):yyvs) = YYM.return (YYNTprimary (yy1), yyvs);
 private yyprod399 yyvals = yybadprod 399 yyvals;
-private yyprod400 ((_, (YYNTliteral yy1)):yyvs) = YYM.return (YYNTterm (yy1), yyvs);
+private yyprod400 ((_, (YYTok yy4)):(_, (YYNTdodefs yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce400 yy1 yy2 yy3 yy4 ;YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod400 yyvals = yybadprod 400 yyvals;
-private yyprod401 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce401 yy1}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod401 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce401 yy1 yy2 yy3}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod401 yyvals = yybadprod 401 yyvals;
-private yyprod402 ((_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce402 yy1}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod402 ((_, (YYNToperator yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { yyr <- reduce402 yy1 yy2 yy3 ;YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod402 yyvals = yybadprod 402 yyvals;
-private yyprod403 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce403 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod403 ((_, (YYNTunop yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce403 yy1 yy2 yy3}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod403 yyvals = yybadprod 403 yyvals;
-private yyprod404 ((_, (YYTok yy4)):(_, (YYNTfields yy3)):(_, (YYTok yy2)):(_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce404 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod404 ((_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce404 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod404 yyvals = yybadprod 404 yyvals;
-private yyprod405 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce405 yy1 yy2}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod405 ((_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce405 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod405 yyvals = yybadprod 405 yyvals;
-private yyprod406 ((_, (YYTok yy3)):(_, (YYNTcommata yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce406 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod406 ((_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce406 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod406 yyvals = yybadprod 406 yyvals;
-private yyprod407 ((_, (YYTok yy3)):(_, (YYNTunop yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce407 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod407 ((_, (YYTok yy4)):(_, (YYNTgetfields yy3)):(_, (YYTok yy2)):(_, (YYNTqualifiers yy1)):yyvs) =  do { let {!yyr = reduce407 yy1 yy2 yy3 yy4}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod407 yyvals = yybadprod 407 yyvals;
-private yyprod408 ((_, (YYTok yy3)):(_, (YYNToperator yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce408 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod408 ((_, (YYTok yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce408 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod408 yyvals = yybadprod 408 yyvals;
-private yyprod409 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce409 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod409 ((_, (YYTok yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce409 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod409 yyvals = yybadprod 409 yyvals;
-private yyprod410 ((_, (YYTok yy4)):(_, (YYNTexpr yy3)):(_, (YYNToperator yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce410 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod410 ((_, (YYTok yy6)):(_, (YYTok yy5)):(_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce410 yy1 yy2 yy3 yy4 yy5 yy6}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod410 yyvals = yybadprod 410 yyvals;
-private yyprod411 ((_, (YYTok yy4)):(_, (YYNToperator yy3)):(_, (YYNTbinex yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce411 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod411 ((_, (YYTok yy5)):(_, (YYNTgetfields yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce411 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod411 yyvals = yybadprod 411 yyvals;
-private yyprod412 ((_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYNTbinex yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce412 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod412 ((_, (YYTok yy5)):(_, (YYNTexpr yy4)):(_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTprimary yy1)):yyvs) =  do { let {!yyr = reduce412 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTprimary yyr, yyvs)};
 private yyprod412 yyvals = yybadprod 412 yyvals;
-private yyprod413 ((_, (YYTok yy5)):(_, (YYNTexprSC yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce413 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod413 ((_, (YYNTqvarid yy1)):yyvs) =  do { let {!yyr = reduce413 yy1}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod413 yyvals = yybadprod 413 yyvals;
-private yyprod414 ((_, (YYTok yy5)):(_, (YYNTexprSS yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce414 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod414 ((_, (YYNTliteral yy1)):yyvs) = YYM.return (YYNTterm (yy1), yyvs);
 private yyprod414 yyvals = yybadprod 414 yyvals;
-private yyprod415 ((_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce415 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod415 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce415 yy1}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod415 yyvals = yybadprod 415 yyvals;
-private yyprod416 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce416 yy1 yy2}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod416 ((_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce416 yy1}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod416 yyvals = yybadprod 416 yyvals;
-private yyprod417 ((_, (YYTok yy3)):(_, (YYNTexprSC yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce417 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
+private yyprod417 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce417 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod417 yyvals = yybadprod 417 yyvals;
-private yyprod418 ((_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYNTexprSC yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce418 yy1 yy2 yy3 yy4 ;YYM.return (YYNTterm yyr, yyvs)};
+private yyprod418 ((_, (YYTok yy4)):(_, (YYNTfields yy3)):(_, (YYTok yy2)):(_, (YYNTqconid yy1)):yyvs) =  do { let {!yyr = reduce418 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod418 yyvals = yybadprod 418 yyvals;
-private yyprod419 ((_, (YYTok yy5)):(_, (YYNTexpr yy4)):(_, (YYTok yy3)):(_, (YYNTexprSC yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce419 yy1 yy2 yy3 yy4 yy5 ;YYM.return (YYNTterm yyr, yyvs)};
+private yyprod419 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce419 yy1 yy2}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod419 yyvals = yybadprod 419 yyvals;
-private yyprod420 ((_, (YYTok yy5)):(_, (YYNTlcquals yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce420 yy1 yy2 yy3 yy4 yy5 ;YYM.return (YYNTterm yyr, yyvs)};
+private yyprod420 ((_, (YYTok yy3)):(_, (YYNTcommata yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce420 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod420 yyvals = yybadprod 420 yyvals;
-private yyprod421 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce421 yy1}; YYM.return (YYNTcommata yyr, yyvs)};
+private yyprod421 ((_, (YYTok yy3)):(_, (YYNTunop yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce421 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod421 yyvals = yybadprod 421 yyvals;
-private yyprod422 ((_, (YYNTcommata yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce422 yy1 yy2}; YYM.return (YYNTcommata yyr, yyvs)};
+private yyprod422 ((_, (YYTok yy3)):(_, (YYNToperator yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce422 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod422 yyvals = yybadprod 422 yyvals;
-private yyprod423 ((_, (YYNTfield yy1)):yyvs) =  do { let {!yyr = reduce423 yy1}; YYM.return (YYNTfields yyr, yyvs)};
+private yyprod423 ((_, (YYTok yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce423 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod423 yyvals = yybadprod 423 yyvals;
-private yyprod424 ((_, (YYNTfields yy3)):(_, (YYTok yy2)):(_, (YYNTfield yy1)):yyvs) =  do { yyr <- reduce424 yy1 yy2 yy3 ;YYM.return (YYNTfields yyr, yyvs)};
+private yyprod424 ((_, (YYTok yy4)):(_, (YYNTexpr yy3)):(_, (YYNToperator yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce424 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod424 yyvals = yybadprod 424 yyvals;
-private yyprod425 ((_, (YYTok yy2)):(_, (YYNTfield yy1)):yyvs) =  do { let {!yyr = reduce425 yy1 yy2}; YYM.return (YYNTfields yyr, yyvs)};
+private yyprod425 ((_, (YYTok yy4)):(_, (YYNToperator yy3)):(_, (YYNTbinex yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce425 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod425 yyvals = yybadprod 425 yyvals;
-private yyprod426 ((_, (YYNTgetfield yy1)):yyvs) =  do { let {!yyr = reduce426 yy1}; YYM.return (YYNTgetfields yyr, yyvs)};
+private yyprod426 ((_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYNTbinex yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce426 yy1 yy2 yy3 yy4}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod426 yyvals = yybadprod 426 yyvals;
-private yyprod427 ((_, (YYNTgetfields yy3)):(_, (YYTok yy2)):(_, (YYNTgetfield yy1)):yyvs) =  do { let {!yyr = reduce427 yy1 yy2 yy3}; YYM.return (YYNTgetfields yyr, yyvs)};
+private yyprod427 ((_, (YYTok yy5)):(_, (YYNTexprSC yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce427 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod427 yyvals = yybadprod 427 yyvals;
-private yyprod428 ((_, (YYTok yy2)):(_, (YYNTgetfield yy1)):yyvs) =  do { let {!yyr = reduce428 yy1 yy2}; YYM.return (YYNTgetfields yyr, yyvs)};
+private yyprod428 ((_, (YYTok yy5)):(_, (YYNTexprSS yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce428 yy1 yy2 yy3 yy4 yy5}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod428 yyvals = yybadprod 428 yyvals;
-private yyprod429 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce429 yy1 yy2 yy3}; YYM.return (YYNTgetfield yyr, yyvs)};
+private yyprod429 ((_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce429 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod429 yyvals = yybadprod 429 yyvals;
-private yyprod430 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce430 yy1 yy2 yy3}; YYM.return (YYNTgetfield yyr, yyvs)};
+private yyprod430 ((_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce430 yy1 yy2}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod430 yyvals = yybadprod 430 yyvals;
-private yyprod431 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce431 yy1}; YYM.return (YYNTgetfield yyr, yyvs)};
+private yyprod431 ((_, (YYTok yy3)):(_, (YYNTexprSC yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce431 yy1 yy2 yy3}; YYM.return (YYNTterm yyr, yyvs)};
 private yyprod431 yyvals = yybadprod 431 yyvals;
-private yyprod432 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYNTvarid yy1)):yyvs) =  do { let {!yyr = reduce432 yy1 yy2 yy3}; YYM.return (YYNTfield yyr, yyvs)};
+private yyprod432 ((_, (YYTok yy4)):(_, (YYTok yy3)):(_, (YYNTexprSC yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce432 yy1 yy2 yy3 yy4 ;YYM.return (YYNTterm yyr, yyvs)};
 private yyprod432 yyvals = yybadprod 432 yyvals;
-private yyprod433 ((_, (YYNTvarid yy1)):yyvs) =  do { let {!yyr = reduce433 yy1}; YYM.return (YYNTfield yyr, yyvs)};
+private yyprod433 ((_, (YYTok yy5)):(_, (YYNTexpr yy4)):(_, (YYTok yy3)):(_, (YYNTexprSC yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce433 yy1 yy2 yy3 yy4 yy5 ;YYM.return (YYNTterm yyr, yyvs)};
 private yyprod433 yyvals = yybadprod 433 yyvals;
-private yyprod434 ((_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce434 yy1}; YYM.return (YYNTexprSC yyr, yyvs)};
+private yyprod434 ((_, (YYTok yy5)):(_, (YYNTlcquals yy4)):(_, (YYTok yy3)):(_, (YYNTexpr yy2)):(_, (YYTok yy1)):yyvs) =  do { yyr <- reduce434 yy1 yy2 yy3 yy4 yy5 ;YYM.return (YYNTterm yyr, yyvs)};
 private yyprod434 yyvals = yybadprod 434 yyvals;
-private yyprod435 ((_, (YYNTexprSC yy3)):(_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce435 yy1 yy2 yy3}; YYM.return (YYNTexprSC yyr, yyvs)};
+private yyprod435 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce435 yy1}; YYM.return (YYNTcommata yyr, yyvs)};
 private yyprod435 yyvals = yybadprod 435 yyvals;
-private yyprod436 ((_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce436 yy1 yy2}; YYM.return (YYNTexprSC yyr, yyvs)};
+private yyprod436 ((_, (YYNTcommata yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce436 yy1 yy2}; YYM.return (YYNTcommata yyr, yyvs)};
 private yyprod436 yyvals = yybadprod 436 yyvals;
-private yyprod437 ((_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce437 yy1}; YYM.return (YYNTexprSS yyr, yyvs)};
+private yyprod437 ((_, (YYNTfield yy1)):yyvs) =  do { let {!yyr = reduce437 yy1}; YYM.return (YYNTfields yyr, yyvs)};
 private yyprod437 yyvals = yybadprod 437 yyvals;
-private yyprod438 ((_, (YYNTexprSS yy3)):(_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce438 yy1 yy2 yy3}; YYM.return (YYNTexprSS yyr, yyvs)};
+private yyprod438 ((_, (YYNTfields yy3)):(_, (YYTok yy2)):(_, (YYNTfield yy1)):yyvs) =  do { yyr <- reduce438 yy1 yy2 yy3 ;YYM.return (YYNTfields yyr, yyvs)};
 private yyprod438 yyvals = yybadprod 438 yyvals;
-private yyprod439 ((_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce439 yy1 yy2}; YYM.return (YYNTexprSS yyr, yyvs)};
+private yyprod439 ((_, (YYTok yy2)):(_, (YYNTfield yy1)):yyvs) =  do { let {!yyr = reduce439 yy1 yy2}; YYM.return (YYNTfields yyr, yyvs)};
 private yyprod439 yyvals = yybadprod 439 yyvals;
+private yyprod440 ((_, (YYNTgetfield yy1)):yyvs) =  do { let {!yyr = reduce440 yy1}; YYM.return (YYNTgetfields yyr, yyvs)};
+private yyprod440 yyvals = yybadprod 440 yyvals;
+private yyprod441 ((_, (YYNTgetfields yy3)):(_, (YYTok yy2)):(_, (YYNTgetfield yy1)):yyvs) =  do { let {!yyr = reduce441 yy1 yy2 yy3}; YYM.return (YYNTgetfields yyr, yyvs)};
+private yyprod441 yyvals = yybadprod 441 yyvals;
+private yyprod442 ((_, (YYTok yy2)):(_, (YYNTgetfield yy1)):yyvs) =  do { let {!yyr = reduce442 yy1 yy2}; YYM.return (YYNTgetfields yyr, yyvs)};
+private yyprod442 yyvals = yybadprod 442 yyvals;
+private yyprod443 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce443 yy1 yy2 yy3}; YYM.return (YYNTgetfield yyr, yyvs)};
+private yyprod443 yyvals = yybadprod 443 yyvals;
+private yyprod444 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce444 yy1 yy2 yy3}; YYM.return (YYNTgetfield yyr, yyvs)};
+private yyprod444 yyvals = yybadprod 444 yyvals;
+private yyprod445 ((_, (YYTok yy1)):yyvs) =  do { let {!yyr = reduce445 yy1}; YYM.return (YYNTgetfield yyr, yyvs)};
+private yyprod445 yyvals = yybadprod 445 yyvals;
+private yyprod446 ((_, (YYNTexpr yy3)):(_, (YYTok yy2)):(_, (YYNTvarid yy1)):yyvs) =  do { let {!yyr = reduce446 yy1 yy2 yy3}; YYM.return (YYNTfield yyr, yyvs)};
+private yyprod446 yyvals = yybadprod 446 yyvals;
+private yyprod447 ((_, (YYNTvarid yy1)):yyvs) =  do { let {!yyr = reduce447 yy1}; YYM.return (YYNTfield yyr, yyvs)};
+private yyprod447 yyvals = yybadprod 447 yyvals;
+private yyprod448 ((_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce448 yy1}; YYM.return (YYNTexprSC yyr, yyvs)};
+private yyprod448 yyvals = yybadprod 448 yyvals;
+private yyprod449 ((_, (YYNTexprSC yy3)):(_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce449 yy1 yy2 yy3}; YYM.return (YYNTexprSC yyr, yyvs)};
+private yyprod449 yyvals = yybadprod 449 yyvals;
+private yyprod450 ((_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce450 yy1 yy2}; YYM.return (YYNTexprSC yyr, yyvs)};
+private yyprod450 yyvals = yybadprod 450 yyvals;
+private yyprod451 ((_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce451 yy1}; YYM.return (YYNTexprSS yyr, yyvs)};
+private yyprod451 yyvals = yybadprod 451 yyvals;
+private yyprod452 ((_, (YYNTexprSS yy3)):(_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce452 yy1 yy2 yy3}; YYM.return (YYNTexprSS yyr, yyvs)};
+private yyprod452 yyvals = yybadprod 452 yyvals;
+private yyprod453 ((_, (YYTok yy2)):(_, (YYNTexpr yy1)):yyvs) =  do { let {!yyr = reduce453 yy1 yy2}; YYM.return (YYNTexprSS yyr, yyvs)};
+private yyprod453 yyvals = yybadprod 453 yyvals;
 ;
 
 private yyprods = let 
@@ -8047,8 +8227,22 @@ private yyprods = let
       (436, yyprod436),
       (437, yyprod437),
       (438, yyprod438),
-      (439, yyprod439)];
-      in sub1 `seq` sub2 `seq` sub3 `seq` sub4 `seq` sub5 `seq` sub6 `seq` sub7 `seq` arrayFromIndexList (sub1 ++ sub2 ++ sub3 ++ sub4 ++ sub5 ++ sub6 ++ sub7);
+      (439, yyprod439),
+      (440, yyprod440),
+      (441, yyprod441),
+      (442, yyprod442),
+      (443, yyprod443),
+      (444, yyprod444),
+      (445, yyprod445),
+      (446, yyprod446),
+      (447, yyprod447),
+      (448, yyprod448)];
+    sub8 = [      (449, yyprod449),
+      (450, yyprod450),
+      (451, yyprod451),
+      (452, yyprod452),
+      (453, yyprod453)];
+      in sub1 `seq` sub2 `seq` sub3 `seq` sub4 `seq` sub5 `seq` sub6 `seq` sub7 `seq` sub8 `seq` arrayFromIndexList (sub1 ++ sub2 ++ sub3 ++ sub4 ++ sub5 ++ sub6 ++ sub7 ++ sub8);
 private yyacts  = let 
     sub1 = [      (0, yyaction0),
       (1, yyaction1),
@@ -8744,8 +8938,27 @@ private yyacts  = let
       (691, yyaction691),
       (692, yyaction692),
       (693, yyaction693),
-      (694, yyaction694)];
-      in sub1 `seq` sub2 `seq` sub3 `seq` sub4 `seq` sub5 `seq` sub6 `seq` sub7 `seq` sub8 `seq` sub9 `seq` sub10 `seq` sub11 `seq` arrayFromIndexList (sub1 ++ sub2 ++ sub3 ++ sub4 ++ sub5 ++ sub6 ++ sub7 ++ sub8 ++ sub9 ++ sub10 ++ sub11);
+      (694, yyaction694),
+      (695, yyaction695),
+      (696, yyaction696),
+      (697, yyaction697),
+      (698, yyaction698),
+      (699, yyaction699),
+      (700, yyaction700),
+      (701, yyaction701),
+      (702, yyaction702),
+      (703, yyaction703)];
+    sub12 = [      (704, yyaction704),
+      (705, yyaction705),
+      (706, yyaction706),
+      (707, yyaction707),
+      (708, yyaction708),
+      (709, yyaction709),
+      (710, yyaction710),
+      (711, yyaction711),
+      (712, yyaction712),
+      (713, yyaction713)];
+      in sub1 `seq` sub2 `seq` sub3 `seq` sub4 `seq` sub5 `seq` sub6 `seq` sub7 `seq` sub8 `seq` sub9 `seq` sub10 `seq` sub11 `seq` sub12 `seq` arrayFromIndexList (sub1 ++ sub2 ++ sub3 ++ sub4 ++ sub5 ++ sub6 ++ sub7 ++ sub8 ++ sub9 ++ sub10 ++ sub11 ++ sub12);
 private yyrecs  = let 
     sub1 = [      (0, yybadstart 0 "a module"),
       (1, yyparsing  1 "a sequence of doc comments"),
@@ -8862,7 +9075,7 @@ private yyrecs  = let
       (112, yyexpect 112(yyfromId INTCONST)),
       (113, yyparsing  113 "specification for module class "),
       (114, yyexpect 114(yyfromId CONID)),
-      (115, yyexpect 115(yyfromId CONID)),
+      (115, yyparsing  115 "a type class declaration"),
       (116, yyparsing  116 "an instance declaration"),
       (117, yyexpect 117(yyfromId DATA)),
       (118, yyexpect 118(yyfromId CONID)),
@@ -8981,396 +9194,396 @@ private yyrecs  = let
       (231, yyparsing  231 "a native item"),
       (232, yyparsing  232 "a native item"),
       (233, yyparsing  233 "a data definition"),
-      (234, yyparsing  234 "a type class declaration"),
-      (235, yybadstart 235 "a sequence of one or more ','"),
-      (236, yyexpect 236(yyfromCh ']')),
-      (237, yyparsing  237 "an instance declaration"),
-      (238, yyparsing  238 "a protected or private declaration"),
-      (239, yyparsing  239 "a type declaration"),
-      (240, yyparsing  240 "an instance derivation"),
-      (241, yyparsing  241 "a native item"),
-      (242, yyparsing  242 "a protected or private declaration"),
+      (234, yyparsing  234 "type class context"),
+      (235, yybadstart 235 "a type variable"),
+      (236, yyparsing  236 "type class context"),
+      (237, yybadstart 237 "declarations local to a class, instance or type"),
+      (238, yyparsing  238 "instance context"),
+      (239, yyparsing  239 "instance constraint"),
+      (240, yyparsing  240 "instance context"),
+      (241, yyparsing  241 "instance head"),
+      (242, yybadstart 242 "declarations local to a class, instance or type"),
       (243, yyparsing  243 "a protected or private declaration"),
-      (244, yyparsing  244 "a protected or private declaration"),
-      (245, yyparsing  245 "a declaration of a native item"),
-      (246, yyparsing  246 "an annotated item"),
-      (247, yyparsing  247 "an annotated item"),
-      (248, yyparsing  248 "an annotated item"),
-      (249, yyparsing  249 "declarations"),
-      (250, yyparsing  250 "a declaration"),
-      (251, yyexpect 251(yyfromCh '{')),
-      (252, yyparsing  252 "a function or pattern binding"),
-      (253, yyparsing  253 "an operator"),
-      (254, yyparsing  254 "an operator"),
-      (255, yyparsing  255 "an operator")];
-    sub5 = [      (256, yyparsing  256 "some operators"),
-      (257, yyparsing  257 "a fixity declaration"),
-      (258, yyparsing  258 "an annotation"),
-      (259, yyparsing  259 "a list of items to annotate"),
-      (260, yyparsing  260 "a valid java identifier"),
-      (261, yyparsing  261 "a valid java identifier"),
-      (262, yybadstart 262 "a valid java identifier"),
-      (263, yyparsing  263 "a valid java identifier"),
-      (264, yyparsing  264 "a declaration of a native item"),
-      (265, yyexpect 265(yyfromId DCOLON)),
-      (266, yyexpect 266(yyfromId DCOLON)),
-      (267, yyexpect 267(yyfromId DCOLON)),
-      (268, yyexpect 268(yyfromCh '{')),
-      (269, yyparsing  269 "a data definition"),
-      (270, yyparsing  270 "a guarded expression"),
-      (271, yyparsing  271 "a function or pattern binding"),
-      (272, yyparsing  272 "a function or pattern binding"),
-      (273, yyparsing  273 "guarded expressions"),
-      (274, yyparsing  274 "a qualified variable name"),
-      (275, yyexpect 275(yyfromCh ')')),
-      (276, yyparsing  276 "a qualified variable name"),
-      (277, yyparsing  277 "a list of qualified variable names"),
-      (278, yyparsing  278 "a qualified variable name"),
-      (279, yyparsing  279 "a module clause"),
-      (280, yyparsing  280 "then branch"),
-      (281, yybadstart 281 "else branch"),
-      (282, yyparsing  282 "a top level expression"),
-      (283, yyparsing  283 "declarations in a let expression or where clause"),
-      (284, yyexpect 284(yyfromId IN)),
-      (285, yyparsing  285 "a list comprehension qualifier"),
-      (286, yyparsing  286 "a guard qualifier"),
-      (287, yyparsing  287 "a list comprehension qualifier"),
-      (288, yyparsing  288 "do expression qualifiers"),
-      (289, yyparsing  289 "a primary expression"),
-      (290, yyparsing  290 "list of expressions separated by ';'"),
-      (291, yyexpect 291(yyfromCh ')')),
-      (292, yyparsing  292 "list of expressions separated by ','"),
-      (293, yyexpect 293(yyfromCh ')')),
-      (294, yyparsing  294 "a term"),
-      (295, yyparsing  295 "a term"),
-      (296, yyparsing  296 "a term"),
+      (244, yyparsing  244 "a type declaration"),
+      (245, yyparsing  245 "an instance derivation"),
+      (246, yyparsing  246 "a native item"),
+      (247, yyparsing  247 "a protected or private declaration"),
+      (248, yyparsing  248 "a protected or private declaration"),
+      (249, yyparsing  249 "a protected or private declaration"),
+      (250, yyparsing  250 "a declaration of a native item"),
+      (251, yyparsing  251 "an annotated item"),
+      (252, yyparsing  252 "an annotated item"),
+      (253, yyparsing  253 "an annotated item"),
+      (254, yyparsing  254 "declarations"),
+      (255, yyparsing  255 "a declaration")];
+    sub5 = [      (256, yyexpect 256(yyfromCh '{')),
+      (257, yyparsing  257 "a function or pattern binding"),
+      (258, yyparsing  258 "an operator"),
+      (259, yyparsing  259 "an operator"),
+      (260, yyparsing  260 "an operator"),
+      (261, yyparsing  261 "some operators"),
+      (262, yyparsing  262 "a fixity declaration"),
+      (263, yyparsing  263 "an annotation"),
+      (264, yyparsing  264 "a list of items to annotate"),
+      (265, yyparsing  265 "a valid java identifier"),
+      (266, yyparsing  266 "a valid java identifier"),
+      (267, yybadstart 267 "a valid java identifier"),
+      (268, yyparsing  268 "a valid java identifier"),
+      (269, yyparsing  269 "a declaration of a native item"),
+      (270, yyexpect 270(yyfromId DCOLON)),
+      (271, yyexpect 271(yyfromId DCOLON)),
+      (272, yyexpect 272(yyfromId DCOLON)),
+      (273, yyexpect 273(yyfromCh '{')),
+      (274, yyparsing  274 "a data definition"),
+      (275, yyparsing  275 "a guarded expression"),
+      (276, yyparsing  276 "a function or pattern binding"),
+      (277, yyparsing  277 "a function or pattern binding"),
+      (278, yyparsing  278 "guarded expressions"),
+      (279, yyparsing  279 "a qualified variable name"),
+      (280, yyexpect 280(yyfromCh ')')),
+      (281, yyparsing  281 "a qualified variable name"),
+      (282, yyparsing  282 "a list of qualified variable names"),
+      (283, yyparsing  283 "a qualified variable name"),
+      (284, yyparsing  284 "a module clause"),
+      (285, yyparsing  285 "then branch"),
+      (286, yybadstart 286 "else branch"),
+      (287, yyparsing  287 "a top level expression"),
+      (288, yyparsing  288 "declarations in a let expression or where clause"),
+      (289, yyexpect 289(yyfromId IN)),
+      (290, yyparsing  290 "a list comprehension qualifier"),
+      (291, yyparsing  291 "a guard qualifier"),
+      (292, yyparsing  292 "a list comprehension qualifier"),
+      (293, yyparsing  293 "do expression qualifiers"),
+      (294, yyparsing  294 "a primary expression"),
+      (295, yyparsing  295 "list of expressions separated by ';'"),
+      (296, yyexpect 296(yyfromCh ')')),
       (297, yyparsing  297 "list of expressions separated by ','"),
-      (298, yyparsing  298 "list comprehension qualifiers"),
-      (299, yyexpect 299(yyfromCh ']')),
+      (298, yyexpect 298(yyfromCh ')')),
+      (299, yyparsing  299 "a term"),
       (300, yyparsing  300 "a term"),
-      (301, yyexpect 301(yyfromCh ']')),
-      (302, yyparsing  302 "a lambda body"),
-      (303, yyparsing  303 "field"),
-      (304, yyparsing  304 "a term"),
-      (305, yyparsing  305 "field list"),
-      (306, yyexpect 306(yyfromId CONID)),
-      (307, yyparsing  307 "a type variable bound in a forall"),
-      (308, yybadstart 308 "'.' or '•'"),
-      (309, yyparsing  309 "type variables bound in a forall"),
-      (310, yyparsing  310 "a type variable"),
-      (311, yyexpect 311(yyfromCh ')')),
-      (312, yyparsing  312 "a type constructor"),
-      (313, yyparsing  313 "a non function type"),
-      (314, yyparsing  314 "a non function type"),
-      (315, yyparsing  315 "a non function type"),
+      (301, yyparsing  301 "a term"),
+      (302, yyparsing  302 "list of expressions separated by ','"),
+      (303, yyparsing  303 "list comprehension qualifiers"),
+      (304, yyexpect 304(yyfromCh ']')),
+      (305, yyparsing  305 "a term"),
+      (306, yyexpect 306(yyfromCh ']')),
+      (307, yyparsing  307 "a lambda body"),
+      (308, yyparsing  308 "field"),
+      (309, yyparsing  309 "a term"),
+      (310, yyparsing  310 "field list"),
+      (311, yyexpect 311(yyfromId CONID)),
+      (312, yyparsing  312 "a type variable bound in a forall"),
+      (313, yybadstart 313 "'.' or '•'"),
+      (314, yyparsing  314 "type variables bound in a forall"),
+      (315, yyparsing  315 "a type variable"),
       (316, yyexpect 316(yyfromCh ')')),
       (317, yyparsing  317 "a type constructor"),
-      (318, yyexpect 318(yyfromCh ']')),
-      (319, yyparsing  319 "a type")];
-    sub6 = [      (320, yyparsing  320 "a constrained type"),
-      (321, yyparsing  321 "non function types"),
-      (322, yyparsing  322 "a primary expression"),
-      (323, yyexpect 323(yyfromCh '}')),
-      (324, yyexpect 324(yyfromCh ']')),
-      (325, yyparsing  325 "a primary expression"),
-      (326, yyexpect 326(yyfromCh '}')),
+      (318, yyparsing  318 "a non function type"),
+      (319, yyparsing  319 "a non function type")];
+    sub6 = [      (320, yyparsing  320 "a non function type"),
+      (321, yyexpect 321(yyfromCh ')')),
+      (322, yyparsing  322 "a type constructor"),
+      (323, yyexpect 323(yyfromCh ']')),
+      (324, yyparsing  324 "a type"),
+      (325, yyparsing  325 "a constrained type"),
+      (326, yyparsing  326 "non function types"),
       (327, yyparsing  327 "a primary expression"),
-      (328, yyparsing  328 "a primary expression"),
-      (329, yyparsing  329 "field list"),
-      (330, yyparsing  330 "a module"),
-      (331, yyparsing  331 "a module import"),
-      (332, yyparsing  332 "a module import"),
-      (333, yyparsing  333 "an import list"),
-      (334, yyparsing  334 "an import list"),
-      (335, yyparsing  335 "a module import"),
-      (336, yyexpect 336(yyfromCh '(')),
-      (337, yyparsing  337 "the type this module derives from"),
-      (338, yybadstart 338 "the interfaces this module implements"),
-      (339, yyexpect 339(yyfromCh ')')),
-      (340, yyexpect 340(yyfromCh ')')),
-      (341, yyexpect 341(yyfromCh ')')),
-      (342, yyexpect 342(yyfromId VARID)),
-      (343, yyparsing  343 "a data definition"),
-      (344, yyparsing  344 "a sequence of type variables"),
-      (345, yyexpect 345(yyfromCh '=')),
-      (346, yyexpect 346(yyfromId EARROW)),
-      (347, yybadstart 347 "declarations local to a class, instance or type"),
-      (348, yybadstart 348 "declarations local to a class, instance or type"),
-      (349, yyparsing  349 "a type declaration"),
+      (328, yyexpect 328(yyfromCh '}')),
+      (329, yyexpect 329(yyfromCh ']')),
+      (330, yyparsing  330 "a primary expression"),
+      (331, yyexpect 331(yyfromCh '}')),
+      (332, yyparsing  332 "a primary expression"),
+      (333, yyparsing  333 "a primary expression"),
+      (334, yyparsing  334 "field list"),
+      (335, yyparsing  335 "a module"),
+      (336, yyparsing  336 "a module import"),
+      (337, yyparsing  337 "a module import"),
+      (338, yyparsing  338 "an import list"),
+      (339, yyparsing  339 "an import list"),
+      (340, yyparsing  340 "a module import"),
+      (341, yyexpect 341(yyfromCh '(')),
+      (342, yyparsing  342 "the type this module derives from"),
+      (343, yybadstart 343 "the interfaces this module implements"),
+      (344, yyexpect 344(yyfromCh ')')),
+      (345, yyexpect 345(yyfromCh ')')),
+      (346, yyexpect 346(yyfromCh ')')),
+      (347, yyexpect 347(yyfromId VARID)),
+      (348, yyparsing  348 "a data definition"),
+      (349, yyparsing  349 "a sequence of type variables"),
       (350, yyexpect 350(yyfromCh '=')),
-      (351, yyparsing  351 "an instance derivation"),
-      (352, yyparsing  352 "an annotated item"),
-      (353, yyparsing  353 "an annotated item"),
-      (354, yyparsing  354 "an annotated item"),
-      (355, yyparsing  355 "declarations"),
-      (356, yyparsing  356 "a where clause"),
-      (357, yyparsing  357 "some operators"),
-      (358, yyparsing  358 "an annotation"),
-      (359, yyparsing  359 "a list of items to annotate"),
-      (360, yybadstart 360 "a valid java identifier"),
-      (361, yyparsing  361 "a valid java identifier"),
-      (362, yyparsing  362 "a method type with optional throws clause"),
-      (363, yyparsing  363 "method types with optional throws clauses"),
-      (364, yyparsing  364 "a declaration of a native item"),
-      (365, yyparsing  365 "a declaration of a native item"),
-      (366, yyparsing  366 "a declaration of a native item"),
-      (367, yyparsing  367 "a declaration of a native item"),
-      (368, yyparsing  368 "declarations local to a class, instance or type"),
-      (369, yyparsing  369 "a guard qualifier"),
-      (370, yyparsing  370 "guard qualifiers"),
-      (371, yybadstart 371 "'='"),
-      (372, yyparsing  372 "a function or pattern binding"),
-      (373, yyparsing  373 "guarded expressions"),
-      (374, yyparsing  374 "a qualified variable name"),
-      (375, yyparsing  375 "a qualified variable name"),
-      (376, yyparsing  376 "a module clause"),
-      (377, yyparsing  377 "a list of qualified variable names"),
-      (378, yyparsing  378 "else branch"),
-      (379, yyexpect 379(yyfromId ELSE)),
-      (380, yyparsing  380 "a top level expression"),
-      (381, yyparsing  381 "a pattern"),
-      (382, yyparsing  382 "case alternative"),
-      (383, yybadstart 383 "a where clause")];
-    sub7 = [      (384, yyexpect 384(yyfromCh '}')),
-      (385, yyparsing  385 "declarations in a let expression or where clause"),
-      (386, yyparsing  386 "a top level expression"),
-      (387, yyexpect 387(yyfromCh '}')),
-      (388, yyparsing  388 "a guard qualifier"),
-      (389, yyparsing  389 "a list comprehension qualifier"),
-      (390, yyparsing  390 "do expression qualifiers"),
-      (391, yyparsing  391 "list of expressions separated by ';'"),
-      (392, yyparsing  392 "a term"),
-      (393, yyparsing  393 "a term"),
-      (394, yyparsing  394 "list comprehension qualifiers"),
-      (395, yyparsing  395 "a term"),
-      (396, yyparsing  396 "a term"),
-      (397, yyparsing  397 "field"),
-      (398, yyparsing  398 "field list"),
-      (399, yyparsing  399 "'.' or '•'"),
-      (400, yyparsing  400 "'.' or '•'"),
-      (401, yyparsing  401 "a qualified type"),
-      (402, yyparsing  402 "type variables bound in a forall"),
-      (403, yyparsing  403 "a type variable"),
-      (404, yyparsing  404 "a type constructor"),
-      (405, yyparsing  405 "a non function type"),
-      (406, yyparsing  406 "a non function type"),
-      (407, yyparsing  407 "a non function type"),
-      (408, yyparsing  408 "a non function type"),
-      (409, yyparsing  409 "a type constructor"),
-      (410, yyparsing  410 "a non function type"),
-      (411, yyparsing  411 "a type"),
-      (412, yyparsing  412 "a type"),
-      (413, yyparsing  413 "a constrained type"),
-      (414, yyparsing  414 "a primary expression"),
-      (415, yyexpect 415(yyfromCh '}')),
-      (416, yyparsing  416 "a primary expression"),
-      (417, yyparsing  417 "a primary expression"),
-      (418, yyparsing  418 "a primary expression"),
-      (419, yyparsing  419 "a primary expression"),
-      (420, yyparsing  420 "field"),
-      (421, yyparsing  421 "a primary expression"),
-      (422, yyparsing  422 "a primary expression"),
-      (423, yyparsing  423 "field"),
-      (424, yyparsing  424 "field"),
-      (425, yyparsing  425 "field list"),
-      (426, yyparsing  426 "a module import"),
-      (427, yyparsing  427 "a module import"),
-      (428, yyparsing  428 "an import list"),
-      (429, yyparsing  429 "an import item"),
-      (430, yyparsing  430 "a qualified variable name"),
-      (431, yyparsing  431 "an import specification"),
-      (432, yyparsing  432 "an import list"),
-      (433, yyexpect 433(yyfromCh ')')),
-      (434, yyparsing  434 "a list of import items"),
-      (435, yyparsing  435 "an import specification"),
-      (436, yyparsing  436 "an import item"),
-      (437, yyparsing  437 "an import item"),
-      (438, yyparsing  438 "an import item"),
-      (439, yyparsing  439 "an import item"),
-      (440, yyparsing  440 "an import list"),
-      (441, yyparsing  441 "the type this module derives from"),
-      (442, yyparsing  442 "the interfaces this module implements"),
-      (443, yyexpect 443(yyfromId WHERE)),
-      (444, yyparsing  444 "an annotated item"),
-      (445, yyparsing  445 "an annotated item"),
-      (446, yyparsing  446 "an annotated item"),
-      (447, yyexpect 447(yyfromId DCOLON))];
-    sub8 = [      (448, yyparsing  448 "a variant of an algebraic datatype"),
-      (449, yyparsing  449 "a variant of an algebraic datatype"),
-      (450, yyparsing  450 "a native data type"),
-      (451, yyparsing  451 "a variant of an algebraic datatype"),
-      (452, yyparsing  452 "a variant of an algebraic datatype"),
-      (453, yyparsing  453 "a variant of an algebraic datatype"),
-      (454, yyexpect 454(yyfromId NATIVE)),
-      (455, yyexpect 455(yyfromId NATIVE)),
-      (456, yyexpect 456(yyfromId CONID)),
-      (457, yyexpect 457(yyfromId CONID)),
-      (458, yybadstart 458 "a valid java identifier"),
-      (459, yyparsing  459 "a data definition"),
-      (460, yyparsing  460 "an algebraic datatype"),
-      (461, yyparsing  461 "a variant of an algebraic datatype"),
+      (351, yyparsing  351 "simple constraints"),
+      (352, yyexpect 352(yyfromCh ')')),
+      (353, yyparsing  353 "simple constraint"),
+      (354, yyexpect 354(yyfromId CONID)),
+      (355, yyparsing  355 "a type class declaration"),
+      (356, yyparsing  356 "instance constraints"),
+      (357, yyexpect 357(yyfromCh ')')),
+      (358, yyparsing  358 "instance constraint"),
+      (359, yyparsing  359 "instance head"),
+      (360, yyparsing  360 "an instance declaration"),
+      (361, yyparsing  361 "a type declaration"),
+      (362, yyexpect 362(yyfromCh '=')),
+      (363, yyparsing  363 "an annotated item"),
+      (364, yyparsing  364 "an annotated item"),
+      (365, yyparsing  365 "an annotated item"),
+      (366, yyparsing  366 "declarations"),
+      (367, yyparsing  367 "a where clause"),
+      (368, yyparsing  368 "some operators"),
+      (369, yyparsing  369 "an annotation"),
+      (370, yyparsing  370 "a list of items to annotate"),
+      (371, yybadstart 371 "a valid java identifier"),
+      (372, yyparsing  372 "a valid java identifier"),
+      (373, yyparsing  373 "a method type with optional throws clause"),
+      (374, yyparsing  374 "method types with optional throws clauses"),
+      (375, yyparsing  375 "a declaration of a native item"),
+      (376, yyparsing  376 "a declaration of a native item"),
+      (377, yyparsing  377 "a declaration of a native item"),
+      (378, yyparsing  378 "a declaration of a native item"),
+      (379, yyparsing  379 "declarations local to a class, instance or type"),
+      (380, yyparsing  380 "a guard qualifier"),
+      (381, yyparsing  381 "guard qualifiers"),
+      (382, yybadstart 382 "'='"),
+      (383, yyparsing  383 "a function or pattern binding")];
+    sub7 = [      (384, yyparsing  384 "guarded expressions"),
+      (385, yyparsing  385 "a qualified variable name"),
+      (386, yyparsing  386 "a qualified variable name"),
+      (387, yyparsing  387 "a module clause"),
+      (388, yyparsing  388 "a list of qualified variable names"),
+      (389, yyparsing  389 "else branch"),
+      (390, yyexpect 390(yyfromId ELSE)),
+      (391, yyparsing  391 "a top level expression"),
+      (392, yyparsing  392 "a pattern"),
+      (393, yyparsing  393 "case alternative"),
+      (394, yybadstart 394 "a where clause"),
+      (395, yyexpect 395(yyfromCh '}')),
+      (396, yyparsing  396 "declarations in a let expression or where clause"),
+      (397, yyparsing  397 "a top level expression"),
+      (398, yyexpect 398(yyfromCh '}')),
+      (399, yyparsing  399 "a guard qualifier"),
+      (400, yyparsing  400 "a list comprehension qualifier"),
+      (401, yyparsing  401 "do expression qualifiers"),
+      (402, yyparsing  402 "list of expressions separated by ';'"),
+      (403, yyparsing  403 "a term"),
+      (404, yyparsing  404 "a term"),
+      (405, yyparsing  405 "list comprehension qualifiers"),
+      (406, yyparsing  406 "a term"),
+      (407, yyparsing  407 "a term"),
+      (408, yyparsing  408 "field"),
+      (409, yyparsing  409 "field list"),
+      (410, yyparsing  410 "'.' or '•'"),
+      (411, yyparsing  411 "'.' or '•'"),
+      (412, yyparsing  412 "a qualified type"),
+      (413, yyparsing  413 "type variables bound in a forall"),
+      (414, yyparsing  414 "a type variable"),
+      (415, yyparsing  415 "a type constructor"),
+      (416, yyparsing  416 "a non function type"),
+      (417, yyparsing  417 "a non function type"),
+      (418, yyparsing  418 "a non function type"),
+      (419, yyparsing  419 "a non function type"),
+      (420, yyparsing  420 "a type constructor"),
+      (421, yyparsing  421 "a non function type"),
+      (422, yyparsing  422 "a type"),
+      (423, yyparsing  423 "a type"),
+      (424, yyparsing  424 "a constrained type"),
+      (425, yyparsing  425 "a primary expression"),
+      (426, yyexpect 426(yyfromCh '}')),
+      (427, yyparsing  427 "a primary expression"),
+      (428, yyparsing  428 "a primary expression"),
+      (429, yyparsing  429 "a primary expression"),
+      (430, yyparsing  430 "a primary expression"),
+      (431, yyparsing  431 "field"),
+      (432, yyparsing  432 "a primary expression"),
+      (433, yyparsing  433 "a primary expression"),
+      (434, yyparsing  434 "field"),
+      (435, yyparsing  435 "field"),
+      (436, yyparsing  436 "field list"),
+      (437, yyparsing  437 "a module import"),
+      (438, yyparsing  438 "a module import"),
+      (439, yyparsing  439 "an import list"),
+      (440, yyparsing  440 "an import item"),
+      (441, yyparsing  441 "a qualified variable name"),
+      (442, yyparsing  442 "an import specification"),
+      (443, yyparsing  443 "an import list"),
+      (444, yyexpect 444(yyfromCh ')')),
+      (445, yyparsing  445 "a list of import items"),
+      (446, yyparsing  446 "an import specification"),
+      (447, yyparsing  447 "an import item")];
+    sub8 = [      (448, yyparsing  448 "an import item"),
+      (449, yyparsing  449 "an import item"),
+      (450, yyparsing  450 "an import item"),
+      (451, yyparsing  451 "an import list"),
+      (452, yyparsing  452 "the type this module derives from"),
+      (453, yyparsing  453 "the interfaces this module implements"),
+      (454, yyexpect 454(yyfromId WHERE)),
+      (455, yyparsing  455 "an annotated item"),
+      (456, yyparsing  456 "an annotated item"),
+      (457, yyparsing  457 "an annotated item"),
+      (458, yyexpect 458(yyfromId DCOLON)),
+      (459, yyparsing  459 "a variant of an algebraic datatype"),
+      (460, yyparsing  460 "a variant of an algebraic datatype"),
+      (461, yyparsing  461 "a native data type"),
       (462, yyparsing  462 "a variant of an algebraic datatype"),
       (463, yyparsing  463 "a variant of an algebraic datatype"),
-      (464, yyparsing  464 "a sequence of type variables"),
-      (465, yyparsing  465 "a data definition"),
-      (466, yyexpect 466(yyfromId VARID)),
-      (467, yyparsing  467 "a type class declaration"),
-      (468, yyparsing  468 "an instance declaration"),
-      (469, yyparsing  469 "a type declaration"),
-      (470, yyparsing  470 "a type declaration"),
-      (471, yyparsing  471 "a where clause"),
-      (472, yyexpect 472(yyfromCh '}')),
-      (473, yyparsing  473 "a valid java identifier"),
-      (474, yyparsing  474 "a method type with optional throws clause"),
-      (475, yyparsing  475 "method types with optional throws clauses"),
-      (476, yyparsing  476 "a declaration of a native item"),
-      (477, yyparsing  477 "a declaration of a native item"),
-      (478, yyparsing  478 "a declaration of a native item"),
-      (479, yyparsing  479 "a protected or private local declaration"),
-      (480, yyparsing  480 "a protected or private local declaration"),
-      (481, yyparsing  481 "a protected or private local declaration"),
-      (482, yyparsing  482 "declarations local to a class, instance or type"),
-      (483, yyparsing  483 "a commented local declaration"),
-      (484, yyparsing  484 "a protected or private local declaration"),
-      (485, yyexpect 485(yyfromCh '}')),
-      (486, yybadstart 486 "the next definition"),
-      (487, yyparsing  487 "a commented local declaration"),
-      (488, yyparsing  488 "guard qualifiers"),
-      (489, yyparsing  489 "'='"),
-      (490, yyparsing  490 "'='"),
-      (491, yyparsing  491 "a guarded expression"),
-      (492, yyparsing  492 "a qualified variable name"),
-      (493, yyparsing  493 "a list of qualified variable names"),
-      (494, yyparsing  494 "else branch"),
-      (495, yyparsing  495 "a top level expression"),
-      (496, yyparsing  496 "case alternative"),
-      (497, yyparsing  497 "case alternative"),
-      (498, yyparsing  498 "list of case alternatives"),
-      (499, yyparsing  499 "case alternative"),
-      (500, yyparsing  500 "a top level expression"),
-      (501, yyparsing  501 "a top level expression"),
-      (502, yyparsing  502 "a list comprehension qualifier"),
-      (503, yyparsing  503 "list of expressions separated by ';'"),
-      (504, yyparsing  504 "list comprehension qualifiers"),
-      (505, yyparsing  505 "a qualified type"),
-      (506, yyparsing  506 "a type kind"),
-      (507, yyparsing  507 "a type kind"),
-      (508, yyparsing  508 "a type kind"),
-      (509, yyexpect 509(yyfromCh ')')),
-      (510, yyparsing  510 "a type kind"),
-      (511, yyparsing  511 "a list of types")];
-    sub9 = [      (512, yyexpect 512(yyfromCh ')')),
-      (513, yyparsing  513 "a list of types separated by '|'"),
-      (514, yyexpect 514(yyfromCh ')')),
-      (515, yyparsing  515 "a non function type"),
-      (516, yyparsing  516 "a primary expression"),
-      (517, yyparsing  517 "a primary expression"),
-      (518, yyparsing  518 "a primary expression"),
-      (519, yyparsing  519 "field"),
-      (520, yyparsing  520 "field"),
-      (521, yyparsing  521 "a module import"),
-      (522, yyparsing  522 "an import item"),
-      (523, yyparsing  523 "a qualified variable name"),
-      (524, yyparsing  524 "an import specification"),
-      (525, yyparsing  525 "an import list"),
-      (526, yyparsing  526 "a list of import items"),
-      (527, yyparsing  527 "a simple name for a member or import item"),
-      (528, yyparsing  528 "a simple name for a member or import item"),
-      (529, yyparsing  529 "a simple name for a member or import item"),
-      (530, yyparsing  530 "an import specification"),
-      (531, yyexpect 531(yyfromCh ')')),
-      (532, yyparsing  532 "the interfaces this module implements"),
-      (533, yyexpect 533(yyfromCh '{')),
-      (534, yyparsing  534 "specification for module class "),
-      (535, yyparsing  535 "a variant of an algebraic datatype"),
-      (536, yyparsing  536 "constructor types"),
-      (537, yyparsing  537 "a variant of an algebraic datatype"),
-      (538, yyparsing  538 "a variant of an algebraic datatype"),
-      (539, yyparsing  539 "a variant of an algebraic datatype"),
-      (540, yyparsing  540 "a variant of an algebraic datatype"),
-      (541, yyparsing  541 "a variant of an algebraic datatype"),
-      (542, yyparsing  542 "a native data type"),
-      (543, yyparsing  543 "a native data type"),
-      (544, yyparsing  544 "a variant of an algebraic datatype"),
-      (545, yyparsing  545 "a variant of an algebraic datatype"),
-      (546, yyparsing  546 "a data definition"),
-      (547, yyparsing  547 "an algebraic datatype"),
-      (548, yyparsing  548 "a variant of an algebraic datatype"),
-      (549, yybadstart 549 "a valid java identifier"),
-      (550, yyparsing  550 "a data definition"),
-      (551, yybadstart 551 "declarations local to a class, instance or type"),
-      (552, yyparsing  552 "a type declaration"),
-      (553, yyparsing  553 "a where clause"),
-      (554, yyparsing  554 "a method type with optional throws clause"),
-      (555, yyparsing  555 "method types with optional throws clauses"),
-      (556, yyparsing  556 "a protected or private local declaration"),
-      (557, yyparsing  557 "a protected or private local declaration"),
-      (558, yyparsing  558 "a protected or private local declaration"),
-      (559, yyparsing  559 "a commented local declaration"),
-      (560, yyparsing  560 "declarations local to a class, instance or type"),
-      (561, yyparsing  561 "local declarations"),
-      (562, yyparsing  562 "guard qualifiers"),
-      (563, yyparsing  563 "a guarded expression"),
-      (564, yyparsing  564 "case alternative"),
-      (565, yyparsing  565 "list of case alternatives"),
-      (566, yyexpect 566(yyfromCh ')')),
-      (567, yyparsing  567 "a type variable"),
-      (568, yyparsing  568 "a type kind"),
-      (569, yyparsing  569 "a list of types"),
-      (570, yyparsing  570 "a non function type"),
-      (571, yyparsing  571 "a list of types separated by '|'"),
-      (572, yyparsing  572 "a non function type"),
-      (573, yyparsing  573 "a member import specification"),
-      (574, yyparsing  574 "an import item"),
-      (575, yyexpect 575(yyfromCh ')'))];
-    sub10 = [      (576, yyparsing  576 "a member import specification"),
-      (577, yyparsing  577 "a list of member imports"),
-      (578, yyparsing  578 "a list of import items"),
-      (579, yyparsing  579 "an import list"),
-      (580, yyparsing  580 "java code"),
-      (581, yyparsing  581 "a field specification"),
-      (582, yyparsing  582 "a field specification"),
-      (583, yyexpect 583(yyfromId VARID)),
-      (584, yyexpect 584(yyfromId VARID)),
-      (585, yyparsing  585 "a constructor field"),
-      (586, yyparsing  586 "a field specification"),
-      (587, yyexpect 587(yyfromCh '}')),
-      (588, yyparsing  588 "constructor fields"),
-      (589, yyexpect 589(yyfromId DCOLON)),
-      (590, yyparsing  590 "field specifications"),
-      (591, yyparsing  591 "a field specification"),
-      (592, yyparsing  592 "a field specification"),
-      (593, yyparsing  593 "an algebraic datatype"),
-      (594, yyparsing  594 "a data definition"),
-      (595, yyparsing  595 "a type class declaration"),
-      (596, yyparsing  596 "local declarations"),
-      (597, yyparsing  597 "a type kind"),
-      (598, yyparsing  598 "a type kind"),
-      (599, yyparsing  599 "a list of types"),
-      (600, yyparsing  600 "a list of types separated by '|'"),
-      (601, yyparsing  601 "a member import specification"),
-      (602, yyparsing  602 "an import item"),
-      (603, yyparsing  603 "a member import specification"),
-      (604, yyparsing  604 "a list of member imports"),
-      (605, yyparsing  605 "java token"),
-      (606, yyparsing  606 "java token"),
-      (607, yyparsing  607 "java token"),
-      (608, yyparsing  608 "java token"),
-      (609, yyparsing  609 "java token"),
-      (610, yyparsing  610 "java token"),
-      (611, yyparsing  611 "java token"),
-      (612, yyparsing  612 "java token"),
-      (613, yyparsing  613 "java token"),
-      (614, yyparsing  614 "java token"),
-      (615, yyparsing  615 "java token"),
-      (616, yyparsing  616 "java token"),
-      (617, yyparsing  617 "java token"),
-      (618, yyparsing  618 "java token"),
-      (619, yyparsing  619 "java token"),
-      (620, yyparsing  620 "java token"),
-      (621, yyparsing  621 "java token"),
-      (622, yyparsing  622 "java token"),
-      (623, yyparsing  623 "java token"),
+      (464, yyparsing  464 "a variant of an algebraic datatype"),
+      (465, yyexpect 465(yyfromId NATIVE)),
+      (466, yyexpect 466(yyfromId NATIVE)),
+      (467, yyexpect 467(yyfromId CONID)),
+      (468, yyexpect 468(yyfromId CONID)),
+      (469, yybadstart 469 "a valid java identifier"),
+      (470, yyparsing  470 "a data definition"),
+      (471, yyparsing  471 "an algebraic datatype"),
+      (472, yyparsing  472 "a variant of an algebraic datatype"),
+      (473, yyparsing  473 "a variant of an algebraic datatype"),
+      (474, yyparsing  474 "a variant of an algebraic datatype"),
+      (475, yyparsing  475 "a sequence of type variables"),
+      (476, yyparsing  476 "a data definition"),
+      (477, yyparsing  477 "simple constraints"),
+      (478, yyparsing  478 "type class context"),
+      (479, yybadstart 479 "a type variable"),
+      (480, yyparsing  480 "instance constraints"),
+      (481, yyparsing  481 "instance context"),
+      (482, yybadstart 482 "a sequence of one or more ','"),
+      (483, yyexpect 483(yyfromCh ']')),
+      (484, yyparsing  484 "instance head"),
+      (485, yyparsing  485 "a type declaration"),
+      (486, yyparsing  486 "a type declaration"),
+      (487, yyparsing  487 "a where clause"),
+      (488, yyexpect 488(yyfromCh '}')),
+      (489, yyparsing  489 "a valid java identifier"),
+      (490, yyparsing  490 "a method type with optional throws clause"),
+      (491, yyparsing  491 "method types with optional throws clauses"),
+      (492, yyparsing  492 "a declaration of a native item"),
+      (493, yyparsing  493 "a declaration of a native item"),
+      (494, yyparsing  494 "a declaration of a native item"),
+      (495, yyparsing  495 "a protected or private local declaration"),
+      (496, yyparsing  496 "a protected or private local declaration"),
+      (497, yyparsing  497 "a protected or private local declaration"),
+      (498, yyparsing  498 "declarations local to a class, instance or type"),
+      (499, yyparsing  499 "a commented local declaration"),
+      (500, yyparsing  500 "a protected or private local declaration"),
+      (501, yyexpect 501(yyfromCh '}')),
+      (502, yybadstart 502 "the next definition"),
+      (503, yyparsing  503 "a commented local declaration"),
+      (504, yyparsing  504 "guard qualifiers"),
+      (505, yyparsing  505 "'='"),
+      (506, yyparsing  506 "'='"),
+      (507, yyparsing  507 "a guarded expression"),
+      (508, yyparsing  508 "a qualified variable name"),
+      (509, yyparsing  509 "a list of qualified variable names"),
+      (510, yyparsing  510 "else branch"),
+      (511, yyparsing  511 "a top level expression")];
+    sub9 = [      (512, yyparsing  512 "case alternative"),
+      (513, yyparsing  513 "case alternative"),
+      (514, yyparsing  514 "list of case alternatives"),
+      (515, yyparsing  515 "case alternative"),
+      (516, yyparsing  516 "a top level expression"),
+      (517, yyparsing  517 "a top level expression"),
+      (518, yyparsing  518 "a list comprehension qualifier"),
+      (519, yyparsing  519 "list of expressions separated by ';'"),
+      (520, yyparsing  520 "list comprehension qualifiers"),
+      (521, yyparsing  521 "a qualified type"),
+      (522, yyparsing  522 "a type kind"),
+      (523, yyparsing  523 "a type kind"),
+      (524, yyparsing  524 "a type kind"),
+      (525, yyexpect 525(yyfromCh ')')),
+      (526, yyparsing  526 "a type kind"),
+      (527, yyparsing  527 "a list of types"),
+      (528, yyexpect 528(yyfromCh ')')),
+      (529, yyparsing  529 "a list of types separated by '|'"),
+      (530, yyexpect 530(yyfromCh ')')),
+      (531, yyparsing  531 "a non function type"),
+      (532, yyparsing  532 "a primary expression"),
+      (533, yyparsing  533 "a primary expression"),
+      (534, yyparsing  534 "a primary expression"),
+      (535, yyparsing  535 "field"),
+      (536, yyparsing  536 "field"),
+      (537, yyparsing  537 "a module import"),
+      (538, yyparsing  538 "an import item"),
+      (539, yyparsing  539 "a qualified variable name"),
+      (540, yyparsing  540 "an import specification"),
+      (541, yyparsing  541 "an import list"),
+      (542, yyparsing  542 "a list of import items"),
+      (543, yyparsing  543 "a simple name for a member or import item"),
+      (544, yyparsing  544 "a simple name for a member or import item"),
+      (545, yyparsing  545 "a simple name for a member or import item"),
+      (546, yyparsing  546 "an import specification"),
+      (547, yyexpect 547(yyfromCh ')')),
+      (548, yyparsing  548 "the interfaces this module implements"),
+      (549, yyexpect 549(yyfromCh '{')),
+      (550, yyparsing  550 "specification for module class "),
+      (551, yyparsing  551 "a variant of an algebraic datatype"),
+      (552, yyparsing  552 "constructor types"),
+      (553, yyparsing  553 "a variant of an algebraic datatype"),
+      (554, yyparsing  554 "a variant of an algebraic datatype"),
+      (555, yyparsing  555 "a variant of an algebraic datatype"),
+      (556, yyparsing  556 "a variant of an algebraic datatype"),
+      (557, yyparsing  557 "a variant of an algebraic datatype"),
+      (558, yyparsing  558 "a native data type"),
+      (559, yyparsing  559 "a native data type"),
+      (560, yyparsing  560 "a variant of an algebraic datatype"),
+      (561, yyparsing  561 "a variant of an algebraic datatype"),
+      (562, yyparsing  562 "a data definition"),
+      (563, yyparsing  563 "an algebraic datatype"),
+      (564, yyparsing  564 "a variant of an algebraic datatype"),
+      (565, yybadstart 565 "a valid java identifier"),
+      (566, yyparsing  566 "a data definition"),
+      (567, yyparsing  567 "simple constraints"),
+      (568, yybadstart 568 "declarations local to a class, instance or type"),
+      (569, yyparsing  569 "instance constraints"),
+      (570, yyparsing  570 "instance head"),
+      (571, yyparsing  571 "a type declaration"),
+      (572, yyparsing  572 "a where clause"),
+      (573, yyparsing  573 "a method type with optional throws clause"),
+      (574, yyparsing  574 "method types with optional throws clauses"),
+      (575, yyparsing  575 "a protected or private local declaration")];
+    sub10 = [      (576, yyparsing  576 "a protected or private local declaration"),
+      (577, yyparsing  577 "a protected or private local declaration"),
+      (578, yyparsing  578 "a commented local declaration"),
+      (579, yyparsing  579 "declarations local to a class, instance or type"),
+      (580, yyparsing  580 "local declarations"),
+      (581, yyparsing  581 "guard qualifiers"),
+      (582, yyparsing  582 "a guarded expression"),
+      (583, yyparsing  583 "case alternative"),
+      (584, yyparsing  584 "list of case alternatives"),
+      (585, yyexpect 585(yyfromCh ')')),
+      (586, yyparsing  586 "a type variable"),
+      (587, yyparsing  587 "a type kind"),
+      (588, yyparsing  588 "a list of types"),
+      (589, yyparsing  589 "a non function type"),
+      (590, yyparsing  590 "a list of types separated by '|'"),
+      (591, yyparsing  591 "a non function type"),
+      (592, yyparsing  592 "a member import specification"),
+      (593, yyparsing  593 "an import item"),
+      (594, yyexpect 594(yyfromCh ')')),
+      (595, yyparsing  595 "a member import specification"),
+      (596, yyparsing  596 "a list of member imports"),
+      (597, yyparsing  597 "a list of import items"),
+      (598, yyparsing  598 "an import list"),
+      (599, yyparsing  599 "java code"),
+      (600, yyparsing  600 "a field specification"),
+      (601, yyparsing  601 "a field specification"),
+      (602, yyexpect 602(yyfromId VARID)),
+      (603, yyexpect 603(yyfromId VARID)),
+      (604, yyparsing  604 "a constructor field"),
+      (605, yyparsing  605 "a field specification"),
+      (606, yyexpect 606(yyfromCh '}')),
+      (607, yyparsing  607 "constructor fields"),
+      (608, yyexpect 608(yyfromId DCOLON)),
+      (609, yyparsing  609 "field specifications"),
+      (610, yyparsing  610 "a field specification"),
+      (611, yyparsing  611 "a field specification"),
+      (612, yyparsing  612 "an algebraic datatype"),
+      (613, yyparsing  613 "a data definition"),
+      (614, yyparsing  614 "a type class declaration"),
+      (615, yyparsing  615 "local declarations"),
+      (616, yyparsing  616 "a type kind"),
+      (617, yyparsing  617 "a type kind"),
+      (618, yyparsing  618 "a list of types"),
+      (619, yyparsing  619 "a list of types separated by '|'"),
+      (620, yyparsing  620 "a member import specification"),
+      (621, yyparsing  621 "an import item"),
+      (622, yyparsing  622 "a member import specification"),
+      (623, yyparsing  623 "a list of member imports"),
       (624, yyparsing  624 "java token"),
       (625, yyparsing  625 "java token"),
       (626, yyparsing  626 "java token"),
@@ -9403,8 +9616,8 @@ private yyrecs  = let
       (653, yyparsing  653 "java token"),
       (654, yyparsing  654 "java token"),
       (655, yyparsing  655 "java token"),
-      (656, yyparsing  656 "java tokens"),
-      (657, yyparsing  657 "java code"),
+      (656, yyparsing  656 "java token"),
+      (657, yyparsing  657 "java token"),
       (658, yyparsing  658 "java token"),
       (659, yyparsing  659 "java token"),
       (660, yyparsing  660 "java token"),
@@ -9416,33 +9629,52 @@ private yyrecs  = let
       (666, yyparsing  666 "java token"),
       (667, yyparsing  667 "java token"),
       (668, yyparsing  668 "java token"),
-      (669, yyexpect 669(yyfromCh '}')),
-      (670, yyparsing  670 "java tokens"),
-      (671, yyparsing  671 "a field specification"),
-      (672, yyparsing  672 "a field specification"),
-      (673, yyparsing  673 "a field specification"),
-      (674, yyparsing  674 "a field specification"),
-      (675, yyexpect 675(yyfromId DCOLON)),
-      (676, yyparsing  676 "a variant of an algebraic datatype"),
-      (677, yyparsing  677 "constructor fields"),
-      (678, yyparsing  678 "constructor fields"),
-      (679, yyparsing  679 "a constructor field"),
-      (680, yyparsing  680 "field specifications"),
-      (681, yyparsing  681 "a list of member imports"),
-      (682, yyparsing  682 "java tokens"),
-      (683, yyexpect 683(yyfromCh '}')),
-      (684, yyparsing  684 "java code"),
-      (685, yyparsing  685 "java tokens"),
-      (686, yyparsing  686 "a constructor field"),
-      (687, yyparsing  687 "constructor fields"),
-      (688, yyparsing  688 "constructor fields"),
-      (689, yyparsing  689 "a constructor field"),
-      (690, yyparsing  690 "field specifications"),
-      (691, yyparsing  691 "java tokens"),
-      (692, yyparsing  692 "java tokens"),
-      (693, yyparsing  693 "a constructor field"),
-      (694, yyparsing  694 "java tokens")];
-      in sub1 `seq` sub2 `seq` sub3 `seq` sub4 `seq` sub5 `seq` sub6 `seq` sub7 `seq` sub8 `seq` sub9 `seq` sub10 `seq` sub11 `seq` arrayFromIndexList (sub1 ++ sub2 ++ sub3 ++ sub4 ++ sub5 ++ sub6 ++ sub7 ++ sub8 ++ sub9 ++ sub10 ++ sub11);
+      (669, yyparsing  669 "java token"),
+      (670, yyparsing  670 "java token"),
+      (671, yyparsing  671 "java token"),
+      (672, yyparsing  672 "java token"),
+      (673, yyparsing  673 "java token"),
+      (674, yyparsing  674 "java token"),
+      (675, yyparsing  675 "java tokens"),
+      (676, yyparsing  676 "java code"),
+      (677, yyparsing  677 "java token"),
+      (678, yyparsing  678 "java token"),
+      (679, yyparsing  679 "java token"),
+      (680, yyparsing  680 "java token"),
+      (681, yyparsing  681 "java token"),
+      (682, yyparsing  682 "java token"),
+      (683, yyparsing  683 "java token"),
+      (684, yyparsing  684 "java token"),
+      (685, yyparsing  685 "java token"),
+      (686, yyparsing  686 "java token"),
+      (687, yyparsing  687 "java token"),
+      (688, yyexpect 688(yyfromCh '}')),
+      (689, yyparsing  689 "java tokens"),
+      (690, yyparsing  690 "a field specification"),
+      (691, yyparsing  691 "a field specification"),
+      (692, yyparsing  692 "a field specification"),
+      (693, yyparsing  693 "a field specification"),
+      (694, yyexpect 694(yyfromId DCOLON)),
+      (695, yyparsing  695 "a variant of an algebraic datatype"),
+      (696, yyparsing  696 "constructor fields"),
+      (697, yyparsing  697 "constructor fields"),
+      (698, yyparsing  698 "a constructor field"),
+      (699, yyparsing  699 "field specifications"),
+      (700, yyparsing  700 "a list of member imports"),
+      (701, yyparsing  701 "java tokens"),
+      (702, yyexpect 702(yyfromCh '}')),
+      (703, yyparsing  703 "java code")];
+    sub12 = [      (704, yyparsing  704 "java tokens"),
+      (705, yyparsing  705 "a constructor field"),
+      (706, yyparsing  706 "constructor fields"),
+      (707, yyparsing  707 "constructor fields"),
+      (708, yyparsing  708 "a constructor field"),
+      (709, yyparsing  709 "field specifications"),
+      (710, yyparsing  710 "java tokens"),
+      (711, yyparsing  711 "java tokens"),
+      (712, yyparsing  712 "a constructor field"),
+      (713, yyparsing  713 "java tokens")];
+      in sub1 `seq` sub2 `seq` sub3 `seq` sub4 `seq` sub5 `seq` sub6 `seq` sub7 `seq` sub8 `seq` sub9 `seq` sub10 `seq` sub11 `seq` sub12 `seq` arrayFromIndexList (sub1 ++ sub2 ++ sub3 ++ sub4 ++ sub5 ++ sub6 ++ sub7 ++ sub8 ++ sub9 ++ sub10 ++ sub11 ++ sub12);
 private yyeacts = let 
     sub1 = [      (5, yyAccept),
       (8, (-25)),
@@ -9459,31 +9691,31 @@ private yyeacts = let
       (22, (-18)),
       (24, (-183)),
       (25, (-186)),
-      (27, (-323)),
-      (28, (-324)),
-      (33, (-327)),
-      (34, (-326)),
-      (35, (-329)),
-      (36, (-330)),
-      (37, (-331)),
-      (38, (-325)),
-      (39, (-332)),
-      (40, (-328)),
+      (27, (-337)),
+      (28, (-338)),
+      (33, (-341)),
+      (34, (-340)),
+      (35, (-343)),
+      (36, (-344)),
+      (37, (-345)),
+      (38, (-339)),
+      (39, (-346)),
+      (40, (-342)),
       (44, (-195)),
       (45, (-194)),
-      (47, (-401)),
+      (47, (-415)),
       (48, (-3)),
       (49, (-4)),
-      (50, (-399)),
-      (51, (-402)),
-      (53, (-363)),
-      (54, (-400)),
-      (55, (-375)),
-      (56, (-371)),
-      (57, (-376)),
-      (58, (-377)),
-      (59, (-379)),
-      (61, (-385)),
+      (50, (-413)),
+      (51, (-416)),
+      (53, (-377)),
+      (54, (-414)),
+      (55, (-389)),
+      (56, (-385)),
+      (57, (-390)),
+      (58, (-391)),
+      (59, (-393)),
+      (61, (-399)),
       (62, (-22)),
       (69, (-26)),
       (70, (-16)),
@@ -9493,12 +9725,12 @@ private yyeacts = let
       (75, (-185)),
       (77, (-188)),
       (78, (-182)),
-      (83, (-370)),
+      (83, (-384)),
       (84, (-193)),
-      (86, (-405)),
-      (93, (-416)),
-      (99, (-380)),
-      (103, (-378)),
+      (86, (-419)),
+      (93, (-430)),
+      (99, (-394)),
+      (103, (-392)),
       (108, (-117)),
       (125, (-1)),
       (126, (-27)),
@@ -9520,43 +9752,43 @@ private yyeacts = let
       (142, (-129)),
       (143, (-206)),
       (147, (-213)),
-      (149, (-314)),
+      (149, (-328)),
       (153, (-24)),
       (154, (-17)),
       (156, (-11)),
       (157, (-184)),
       (158, (-181)),
-      (159, (-365)),
+      (159, (-379)),
       (163, (-137)),
-      (170, (-336)),
-      (172, (-409)),
-      (173, (-422)),
-      (175, (-415)),
-      (177, (-408)),
-      (179, (-407)),
-      (180, (-406)),
-      (187, (-417)),
-      (189, (-360)),
-      (190, (-359)),
-      (191, (-382)),
+      (170, (-350)),
+      (172, (-423)),
+      (173, (-436)),
+      (175, (-429)),
+      (177, (-422)),
+      (179, (-421)),
+      (180, (-420)),
+      (187, (-431)),
+      (189, (-374)),
+      (190, (-373)),
+      (191, (-396)),
       (192, (-171)),
-      (193, (-403)),
+      (193, (-417)),
       (197, (-252)),
       (202, (-254)),
-      (203, (-362)),
+      (203, (-376)),
       (204, (-229)),
       (205, (-230)),
       (206, (-236)),
       (207, (-235)),
       (208, (-245)),
-      (209, (-294)),
+      (209, (-308)),
       (210, (-246)),
       (211, (-247)),
-      (212, (-368)),
-      (213, (-369)),
-      (214, (-387)),
-      (217, (-388)),
-      (218, (-389)),
+      (212, (-382)),
+      (213, (-383)),
+      (214, (-401)),
+      (217, (-402)),
+      (218, (-403)),
       (223, (-145)),
       (224, (-196)),
       (225, (-198)),
@@ -9565,278 +9797,288 @@ private yyeacts = let
       (230, (-215)),
       (231, (-216)),
       (232, (-214)),
-      (238, (-37)),
-      (242, (-34)),
-      (243, (-35)),
-      (244, (-36)),
-      (245, (-212)),
-      (249, (-28)),
-      (250, (-31))];
-    sub3 = [      (252, (-321)),
-      (253, (-200)),
-      (254, (-201)),
-      (255, (-199)),
-      (256, (-202)),
-      (257, (-204)),
-      (260, (-5)),
-      (261, (-6)),
-      (263, (-9)),
-      (269, (-268)),
-      (272, (-320)),
-      (273, (-351)),
-      (276, (-192)),
-      (278, (-191)),
-      (279, (-19)),
-      (280, (-364)),
-      (289, (-386)),
-      (294, (-410)),
-      (295, (-412)),
-      (296, (-411)),
-      (297, (-435)),
-      (300, (-418)),
-      (302, (-361)),
-      (304, (-404)),
-      (307, (-228)),
-      (312, (-256)),
-      (314, (-239)),
-      (315, (-238)),
-      (317, (-255)),
-      (321, (-295)),
-      (328, (-393)),
-      (330, (-2)),
-      (332, (-145)),
-      (333, (-145)),
-      (335, (-142)),
-      (347, (-314)),
-      (348, (-314)),
-      (351, (-267)),
-      (355, (-29)),
-      (357, (-203)),
-      (358, (-205)),
-      (359, (-211)),
-      (361, (-8)),
-      (362, (-219)),
-      (363, (-220)),
-      (364, (-222)),
-      (372, (-319)),
-      (373, (-352)),
-      (375, (-190)),
-      (376, (-21)),
-      (378, (-367)),
-      (381, (-333)),
-      (385, (-141)),
-      (388, (-346)),
-      (389, (-337)),
-      (390, (-344)),
-      (392, (-414)),
-      (393, (-413)),
-      (395, (-420)),
-      (396, (-419)),
-      (397, (-432)),
-      (398, (-424)),
-      (399, (-233)),
-      (400, (-232))];
-    sub4 = [      (402, (-227)),
-      (404, (-258)),
-      (405, (-248)),
-      (409, (-257)),
-      (410, (-251)),
-      (411, (-236)),
-      (412, (-237)),
-      (413, (-234)),
-      (417, (-397)),
-      (418, (-398)),
-      (419, (-392)),
-      (420, (-429)),
-      (421, (-390)),
-      (422, (-391)),
-      (423, (-430)),
-      (425, (-427)),
-      (426, (-145)),
-      (427, (-144)),
-      (428, (-149)),
-      (432, (-147)),
-      (436, (-153)),
-      (437, (-156)),
-      (438, (-157)),
-      (439, (-158)),
-      (441, (-44)),
-      (444, (-209)),
-      (445, (-207)),
-      (446, (-208)),
-      (448, (-290)),
-      (450, (-271)),
-      (459, (-275)),
-      (460, (-278)),
-      (461, (-280)),
-      (462, (-283)),
-      (463, (-289)),
-      (464, (-277)),
-      (467, (-264)),
-      (468, (-266)),
-      (469, (-312)),
-      (471, (-317)),
-      (473, (-7)),
-      (476, (-223)),
-      (477, (-224)),
-      (478, (-225)),
-      (482, (-315)),
-      (484, (-130)),
-      (487, (-136)),
-      (489, (-334)),
-      (490, (-335)),
-      (492, (-189)),
-      (493, (-180)),
-      (494, (-366)),
-      (495, (-372)),
-      (496, (-354)),
-      (499, (-355)),
-      (500, (-373)),
-      (501, (-374)),
-      (503, (-438)),
-      (504, (-340)),
-      (505, (-231)),
-      (506, (-262)),
-      (507, (-261)),
-      (511, (-241)),
-      (515, (-240))];
-    sub5 = [      (516, (-396)),
-      (517, (-394)),
-      (518, (-395)),
-      (521, (-143)),
-      (524, (-161)),
-      (525, (-148)),
-      (527, (-168)),
-      (528, (-169)),
-      (529, (-170)),
-      (530, (-160)),
-      (532, (-46)),
-      (534, (-42)),
-      (536, (-293)),
-      (537, (-292)),
-      (538, (-282)),
-      (539, (-285)),
-      (540, (-286)),
-      (541, (-284)),
-      (542, (-269)),
-      (543, (-270)),
-      (544, (-288)),
-      (545, (-287)),
-      (546, (-272)),
-      (548, (-281)),
-      (550, (-274)),
-      (551, (-314)),
-      (552, (-313)),
-      (553, (-318)),
-      (554, (-218)),
-      (555, (-221)),
-      (556, (-131)),
-      (557, (-132)),
-      (558, (-133)),
-      (559, (-135)),
-      (560, (-316)),
-      (562, (-348)),
-      (563, (-350)),
-      (564, (-353)),
-      (565, (-357)),
-      (567, (-253)),
-      (570, (-249)),
-      (572, (-250)),
-      (574, (-155)),
-      (578, (-152)),
-      (579, (-146)),
-      (586, (-311)),
-      (591, (-305)),
-      (592, (-308)),
-      (593, (-279)),
-      (594, (-273)),
-      (595, (-265)),
-      (596, (-126)),
-      (597, (-263)),
-      (598, (-259)),
-      (599, (-242)),
-      (600, (-244)),
-      (601, (-164)),
-      (602, (-154)),
-      (603, (-163)),
-      (605, (-49)),
-      (606, (-50)),
-      (607, (-51)),
-      (608, (-52)),
-      (609, (-53))];
-    sub6 = [      (610, (-54)),
-      (611, (-55)),
-      (612, (-56)),
-      (613, (-57)),
-      (614, (-58)),
-      (615, (-59)),
-      (616, (-60)),
-      (617, (-61)),
-      (618, (-62)),
-      (619, (-63)),
-      (620, (-64)),
-      (621, (-65)),
-      (622, (-66)),
-      (623, (-67)),
-      (624, (-68)),
-      (625, (-69)),
-      (626, (-70)),
-      (627, (-71)),
-      (628, (-72)),
-      (629, (-73)),
-      (630, (-74)),
-      (631, (-75)),
-      (632, (-76)),
-      (633, (-77)),
-      (634, (-78)),
-      (635, (-79)),
-      (636, (-80)),
-      (637, (-81)),
-      (638, (-82)),
-      (639, (-83)),
-      (640, (-84)),
-      (641, (-85)),
-      (642, (-86)),
-      (643, (-87)),
-      (644, (-88)),
-      (645, (-89)),
-      (646, (-90)),
-      (647, (-91)),
-      (648, (-92)),
-      (649, (-93)),
-      (650, (-94)),
-      (651, (-95)),
-      (652, (-96)),
-      (653, (-97)),
-      (654, (-106)),
-      (655, (-107)),
-      (657, (-48)),
-      (658, (-104)),
-      (659, (-102)),
-      (660, (-103)),
-      (661, (-98)),
-      (662, (-99)),
-      (663, (-100)),
-      (664, (-101)),
-      (665, (-105)),
-      (666, (-108)),
-      (667, (-109)),
-      (668, (-110)),
-      (671, (-307)),
-      (672, (-306)),
-      (673, (-310)),
-      (674, (-309)),
-      (676, (-291)),
-      (681, (-167))];
-    sub7 = [      (684, (-47)),
-      (685, (-112)),
-      (687, (-300)),
-      (688, (-299)),
-      (689, (-301)),
-      (690, (-304)),
-      (691, (-116)),
-      (693, (-302)),
-      (694, (-114))];
+      (236, (-268)),
+      (237, (-328)),
+      (240, (-276)),
+      (241, (-279)),
+      (242, (-328)),
+      (243, (-37)),
+      (245, (-281))];
+    sub3 = [      (247, (-34)),
+      (248, (-35)),
+      (249, (-36)),
+      (250, (-212)),
+      (254, (-28)),
+      (255, (-31)),
+      (257, (-335)),
+      (258, (-200)),
+      (259, (-201)),
+      (260, (-199)),
+      (261, (-202)),
+      (262, (-204)),
+      (265, (-5)),
+      (266, (-6)),
+      (268, (-9)),
+      (274, (-282)),
+      (277, (-334)),
+      (278, (-365)),
+      (281, (-192)),
+      (283, (-191)),
+      (284, (-19)),
+      (285, (-378)),
+      (294, (-400)),
+      (299, (-424)),
+      (300, (-426)),
+      (301, (-425)),
+      (302, (-449)),
+      (305, (-432)),
+      (307, (-375)),
+      (309, (-418)),
+      (312, (-228)),
+      (317, (-256)),
+      (319, (-239)),
+      (320, (-238)),
+      (322, (-255)),
+      (326, (-309)),
+      (333, (-407)),
+      (335, (-2)),
+      (337, (-145)),
+      (338, (-145)),
+      (340, (-142)),
+      (353, (-264)),
+      (355, (-271)),
+      (358, (-272)),
+      (360, (-280)),
+      (366, (-29)),
+      (368, (-203)),
+      (369, (-205)),
+      (370, (-211)),
+      (372, (-8)),
+      (373, (-219)),
+      (374, (-220)),
+      (375, (-222)),
+      (383, (-333)),
+      (384, (-366)),
+      (386, (-190)),
+      (387, (-21)),
+      (389, (-381)),
+      (392, (-347)),
+      (396, (-141)),
+      (399, (-360)),
+      (400, (-351)),
+      (401, (-358)),
+      (403, (-428))];
+    sub4 = [      (404, (-427)),
+      (406, (-434)),
+      (407, (-433)),
+      (408, (-446)),
+      (409, (-438)),
+      (410, (-233)),
+      (411, (-232)),
+      (413, (-227)),
+      (415, (-258)),
+      (416, (-248)),
+      (420, (-257)),
+      (421, (-251)),
+      (422, (-236)),
+      (423, (-237)),
+      (424, (-234)),
+      (428, (-411)),
+      (429, (-412)),
+      (430, (-406)),
+      (431, (-443)),
+      (432, (-404)),
+      (433, (-405)),
+      (434, (-444)),
+      (436, (-441)),
+      (437, (-145)),
+      (438, (-144)),
+      (439, (-149)),
+      (443, (-147)),
+      (447, (-153)),
+      (448, (-156)),
+      (449, (-157)),
+      (450, (-158)),
+      (452, (-44)),
+      (455, (-209)),
+      (456, (-207)),
+      (457, (-208)),
+      (459, (-304)),
+      (461, (-285)),
+      (470, (-289)),
+      (471, (-292)),
+      (472, (-294)),
+      (473, (-297)),
+      (474, (-303)),
+      (475, (-291)),
+      (478, (-269)),
+      (481, (-277)),
+      (485, (-326)),
+      (487, (-331)),
+      (489, (-7)),
+      (492, (-223)),
+      (493, (-224)),
+      (494, (-225)),
+      (498, (-329)),
+      (500, (-130)),
+      (503, (-136)),
+      (505, (-348)),
+      (506, (-349)),
+      (508, (-189)),
+      (509, (-180)),
+      (510, (-380)),
+      (511, (-386)),
+      (512, (-368)),
+      (515, (-369)),
+      (516, (-387)),
+      (517, (-388))];
+    sub5 = [      (519, (-452)),
+      (520, (-354)),
+      (521, (-231)),
+      (522, (-262)),
+      (523, (-261)),
+      (527, (-241)),
+      (531, (-240)),
+      (532, (-410)),
+      (533, (-408)),
+      (534, (-409)),
+      (537, (-143)),
+      (540, (-161)),
+      (541, (-148)),
+      (543, (-168)),
+      (544, (-169)),
+      (545, (-170)),
+      (546, (-160)),
+      (548, (-46)),
+      (550, (-42)),
+      (552, (-307)),
+      (553, (-306)),
+      (554, (-296)),
+      (555, (-299)),
+      (556, (-300)),
+      (557, (-298)),
+      (558, (-283)),
+      (559, (-284)),
+      (560, (-302)),
+      (561, (-301)),
+      (562, (-286)),
+      (564, (-295)),
+      (566, (-288)),
+      (567, (-267)),
+      (568, (-328)),
+      (569, (-275)),
+      (570, (-278)),
+      (571, (-327)),
+      (572, (-332)),
+      (573, (-218)),
+      (574, (-221)),
+      (575, (-131)),
+      (576, (-132)),
+      (577, (-133)),
+      (578, (-135)),
+      (579, (-330)),
+      (581, (-362)),
+      (582, (-364)),
+      (583, (-367)),
+      (584, (-371)),
+      (586, (-253)),
+      (589, (-249)),
+      (591, (-250)),
+      (593, (-155)),
+      (597, (-152)),
+      (598, (-146)),
+      (605, (-325)),
+      (610, (-319)),
+      (611, (-322)),
+      (612, (-293)),
+      (613, (-287)),
+      (614, (-270)),
+      (615, (-126)),
+      (616, (-263)),
+      (617, (-259))];
+    sub6 = [      (618, (-242)),
+      (619, (-244)),
+      (620, (-164)),
+      (621, (-154)),
+      (622, (-163)),
+      (624, (-49)),
+      (625, (-50)),
+      (626, (-51)),
+      (627, (-52)),
+      (628, (-53)),
+      (629, (-54)),
+      (630, (-55)),
+      (631, (-56)),
+      (632, (-57)),
+      (633, (-58)),
+      (634, (-59)),
+      (635, (-60)),
+      (636, (-61)),
+      (637, (-62)),
+      (638, (-63)),
+      (639, (-64)),
+      (640, (-65)),
+      (641, (-66)),
+      (642, (-67)),
+      (643, (-68)),
+      (644, (-69)),
+      (645, (-70)),
+      (646, (-71)),
+      (647, (-72)),
+      (648, (-73)),
+      (649, (-74)),
+      (650, (-75)),
+      (651, (-76)),
+      (652, (-77)),
+      (653, (-78)),
+      (654, (-79)),
+      (655, (-80)),
+      (656, (-81)),
+      (657, (-82)),
+      (658, (-83)),
+      (659, (-84)),
+      (660, (-85)),
+      (661, (-86)),
+      (662, (-87)),
+      (663, (-88)),
+      (664, (-89)),
+      (665, (-90)),
+      (666, (-91)),
+      (667, (-92)),
+      (668, (-93)),
+      (669, (-94)),
+      (670, (-95)),
+      (671, (-96)),
+      (672, (-97)),
+      (673, (-106)),
+      (674, (-107)),
+      (676, (-48)),
+      (677, (-104)),
+      (678, (-102)),
+      (679, (-103)),
+      (680, (-98)),
+      (681, (-99)),
+      (682, (-100)),
+      (683, (-101))];
+    sub7 = [      (684, (-105)),
+      (685, (-108)),
+      (686, (-109)),
+      (687, (-110)),
+      (690, (-321)),
+      (691, (-320)),
+      (692, (-324)),
+      (693, (-323)),
+      (695, (-305)),
+      (700, (-167)),
+      (703, (-47)),
+      (704, (-112)),
+      (706, (-314)),
+      (707, (-313)),
+      (708, (-315)),
+      (709, (-318)),
+      (710, (-116)),
+      (712, (-316)),
+      (713, (-114))];
       in sub1 `seq` sub2 `seq` sub3 `seq` sub4 `seq` sub5 `seq` sub6 `seq` sub7 `seq` arrayFromIndexList (sub1 ++ sub2 ++ sub3 ++ sub4 ++ sub5 ++ sub6 ++ sub7);
 
 
@@ -9848,212 +10090,218 @@ decodeArr s1 s2 = arrayFromIndexList (zip (un s1) (un s2))
 private yygo0 = decodeArr "\u0001\u0002\u0003\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015" "\u0005\u0005\u0005\u0007\u0007\u0007\u0006\u0006\u0006\u0006\u0006"
 private yygo1 = decodeArr "\u000e\u000f\u0010\u0019\u001a" "\t\t\t\n\n"
 private yygo2 = decodeArr "\n\u000b\f\r¬­®¯°±²" "\u0014\u0014\u0014\u0016\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
-private yygo4 = decodeArr "\u0004µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "022233344666666666671155558888899::<<;;;;;;;;;;;;;;======================"
+private yygo4 = decodeArr "\u0004µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "022233344666666666671155558888899::<<;;;;;;;;;;;;;;======================"
 private yygo6 = decodeArr "\u0016\u0017\u0018" "BAA"
 private yygo8 = decodeArr "\u0019\u001a" "EE"
 private yygo10 = decodeArr "\u000e\u000f\u0010" "FFF"
 private yygo13 = decodeArr "\n\u000b\f¬­®¯°±²" "GGG\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
 private yygo23 = decodeArr "\n\u000b\f\r¬­®¯°±²" "\u0014\u0014\u0014I\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
 private yygo26 = decodeArr "»¼ÂÃ" "NNMM"
-private yygo29 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667OO55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo30 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667PP55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo41 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667SSSSS99::<<;;;;;;;;;;;;;;======================"
-private yygo42 = decodeArr "µ¶·¸¹ºÁÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦ" "222333YZZ66666666667XX\\\\\\\\8888899::<<;;;;;;;;;;;;;;======================[["
-private yygo43 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƲƳƴ" "2223334466666666667^^55558888899::<<;;;;;;;;;;;;;;======================___"
-private yygo46 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666aa``<<;;;;;;;;;;;;;;======================"
-private yygo52 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666cc<<;;;;;;;;;;;;;;======================"
-private yygo57 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666gg<<;;;;;;;;;;;;;;======================"
-private yygo64 = decodeArr "\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "}}}~~~~\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo29 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667OO55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo30 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667PP55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo41 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667SSSSS99::<<;;;;;;;;;;;;;;======================"
+private yygo42 = decodeArr "µ¶·¸¹ºÁÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴ" "222333YZZ66666666667XX\\\\\\\\8888899::<<;;;;;;;;;;;;;;======================[["
+private yygo43 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲǀǁǂ" "2223334466666666667^^55558888899::<<;;;;;;;;;;;;;;======================___"
+private yygo46 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666aa``<<;;;;;;;;;;;;;;======================"
+private yygo52 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666cc<<;;;;;;;;;;;;;;======================"
+private yygo57 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666gg<<;;;;;;;;;;;;;;======================"
+private yygo64 = decodeArr "\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĎďĘęĚĞğĠġņŇōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "}}}~~~~\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
 private yygo66 = decodeArr "\u0016\u0017\u0018" "B\u0099\u0099"
 private yygo67 = decodeArr "\n\u000b\f\r¬­®¯°±²" "\u0014\u0014\u0014\u009a\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
 private yygo72 = decodeArr "\n\u000b\f¬­®¯°±²" "\u009c\u009c\u009c\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
 private yygo76 = decodeArr "»¼ÂÃ" "\u009e\u009eMM"
-private yygo79 = decodeArr "Ŭŭ" "¡¡"
-private yygo81 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "¥¥¦¦¦\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo82 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŐőŒŖŗŘřŚŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666©©©«««ªª7¨¨55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo85 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667SSSSS99::<<;;;;;;;;;;;;;;======================"
-private yygo87 = decodeArr "ƥƦ" "­­"
-private yygo89 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667²²55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo90 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666cc<<;;;;;;;;;;;;;;======================"
+private yygo79 = decodeArr "źŻ" "¡¡"
+private yygo81 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "¥¥¦¦¦\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo82 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŞşŠŤťŦŧŨŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666©©©«««ªª7¨¨55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo85 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667SSSSS99::<<;;;;;;;;;;;;;;======================"
+private yygo87 = decodeArr "Ƴƴ" "­­"
+private yygo89 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667²²55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo90 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666cc<<;;;;;;;;;;;;;;======================"
 private yygo92 = decodeArr "Á" "·"
-private yygo96 = decodeArr "ŧŨũ" "½¾¾"
-private yygo97 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666aa¿¿<<;;;;;;;;;;;;;;======================"
-private yygo98 = decodeArr "«ƧƨƩưƱ" "ÂÃÃÃÄÄ"
-private yygo100 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊËËÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo101 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ÔÔÔÔ8888899::<<;;;;;;;;;;;;;;======================"
-private yygo102 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ÕÕÕÕ8888899::<<;;;;;;;;;;;;;;======================"
+private yygo96 = decodeArr "ŵŶŷ" "½¾¾"
+private yygo97 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666aa¿¿<<;;;;;;;;;;;;;;======================"
+private yygo98 = decodeArr "«ƵƶƷƾƿ" "ÂÃÃÃÄÄ"
+private yygo100 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊËËÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo101 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ÔÔÔÔ8888899::<<;;;;;;;;;;;;;;======================"
+private yygo102 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ÕÕÕÕ8888899::<<;;;;;;;;;;;;;;======================"
 private yygo104 = decodeArr "ÁÂÃ" "ÙÚÚ"
-private yygo105 = decodeArr "ƪƫƬƭƮƯ" "ÜÜÜÝÝÝ"
-private yygo106 = decodeArr "\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ÞÞÞ~~~~\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo105 = decodeArr "ƸƹƺƻƼƽ" "ÜÜÜÝÝÝ"
+private yygo106 = decodeArr "\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĎďĘęĚĞğĠġņŇōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "ÞÞÞ~~~~\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
 private yygo109 = decodeArr "\n\u000b\f\r¬­®¯°±²" "\u0014\u0014\u0014ß\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
 private yygo113 = decodeArr "«ÁÂÃÎÏÐÑ" "\u008fæççèèèè"
-private yygo116 = decodeArr "¸¹ºþÿĀāĂ" "ÊÊÊííííí"
-private yygo117 = decodeArr "ČĐđĒē" "î\u0095\u0095\u0095\u0095"
-private yygo119 = decodeArr "¸¹ºþÿĀāĂ" "ÊÊÊððððð"
-private yygo120 = decodeArr "vwxyz{\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "òòòòòò\u008b\u008b\u008b\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo121 = decodeArr "vwxyz{\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "óóóóóó\u008b\u008b\u008b\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo122 = decodeArr "vwxyz{\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ôôôôôô\u008b\u008b\u008b\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo123 = decodeArr "Ö×ØÙÞßàá" "\u0094\u0094\u0094\u0094õõõõ"
-private yygo124 = decodeArr "µ¶·¸¹ºÁÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦ" "222333÷øø66666666667XX\\\\\\\\8888899::<<;;;;;;;;;;;;;;======================[["
-private yygo126 = decodeArr "\u0019\u001a" "ùù"
-private yygo127 = decodeArr "\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "úúúú\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo142 = decodeArr "Ľľ" "üü"
-private yygo144 = decodeArr "ÁÇÈÉÊË" "ÿĀĀĀāā"
-private yygo148 = decodeArr "\u0005\u0006\u0007\b\tÁÂÃ" "ĉĉĉĉĉĊċċ"
-private yygo149 = decodeArr "ĺĻļ" "ččč"
-private yygo150 = decodeArr "ŞşŠ" "đĐĐ"
-private yygo152 = decodeArr "³´»¼½¾¿ÀÁÂÃ" "ēēĖĖĕĕĕĕĔMM"
-private yygo155 = decodeArr "\n\u000b\f\r¬­®¯°±²" "\u0014\u0014\u0014ė\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
-private yygo161 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ęę55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo164 = decodeArr "Ľľ" "üü"
-private yygo165 = decodeArr "\u0019\u001a" "ěě"
-private yygo169 = decodeArr "\u0019\u001a" "ĠĠ"
-private yygo174 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƵƶƷ" "2223334466666666667ĢĢ55558888899::<<;;;;;;;;;;;;;;======================ģģģ"
-private yygo176 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƲƳƴ" "2223334466666666667ĤĤ55558888899::<<;;;;;;;;;;;;;;======================ĥĥĥ"
-private yygo181 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ÔÔÔÔ8888899::<<;;;;;;;;;;;;;;======================"
-private yygo182 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ÕÕÕÕ8888899::<<;;;;;;;;;;;;;;======================"
-private yygo184 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƲƳƴ" "2223334466666666667ĤĤ55558888899::<<;;;;;;;;;;;;;;======================ĩĩĩ"
-private yygo185 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŐőŒœŔŕřŚŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666ĪĪĪīīīªª7¨¨55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo186 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ĭĭ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo188 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ĮĮ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo199 = decodeArr "âãä" "ĴĴĵ"
-private yygo200 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħƥƦ" "ÊÊÊĺĹĹĹĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐļļ"
-private yygo201 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺľľľĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo209 = decodeArr "¸¹ºö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊÑÑÑÑÑÑÒÒÓÓÓÓÓŁŁ"
-private yygo215 = decodeArr "ƪƫƬƭƮƯ" "ŃŃŃÝÝÝ"
-private yygo216 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ńń55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo223 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ŏŏŏŏŏŐ"
-private yygo227 = decodeArr "+," "ŒŒ"
-private yygo229 = decodeArr "ÁÂÃ" "Ŕŕŕ"
-private yygo233 = decodeArr "üýĔĕ" "ŘŘřř"
-private yygo234 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺŚŚŚĻÑÑÑÑÑÑśśÓÓÓÓÓÐÐ"
-private yygo235 = decodeArr "ƥƦ" "ļļ"
-private yygo237 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊŜŜÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo239 = decodeArr "üýĔĕ" "ŘŘŞŞ"
-private yygo240 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊşşÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo241 = decodeArr "«ÁÂÃÎÏÐÑ" "\u008fæççèèèè"
-private yygo246 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667SSSSS99::<<;;;;;;;;;;;;;;======================"
-private yygo247 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667²²55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo248 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666cc<<;;;;;;;;;;;;;;======================"
-private yygo249 = decodeArr "\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĈĉĊċČĐđĒēĸĹĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ţţţ~~~~\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo256 = decodeArr "ÁÇÈÉÊË" "ÿĀĀĀťť"
-private yygo258 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊŦŦÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo259 = decodeArr "«ÎÏÐÑÒÓ" "\u008f\u0092\u0092\u0092\u0092ŧŧ"
-private yygo262 = decodeArr "\u0005\u0006\u0007\b\t" "ũũũũũ"
-private yygo264 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊūūŬŬŪŪÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo270 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌřŚśŜŝŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666ŲŲųųų7űű55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo271 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ŴŴ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo273 = decodeArr "ŞşŠ" "đŵŵ"
-private yygo274 = decodeArr "»¼ÂÃ" "ŷŷMM"
-private yygo281 = decodeArr "Ůů" "żż"
-private yygo282 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌōšŢţŤťŦŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666žſſſƀƀƀ7ŽŽ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo283 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "¥¥ƁƁƁ\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo285 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "¥¥ƃƃƃ\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo286 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƄƄ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo287 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƅƅ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo288 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŐőŒŖŗŘřŚŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666©©©ƆƆƆªª7¨¨55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo303 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƍƍ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo305 = decodeArr "«ƧƨƩưƱ" "ÂƎƎƎÄÄ"
-private yygo308 = decodeArr "èé" "ƑƑ"
-private yygo309 = decodeArr "âãä" "ƒƒĵ"
-private yygo319 = decodeArr "¸¹ºìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊƜƜƛÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo320 = decodeArr "¸¹ºìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊƝƝƛÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo325 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƤƤ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo327 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƧƧ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo329 = decodeArr "ƪƫƬƭƮƯ" "ƩƩƩÝÝÝ"
-private yygo332 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ƫƫƫƫƫŐ"
-private yygo333 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ƬƬƬƬƬŐ"
-private yygo334 = decodeArr "\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ƱƱƱƳƳƳƳƳƳƲƲƲƴƴƴƵƵƵƶƷƷ"
-private yygo337 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺƹƹƹĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo338 = decodeArr "-." "ƻƻ"
-private yygo343 = decodeArr "čĎďĖėĘęĚěĜĝĞğĠġĢģĤ" "ǊǊǊǋǋǌǌǌǍǍǍǍǎǎǎǏǏǏ"
-private yygo344 = decodeArr "üýĔĕ" "ŘŘǐǐ"
-private yygo347 = decodeArr "ĺĻļ" "ǓǓǓ"
-private yygo348 = decodeArr "ĺĻļ" "ǔǔǔ"
-private yygo349 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊǕǕÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo356 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "¥¥ǘǘǘ\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo360 = decodeArr "\u0005\u0006\u0007\b\t" "ǙǙǙǙǙ"
-private yygo365 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊūūǜǜŪŪÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo366 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊūūǝǝŪŪÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo367 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊūūǞǞŪŪÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo368 = decodeArr "u|}~\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ǣǥǥǥǤǤǤǧǧǧǧǦǦǦ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo371 = decodeArr "Ŏŏ" "ǫǫ"
-private yygo374 = decodeArr "»¼ÂÃ" "ǬǬMM"
-private yygo377 = decodeArr "³´»¼½¾¿ÀÁÂÃ" "ǭǭĖĖĕĕĕĕĔMM"
-private yygo380 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ǯǯ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo382 = decodeArr "ŎŏŞşŠ" "ǱǱđǰǰ"
-private yygo383 = decodeArr "Ľľ" "ǳǳ"
-private yygo386 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ǵǵ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo391 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƵƶƷ" "2223334466666666667ĢĢ55558888899::<<;;;;;;;;;;;;;;======================ǷǷǷ"
-private yygo394 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŐőŒœŔŕřŚŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666ĪĪĪǸǸǸªª7¨¨55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo401 = decodeArr "¸¹ºêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊǹǹÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo403 = decodeArr "ăĄąĆć" "ǽǽǾǾǾ"
-private yygo406 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺǿǿǿȀȀĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo407 = decodeArr "¸¹ºçîïðóôõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺȁȁȁȂȂĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo408 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺȃȃȃĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo414 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƤƤ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo416 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƧƧ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo426 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ȉȉȉȉȉŐ"
-private yygo430 = decodeArr "»¼ÂÃ" "NNMM"
-private yygo431 = decodeArr "\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ƳƳƳƳƳƳȌȌȌƴƴƴƵƵƵƶƷƷ"
-private yygo435 = decodeArr "¨©ªÁ" "ȒȒȒȑ"
-private yygo440 = decodeArr "\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ȓȓȓƳƳƳƳƳƳƲƲƲƴƴƴƵƵƵƶƷƷ"
-private yygo442 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺǿǿǿȔȔĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo443 = decodeArr "/0" "ȖȖ"
-private yygo448 = decodeArr "¸¹ºö÷øùúûüýþÿĀāĂĥĦħ" "ÊÊÊÑÑÑÑÑÑÒÒÓÓÓÓÓșȘȘ"
-private yygo449 = decodeArr "ěĜĝĞğĠġĢģĤ" "ȚȚȚȚǎǎǎǏǏǏ"
-private yygo451 = decodeArr "ğĠġĢģĤ" "țțțǏǏǏ"
-private yygo452 = decodeArr "ğĠġĢģĤ" "ȜȜȜǏǏǏ"
-private yygo453 = decodeArr "ğĠġĢģĤ" "ȝȝȝǏǏǏ"
-private yygo456 = decodeArr "ĢģĤ" "ȠȠȠ"
-private yygo457 = decodeArr "ĢģĤ" "ȡȡȡ"
-private yygo458 = decodeArr "\u0005\u0006\u0007\b\t" "ȢȢȢȢȢ"
-private yygo465 = decodeArr "čĎďĖėĘęĚěĜĝĞğĠġĢģĤ" "ȥȥȥȦȦǌǌǌǍǍǍǍǎǎǎǏǏǏ"
-private yygo466 = decodeArr "«" "ȧ"
-private yygo470 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊȨȨÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo474 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺǿǿǿȪȪĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo475 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊūūȫȫŪŪÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo479 = decodeArr "\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ȬȬȬ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo480 = decodeArr "\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ȭȭȭ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo481 = decodeArr "\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ȮȮȮ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo483 = decodeArr "u\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ǣǤǤǤǧǧǧǧȯȯȯ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo486 = decodeArr "\u0019\u001a" "ȱȱ"
-private yygo488 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌřŚśŜŝŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666ŲŲȲȲȲ7űű55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo491 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ȳȳ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo497 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ȴȴ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo498 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌōšŢţŤťŦŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "222333446666666666žſſſȵȵȵ7ŽŽ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo508 = decodeArr "ăĄąĆć" "ȶȶǾǾǾ"
-private yygo519 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƤƤ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo520 = decodeArr "µ¶·¸¹ºÂÃŃńŅņŇňŉŊŋŌŧŪūŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "2223334466666666667ƧƧ55558888899::<<;;;;;;;;;;;;;;======================"
-private yygo522 = decodeArr "¢£¤¥¦§¨©ªÁ" "ɁɁɁȿȿȿɀɀɀȑ"
-private yygo523 = decodeArr "»¼ÂÃ" "\u009e\u009eMM"
-private yygo526 = decodeArr "\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ɂɂɂƳƳƳƳƳƳƲƲƲƴƴƴƵƵƵƶƷƷ"
-private yygo535 = decodeArr "\u000e\u000f\u0010«ĨĩĪīĬĭĮįİıĲĳĴĵĶķ" "ɉɉɉɊɋɋɋɋɋɌɌɍɍɎɎɎɏɏɏɐ"
-private yygo547 = decodeArr "ĖėĘęĚěĜĝĞğĠġĢģĤ" "ɑɑǌǌǌǍǍǍǍǎǎǎǏǏǏ"
-private yygo549 = decodeArr "\u0005\u0006\u0007\b\t" "ɒɒɒɒɒ"
-private yygo551 = decodeArr "ĺĻļ" "ɓɓɓ"
-private yygo561 = decodeArr "u|}~\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĿŀŁłŃńŅņŇňŉŊŋŌŧŰűŲųŴŵŶŷŸŹźŻżſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤ" "ǣɔɔɔǤǤǤǧǧǧǧǦǦǦ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
-private yygo568 = decodeArr "ăĄąĆć" "ɖɖǾǾǾ"
-private yygo569 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺǿǿǿɗɗĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo571 = decodeArr "¸¹ºçîïðóôõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊĺȁȁȁɘɘĻÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo573 = decodeArr "¢£¤¨©ªÁ" "əəəɀɀɀȑ"
-private yygo576 = decodeArr "¨©ªÁ" "ɛɛɛȑ"
-private yygo580 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʝʝʝʝʝʝ"
-private yygo581 = decodeArr "«ĴĵĶķ" "Ɋʟʟʟɐ"
-private yygo582 = decodeArr "«ĴĵĶķ" "Ɋʠʠʠɐ"
-private yygo583 = decodeArr "«ķ" "Ɋʡ"
-private yygo584 = decodeArr "«ķ" "Ɋʢ"
-private yygo585 = decodeArr "«įİıĲĳĴĵĶķ" "ɊʣʣɎɎɎɏɏɏɐ"
-private yygo604 = decodeArr "¢£¤¥¦§¨©ªÁ" "ɁɁɁʩʩʩɀɀɀȑ"
-private yygo656 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʫʫʫʫʫʫ"
-private yygo670 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʭʭʭʭʭʭ"
-private yygo677 = decodeArr "\u000e\u000f\u0010«ĨĩĪīĬĭĮįİıĲĳĴĵĶķ" "ɉɉɉɊʯʯʯʯʯɌɌɍɍɎɎɎɏɏɏɐ"
-private yygo678 = decodeArr "\u000e\u000f\u0010«ĨĩĪīĬĭĮįİıĲĳĴĵĶķ" "ɉɉɉɊʰʰʰʰʰɌɌɍɍɎɎɎɏɏɏɐ"
-private yygo679 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊʱʱÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo680 = decodeArr "«įİıĲĳĴĵĶķ" "ɊʲʲɎɎɎɏɏɏɐ"
-private yygo682 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʳʳʳʳʳʳ"
-private yygo686 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĦħ" "ÊÊÊʵʵÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
-private yygo692 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʞʶʶʶʶʶʶ"
+private yygo115 = decodeArr "¸¹ºĈČč" "ëëëìíí"
+private yygo116 = decodeArr "¸¹ºĐĔĕĖė" "ïïïðññòò"
+private yygo117 = decodeArr "ĚĞğĠġ" "ó\u0095\u0095\u0095\u0095"
+private yygo119 = decodeArr "¸¹ºĐĔĕĖė" "ïïïðññõõ"
+private yygo120 = decodeArr "vwxyz{\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĎďĘęĚĞğĠġņŇōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "÷÷÷÷÷÷\u008b\u008b\u008b\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo121 = decodeArr "vwxyz{\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĎďĘęĚĞğĠġņŇōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "øøøøøø\u008b\u008b\u008b\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo122 = decodeArr "vwxyz{\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĎďĘęĚĞğĠġņŇōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "ùùùùùù\u008b\u008b\u008b\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo123 = decodeArr "Ö×ØÙÞßàá" "\u0094\u0094\u0094\u0094úúúú"
+private yygo124 = decodeArr "µ¶·¸¹ºÁÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴ" "222333üýý66666666667XX\\\\\\\\8888899::<<;;;;;;;;;;;;;;======================[["
+private yygo126 = decodeArr "\u0019\u001a" "þþ"
+private yygo127 = decodeArr "\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĎďĘęĚĞğĠġņŇōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "ÿÿÿÿ\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo142 = decodeArr "ŋŌ" "āā"
+private yygo144 = decodeArr "ÁÇÈÉÊË" "ĄąąąĆĆ"
+private yygo148 = decodeArr "\u0005\u0006\u0007\b\tÁÂÃ" "ĎĎĎĎĎďĐĐ"
+private yygo149 = decodeArr "ňŉŊ" "ĒĒĒ"
+private yygo150 = decodeArr "ŬŭŮ" "Ėĕĕ"
+private yygo152 = decodeArr "³´»¼½¾¿ÀÁÂÃ" "ĘĘěěĚĚĚĚęMM"
+private yygo155 = decodeArr "\n\u000b\f\r¬­®¯°±²" "\u0014\u0014\u0014Ĝ\u0015\u0015\u0015\u0015\u0015\u0015\u0015"
+private yygo161 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ĞĞ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo164 = decodeArr "ŋŌ" "āā"
+private yygo165 = decodeArr "\u0019\u001a" "ĠĠ"
+private yygo169 = decodeArr "\u0019\u001a" "ĥĥ"
+private yygo174 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲǃǄǅ" "2223334466666666667ħħ55558888899::<<;;;;;;;;;;;;;;======================ĨĨĨ"
+private yygo176 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲǀǁǂ" "2223334466666666667ĩĩ55558888899::<<;;;;;;;;;;;;;;======================ĪĪĪ"
+private yygo181 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ÔÔÔÔ8888899::<<;;;;;;;;;;;;;;======================"
+private yygo182 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ÕÕÕÕ8888899::<<;;;;;;;;;;;;;;======================"
+private yygo184 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲǀǁǂ" "2223334466666666667ĩĩ55558888899::<<;;;;;;;;;;;;;;======================ĮĮĮ"
+private yygo185 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŞşŠšŢţŧŨŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666įįįİİİªª7¨¨55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo186 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ĲĲ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo188 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ĳĳ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo199 = decodeArr "âãä" "ĹĹĺ"
+private yygo200 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĴĵƳƴ" "ÊÊÊĿľľľŀÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐŁŁ"
+private yygo201 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊĿŃŃŃŀÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo209 = decodeArr "¸¹ºö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊÑÑÑÑÑÑÒÒÓÓÓÓÓņņ"
+private yygo215 = decodeArr "ƸƹƺƻƼƽ" "ňňňÝÝÝ"
+private yygo216 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ŉŉ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo223 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ŔŔŔŔŔŕ"
+private yygo227 = decodeArr "+," "ŗŗ"
+private yygo229 = decodeArr "ÁÂÃ" "řŚŚ"
+private yygo233 = decodeArr "üýĢģ" "ŝŝŞŞ"
+private yygo234 = decodeArr "¸¹ºĈĉĊċ" "ëëëşŠŠŠ"
+private yygo235 = decodeArr "üý" "šš"
+private yygo237 = decodeArr "ňŉŊ" "ţţţ"
+private yygo238 = decodeArr "¸¹ºĐđĒē" "ïïïŤťťť"
+private yygo239 = decodeArr "¸¹ºö÷øùúûüýþÿĀāĂ" "ÊÊÊŦŦŦŦŦŦÒÒÓÓÓÓÓ"
+private yygo242 = decodeArr "ňŉŊ" "ŨŨŨ"
+private yygo244 = decodeArr "üýĢģ" "ŝŝŪŪ"
+private yygo246 = decodeArr "«ÁÂÃÎÏÐÑ" "\u008fæççèèèè"
+private yygo251 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667SSSSS99::<<;;;;;;;;;;;;;;======================"
+private yygo252 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667²²55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo253 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666cc<<;;;;;;;;;;;;;;======================"
+private yygo254 = decodeArr "\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*uvwxyz{\u007f\u0080\u0081\u008e\u008f\u0090«µ¶·¸¹ºÂÃÄÅÆÌÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáĎďĘęĚĞğĠġņŇōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "ŮŮŮ~~~~\u0081\u0081\u0081\u0081\u0080\u0080\u0080\u0080\u0086\u007f\u0082\u0082\u0082\u0082\u0082\u0082\u008b\u008b\u008b\u0084\u0084\u0084\u008f22233344\u0090\u0090\u0090\u0085\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u0088\u0088\u0089\u008a\u0083\u0095\u0095\u0095\u0095\u0087\u0087\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo261 = decodeArr "ÁÇÈÉÊË" "ĄąąąŰŰ"
+private yygo263 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊűűÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo264 = decodeArr "«ÎÏÐÑÒÓ" "\u008f\u0092\u0092\u0092\u0092ŲŲ"
+private yygo267 = decodeArr "\u0005\u0006\u0007\b\t" "ŴŴŴŴŴ"
+private yygo269 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊŶŶŷŷŵŵÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo275 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŧŨũŪūŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666ŽŽžžž7żż55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo276 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ſſ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo278 = decodeArr "ŬŭŮ" "Ėƀƀ"
+private yygo279 = decodeArr "»¼ÂÃ" "ƂƂMM"
+private yygo286 = decodeArr "żŽ" "ƇƇ"
+private yygo287 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚśůŰűŲųŴŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666ƉƊƊƊƋƋƋ7ƈƈ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo288 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "¥¥ƌƌƌ\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo290 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "¥¥ƎƎƎ\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo291 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ƏƏ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo292 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ƐƐ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo293 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŞşŠŤťŦŧŨŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666©©©ƑƑƑªª7¨¨55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo308 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ƘƘ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo310 = decodeArr "«ƵƶƷƾƿ" "ÂƙƙƙÄÄ"
+private yygo313 = decodeArr "èé" "ƜƜ"
+private yygo314 = decodeArr "âãä" "ƝƝĺ"
+private yygo324 = decodeArr "¸¹ºìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊƧƧƦÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo325 = decodeArr "¸¹ºìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊƨƨƦÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo330 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ƯƯ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo332 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ƲƲ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo334 = decodeArr "ƸƹƺƻƼƽ" "ƴƴƴÝÝÝ"
+private yygo337 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ƶƶƶƶƶŕ"
+private yygo338 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "ƷƷƷƷƷŕ"
+private yygo339 = decodeArr "\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ƼƼƼƾƾƾƾƾƾƽƽƽƿƿƿǀǀǀǁǂǂ"
+private yygo342 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊĿǄǄǄŀÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo343 = decodeArr "-." "ǆǆ"
+private yygo348 = decodeArr "ěĜĝĤĥĦħĨĩĪīĬĭĮįİıĲ" "ǕǕǕǖǖǗǗǗǘǘǘǘǙǙǙǚǚǚ"
+private yygo349 = decodeArr "üýĢģ" "ŝŝǛǛ"
+private yygo359 = decodeArr "¸¹ºþÿĀāĂ" "ÊÊÊǤǤǤǤǤ"
+private yygo361 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊǥǥÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo367 = decodeArr "\u0089\u008a\u008b\u008c\u008d«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "¥¥ǨǨǨ\u008f22233344£\u0092\u0092\u0092\u0092\u0091\u0091¤¤¤\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo371 = decodeArr "\u0005\u0006\u0007\b\t" "ǩǩǩǩǩ"
+private yygo376 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊŶŶǬǬŵŵÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo377 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊŶŶǭǭŵŵÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo378 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊŶŶǮǮŵŵÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo379 = decodeArr "u|}~\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "ǳǵǵǵǴǴǴǷǷǷǷǶǶǶ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo382 = decodeArr "Ŝŝ" "ǻǻ"
+private yygo385 = decodeArr "»¼ÂÃ" "ǼǼMM"
+private yygo388 = decodeArr "³´»¼½¾¿ÀÁÂÃ" "ǽǽěěĚĚĚĚęMM"
+private yygo391 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ǿǿ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo393 = decodeArr "ŜŝŬŭŮ" "ȁȁĖȀȀ"
+private yygo394 = decodeArr "ŋŌ" "ȃȃ"
+private yygo397 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ȅȅ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo402 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲǃǄǅ" "2223334466666666667ħħ55558888899::<<;;;;;;;;;;;;;;======================ȇȇȇ"
+private yygo405 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŞşŠšŢţŧŨŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666įįįȈȈȈªª7¨¨55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo412 = decodeArr "¸¹ºêëìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊȉȉÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo414 = decodeArr "ăĄąĆć" "ȍȍȎȎȎ"
+private yygo417 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊĿȏȏȏȐȐŀÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo418 = decodeArr "¸¹ºçîïðóôõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊĿȑȑȑȒȒŀÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo419 = decodeArr "¸¹ºçîïðõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊĿȓȓȓŀÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo425 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ƯƯ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo427 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ƲƲ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo437 = decodeArr "\u0091\u0092\u0093\u0094\u0095«" "șșșșșŕ"
+private yygo441 = decodeArr "»¼ÂÃ" "NNMM"
+private yygo442 = decodeArr "\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ƾƾƾƾƾƾȜȜȜƿƿƿǀǀǀǁǂǂ"
+private yygo446 = decodeArr "¨©ªÁ" "ȢȢȢȡ"
+private yygo451 = decodeArr "\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ȣȣȣƾƾƾƾƾƾƽƽƽƿƿƿǀǀǀǁǂǂ"
+private yygo453 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊĿȏȏȏȤȤŀÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo454 = decodeArr "/0" "ȦȦ"
+private yygo459 = decodeArr "¸¹ºö÷øùúûüýþÿĀāĂĳĴĵ" "ÊÊÊÑÑÑÑÑÑÒÒÓÓÓÓÓȩȨȨ"
+private yygo460 = decodeArr "ĩĪīĬĭĮįİıĲ" "ȪȪȪȪǙǙǙǚǚǚ"
+private yygo462 = decodeArr "ĭĮįİıĲ" "ȫȫȫǚǚǚ"
+private yygo463 = decodeArr "ĭĮįİıĲ" "ȬȬȬǚǚǚ"
+private yygo464 = decodeArr "ĭĮįİıĲ" "ȭȭȭǚǚǚ"
+private yygo467 = decodeArr "İıĲ" "ȰȰȰ"
+private yygo468 = decodeArr "İıĲ" "ȱȱȱ"
+private yygo469 = decodeArr "\u0005\u0006\u0007\b\t" "ȲȲȲȲȲ"
+private yygo476 = decodeArr "ěĜĝĤĥĦħĨĩĪīĬĭĮįİıĲ" "ȵȵȵȶȶǗǗǗǘǘǘǘǙǙǙǚǚǚ"
+private yygo477 = decodeArr "¸¹ºĈĉĊċ" "ëëëşȷȷȷ"
+private yygo479 = decodeArr "üý" "ȸȸ"
+private yygo480 = decodeArr "¸¹ºĐđĒē" "ïïïŤȹȹȹ"
+private yygo482 = decodeArr "Ƴƴ" "ŁŁ"
+private yygo484 = decodeArr "¸¹ºö÷øùúûüýþÿĀāĂ" "ÊÊÊȺȺȺȺȺȺÒÒÓÓÓÓÓ"
+private yygo486 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊȻȻÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo490 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊĿȏȏȏȽȽŀÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo491 = decodeArr "¸¹ºÚÛÜÝåæçêëìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊŶŶȾȾŵŵÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo495 = decodeArr "\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "ȿȿȿ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo496 = decodeArr "\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "ɀɀɀ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo497 = decodeArr "\u007f\u0080\u0081«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "ɁɁɁ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo499 = decodeArr "u\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "ǳǴǴǴǷǷǷǷɂɂɂ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo502 = decodeArr "\u0019\u001a" "ɄɄ"
+private yygo504 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŧŨũŪūŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666ŽŽɅɅɅ7żż55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo507 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ɆɆ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo513 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ɇɇ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo514 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚśůŰűŲųŴŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "222333446666666666ƉƊƊƊɈɈɈ7ƈƈ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo524 = decodeArr "ăĄąĆć" "ɉɉȎȎȎ"
+private yygo535 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ƯƯ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo536 = decodeArr "µ¶·¸¹ºÂÃőŒœŔŕŖŗŘřŚŵŸŹžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "2223334466666666667ƲƲ55558888899::<<;;;;;;;;;;;;;;======================"
+private yygo538 = decodeArr "¢£¤¥¦§¨©ªÁ" "ɔɔɔɒɒɒɓɓɓȡ"
+private yygo539 = decodeArr "»¼ÂÃ" "\u009e\u009eMM"
+private yygo542 = decodeArr "\u0096\u0097\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f ¡µ¶·¸¹ºÁÂÃ" "ɕɕɕƾƾƾƾƾƾƽƽƽƿƿƿǀǀǀǁǂǂ"
+private yygo551 = decodeArr "\u000e\u000f\u0010«ĶķĸĹĺĻļĽľĿŀŁłŃńŅ" "ɜɜɜɝɞɞɞɞɞɟɟɠɠɡɡɡɢɢɢɣ"
+private yygo563 = decodeArr "ĤĥĦħĨĩĪīĬĭĮįİıĲ" "ɤɤǗǗǗǘǘǘǘǙǙǙǚǚǚ"
+private yygo565 = decodeArr "\u0005\u0006\u0007\b\t" "ɥɥɥɥɥ"
+private yygo568 = decodeArr "ňŉŊ" "ɦɦɦ"
+private yygo580 = decodeArr "u|}~\u007f\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088«µ¶·¸¹ºÂÃÍÎÏÐÑÒÓÔÕÖ×ØÙÞßàáōŎŏŐőŒœŔŕŖŗŘřŚŵžſƀƁƂƃƄƅƆƇƈƉƊƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲ" "ǳɧɧɧǴǴǴǷǷǷǷǶǶǶ\u008f22233344\u008c\u0092\u0092\u0092\u0092\u0091\u0091\u008d\u008d\u0094\u0094\u0094\u0094\u0093\u0093\u0093\u0093\u008e\u008e\u008e\u009666666666667\u0097\u0097\u0097\u00978888899::<<;;;;;;;;;;;;;;======================"
+private yygo587 = decodeArr "ăĄąĆć" "ɩɩȎȎȎ"
+private yygo588 = decodeArr "¸¹ºçîïðñòõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊĿȏȏȏɪɪŀÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo590 = decodeArr "¸¹ºçîïðóôõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊĿȑȑȑɫɫŀÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo592 = decodeArr "¢£¤¨©ªÁ" "ɬɬɬɓɓɓȡ"
+private yygo595 = decodeArr "¨©ªÁ" "ɮɮɮȡ"
+private yygo599 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʰʰʰʰʰʰ"
+private yygo600 = decodeArr "«łŃńŅ" "ɝʲʲʲɣ"
+private yygo601 = decodeArr "«łŃńŅ" "ɝʳʳʳɣ"
+private yygo602 = decodeArr "«Ņ" "ɝʴ"
+private yygo603 = decodeArr "«Ņ" "ɝʵ"
+private yygo604 = decodeArr "«ĽľĿŀŁłŃńŅ" "ɝʶʶɡɡɡɢɢɢɣ"
+private yygo623 = decodeArr "¢£¤¥¦§¨©ªÁ" "ɔɔɔʼʼʼɓɓɓȡ"
+private yygo675 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʾʾʾʾʾʾ"
+private yygo689 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱˀˀˀˀˀˀ"
+private yygo696 = decodeArr "\u000e\u000f\u0010«ĶķĸĹĺĻļĽľĿŀŁłŃńŅ" "ɜɜɜɝ˂˂˂˂˂ɟɟɠɠɡɡɡɢɢɢɣ"
+private yygo697 = decodeArr "\u000e\u000f\u0010«ĶķĸĹĺĻļĽľĿŀŁłŃńŅ" "ɜɜɜɝ˃˃˃˃˃ɟɟɠɠɡɡɡɢɢɢɣ"
+private yygo698 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊ˄˄ÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo699 = decodeArr "«ĽľĿŀŁłŃńŅ" "ɝ˅˅ɡɡɡɢɢɢɣ"
+private yygo701 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱˆˆˆˆˆˆ"
+private yygo705 = decodeArr "¸¹ºåæçêëìíõö÷øùúûüýþÿĀāĂĴĵ" "ÊÊÊˈˈÌÍÍÏÏÎÑÑÑÑÑÑÒÒÓÓÓÓÓÐÐ"
+private yygo711 = decodeArr "123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrst" "ʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱʱˉˉˉˉˉˉ"
 private yygos = let 
     sub1 = [      (0, yygo0),
       (1, yygo1),
@@ -10097,6 +10345,7 @@ private yygos = let
       (106, yygo106),
       (109, yygo109),
       (113, yygo113),
+      (115, yygo115),
       (116, yygo116),
       (117, yygo117),
       (119, yygo119),
@@ -10117,9 +10366,9 @@ private yygos = let
       (161, yygo161),
       (164, yygo164),
       (165, yygo165),
-      (169, yygo169),
-      (174, yygo174)];
-    sub2 = [      (176, yygo176),
+      (169, yygo169)];
+    sub2 = [      (174, yygo174),
+      (176, yygo176),
       (181, yygo181),
       (182, yygo182),
       (184, yygo184),
@@ -10139,131 +10388,136 @@ private yygos = let
       (234, yygo234),
       (235, yygo235),
       (237, yygo237),
+      (238, yygo238),
       (239, yygo239),
-      (240, yygo240),
-      (241, yygo241),
+      (242, yygo242),
+      (244, yygo244),
       (246, yygo246),
-      (247, yygo247),
-      (248, yygo248),
-      (249, yygo249),
-      (256, yygo256),
-      (258, yygo258),
-      (259, yygo259),
-      (262, yygo262),
+      (251, yygo251),
+      (252, yygo252),
+      (253, yygo253),
+      (254, yygo254),
+      (261, yygo261),
+      (263, yygo263),
       (264, yygo264),
-      (270, yygo270),
-      (271, yygo271),
-      (273, yygo273),
-      (274, yygo274),
-      (281, yygo281),
-      (282, yygo282),
-      (283, yygo283),
-      (285, yygo285),
+      (267, yygo267),
+      (269, yygo269),
+      (275, yygo275),
+      (276, yygo276),
+      (278, yygo278),
+      (279, yygo279),
       (286, yygo286),
       (287, yygo287),
       (288, yygo288),
-      (303, yygo303),
-      (305, yygo305),
+      (290, yygo290),
+      (291, yygo291),
+      (292, yygo292),
+      (293, yygo293),
       (308, yygo308),
-      (309, yygo309),
-      (319, yygo319),
-      (320, yygo320),
+      (310, yygo310),
+      (313, yygo313),
+      (314, yygo314),
+      (324, yygo324),
       (325, yygo325),
-      (327, yygo327),
-      (329, yygo329),
+      (330, yygo330),
       (332, yygo332),
-      (333, yygo333),
       (334, yygo334),
       (337, yygo337),
       (338, yygo338),
+      (339, yygo339),
+      (342, yygo342),
       (343, yygo343),
-      (344, yygo344),
-      (347, yygo347),
       (348, yygo348),
       (349, yygo349),
-      (356, yygo356),
-      (360, yygo360)];
-    sub3 = [      (365, yygo365),
-      (366, yygo366),
-      (367, yygo367),
-      (368, yygo368),
+      (359, yygo359),
+      (361, yygo361)];
+    sub3 = [      (367, yygo367),
       (371, yygo371),
-      (374, yygo374),
+      (376, yygo376),
       (377, yygo377),
-      (380, yygo380),
+      (378, yygo378),
+      (379, yygo379),
       (382, yygo382),
-      (383, yygo383),
-      (386, yygo386),
+      (385, yygo385),
+      (388, yygo388),
       (391, yygo391),
+      (393, yygo393),
       (394, yygo394),
-      (401, yygo401),
-      (403, yygo403),
-      (406, yygo406),
-      (407, yygo407),
-      (408, yygo408),
+      (397, yygo397),
+      (402, yygo402),
+      (405, yygo405),
+      (412, yygo412),
       (414, yygo414),
-      (416, yygo416),
-      (426, yygo426),
-      (430, yygo430),
-      (431, yygo431),
-      (435, yygo435),
-      (440, yygo440),
+      (417, yygo417),
+      (418, yygo418),
+      (419, yygo419),
+      (425, yygo425),
+      (427, yygo427),
+      (437, yygo437),
+      (441, yygo441),
       (442, yygo442),
-      (443, yygo443),
-      (448, yygo448),
-      (449, yygo449),
+      (446, yygo446),
       (451, yygo451),
-      (452, yygo452),
       (453, yygo453),
-      (456, yygo456),
-      (457, yygo457),
-      (458, yygo458),
-      (465, yygo465),
-      (466, yygo466),
-      (470, yygo470),
-      (474, yygo474),
-      (475, yygo475),
+      (454, yygo454),
+      (459, yygo459),
+      (460, yygo460),
+      (462, yygo462),
+      (463, yygo463),
+      (464, yygo464),
+      (467, yygo467),
+      (468, yygo468),
+      (469, yygo469),
+      (476, yygo476),
+      (477, yygo477),
       (479, yygo479),
       (480, yygo480),
-      (481, yygo481),
-      (483, yygo483),
+      (482, yygo482),
+      (484, yygo484),
       (486, yygo486),
-      (488, yygo488),
+      (490, yygo490),
       (491, yygo491),
+      (495, yygo495),
+      (496, yygo496),
       (497, yygo497),
-      (498, yygo498),
-      (508, yygo508),
-      (519, yygo519),
-      (520, yygo520),
-      (522, yygo522),
-      (523, yygo523),
-      (526, yygo526),
+      (499, yygo499),
+      (502, yygo502),
+      (504, yygo504),
+      (507, yygo507),
+      (513, yygo513),
+      (514, yygo514),
+      (524, yygo524),
       (535, yygo535),
-      (547, yygo547),
-      (549, yygo549),
+      (536, yygo536),
+      (538, yygo538),
+      (539, yygo539),
+      (542, yygo542),
       (551, yygo551),
-      (561, yygo561),
-      (568, yygo568),
-      (569, yygo569),
-      (571, yygo571),
-      (573, yygo573)];
-    sub4 = [      (576, yygo576),
+      (563, yygo563),
+      (565, yygo565)];
+    sub4 = [      (568, yygo568),
       (580, yygo580),
-      (581, yygo581),
-      (582, yygo582),
-      (583, yygo583),
-      (584, yygo584),
-      (585, yygo585),
+      (587, yygo587),
+      (588, yygo588),
+      (590, yygo590),
+      (592, yygo592),
+      (595, yygo595),
+      (599, yygo599),
+      (600, yygo600),
+      (601, yygo601),
+      (602, yygo602),
+      (603, yygo603),
       (604, yygo604),
-      (656, yygo656),
-      (670, yygo670),
-      (677, yygo677),
-      (678, yygo678),
-      (679, yygo679),
-      (680, yygo680),
-      (682, yygo682),
-      (686, yygo686),
-      (692, yygo692)];
+      (623, yygo623),
+      (675, yygo675),
+      (689, yygo689),
+      (696, yygo696),
+      (697, yygo697),
+      (698, yygo698),
+      (699, yygo699),
+      (701, yygo701),
+      (705, yygo705),
+      (711, yygo711)];
       in sub1 `seq` sub2 `seq` sub3 `seq` sub4 `seq` genericArrayFromIndexList (sub1 ++ sub2 ++ sub3 ++ sub4);
 {-
 

--- a/frege/compiler/instances/Nicer.fr
+++ b/frege/compiler/instances/Nicer.fr
@@ -142,7 +142,7 @@ instance Nice  ExprT where
     nicer = showex true
 
 
-instance Nice (Nice q, QNameMatcher q) => PatternT q where
+instance (Nice q, QNameMatcher q) => Nice (PatternT q) where
     nice  p g = showp g false 17 p
     nicer p g = showp g true  17 p
 
@@ -180,7 +180,7 @@ private showp g nicer 1  p = showp g nicer 0 p
 private showp g nicer _  p = Prelude.error ("can't show pattern with constructor" ++ show (constructor p))
 
 
-instance Nice (Nice t, QNameMatcher t) => SigmaT t where
+instance (Nice t, QNameMatcher t) => Nice (SigmaT t) where
     nice (ForAll bndrs rho) g 
         | null bndrs = rho.nice g
         | otherwise  = fA ++ (joined " " . map fst) bndrs ++ "." ++ rho.nice g
@@ -192,7 +192,7 @@ instance Nice (Nice t, QNameMatcher t) => SigmaT t where
         where
             fA = if isOn g.options.flags USEUNICODE then "∀ " else "forall "
 
-instance Nice (Nice t, QNameMatcher t) => RhoT t where
+instance (Nice t, QNameMatcher t) => Nice (RhoT t) where
     nice (RhoFun ctx sigma rho) g
         | ForAll (_:_) _ <- sigma = nicectx ctx g ++ "(" ++ sigma.nice g ++ ") " ++ arrow ++ " " ++ rng
         | isFun sigma g           = nicectx ctx g ++ "(" ++ sigma.nice g ++ ") " ++ arrow ++ " " ++ rng
@@ -231,7 +231,7 @@ nicerctx xs g
         single (Ctx pos name tau) = nicer (TApp (TCon {pos,name}) tau) g
 
 
-instance Nice (Nice t, QNameMatcher t) => TauT t where
+instance (Nice t, QNameMatcher t) => Nice (TauT t) where
     nicer t g = showt 2 (unAlias g t) -- if isOn g.options.flags IDE then showt 2 (unAlias g t) else nice t g
         where
             arrow = if isOn g.options.flags USEUNICODE then "→" else "->"
@@ -286,7 +286,7 @@ instance Nice (Nice t, QNameMatcher t) => TauT t where
             showt _ x             = Prelude.error ("can't show type with constructor " ++ show (constructor x))
 
 
-instance Nice (Nice s, QNameMatcher s) => MetaTvT s where
+instance (Nice s, QNameMatcher s) => Nice (MetaTvT s) where
     nice (Rigid i s _) g = "t" ++ show i ++ "#" ++ s
     nice (flexi@Flexi{uid, hint, kind}) g
         | Just t <- g.bound flexi = "<" ++ t.nice g ++ ">"

--- a/frege/compiler/types/Types.fr
+++ b/frege/compiler/types/Types.fr
@@ -24,12 +24,12 @@ data MetaTvT s =
             isFlexi _         = false
 
 
-instance Eq MetaTvT s where
+instance Eq (MetaTvT s) where
     tv1 == tv2  = tv1.uid. == tv2.uid
     hashCode x = x.uid
 
 
-instance Ord MetaTvT s where
+instance Ord (MetaTvT s) where
     Flexi{} <=> Rigid{}   = Lt
     Rigid{} <=> Flexi{}   = Gt
     tv1     <=> tv2       = tv1.uid. <=> tv2.uid

--- a/frege/control/Arrow.fr
+++ b/frege/control/Arrow.fr
@@ -13,7 +13,7 @@ import frege.control.CombineIn
     Generalising Monads to Arrows, by John Hughes,
     Science of Computer Programming, pp67-111, May 2000.
 -}
-class Arrow (Category a, First a, Second a, CombineIn a) => a where
+class (Category a, First a, Second a, CombineIn a) => Arrow a where
   --- Lift a function to an arrow.
   arr :: (b -> c) -> a b c
 

--- a/frege/control/Category.fr
+++ b/frege/control/Category.fr
@@ -16,7 +16,7 @@ private type F = (->)
     _identity morphism for A_, such that for every morphism @f: A -> B@ we have
     > id(B) • f = f = f • id(A)   
 -}
-class Category (Semigroupoid f) => f where
+class (Semigroupoid f) => Category f where
     --- the identity morphism
     id :: f a a
 

--- a/frege/control/CombineIn.fr
+++ b/frege/control/CombineIn.fr
@@ -5,7 +5,7 @@ import frege.control.Semigroupoid (Semigroupoid())
 
 infixr 3 `&&&`
 
-class CombineIn (Semigroupoid f) => f where
+class (Semigroupoid f) => CombineIn f where
   {--
       Send the input to both argument semigroupoids and combine
       their output.

--- a/frege/control/First.fr
+++ b/frege/control/First.fr
@@ -3,7 +3,7 @@ package frege.control.First where
 
 import frege.control.Tensor
 
-class First (Tensor f) => f where
+class (Tensor f) => First f where
   {--
       Send the first component of the input through the argument
       tensor, and copy the rest unchanged to the output.

--- a/frege/control/Second.fr
+++ b/frege/control/Second.fr
@@ -3,7 +3,7 @@ package frege.control.Second where
 
 import frege.control.Tensor
 
-class Second (Tensor f) => f where
+class (Tensor f) => Second f where
   {--
       Send the second component of the input through the argument
       tensor, and copy the rest unchanged to the output.

--- a/frege/control/Tensor.fr
+++ b/frege/control/Tensor.fr
@@ -5,7 +5,7 @@ import frege.control.Semigroupoid (Semigroupoid())
 
 infixr 3 `***`
 
-class Tensor (Semigroupoid f) => f where
+class (Semigroupoid f) => Tensor f where
   {--
       Split the input between the two argument semigroupoids and combine
       their output.  Note that this is in general not a functor.

--- a/frege/control/arrow/Kleisli.fr
+++ b/frege/control/arrow/Kleisli.fr
@@ -8,7 +8,7 @@ import frege.control.Arrow
 
 data Kleisli m a b = Kleisli { run :: a -> m b }
 
-instance Arrow Monad m => (Kleisli m) where
+instance Monad m => Arrow (Kleisli m) where
   id = Kleisli return
 
   Kleisli f . Kleisli g = Kleisli (f <=< g)
@@ -27,8 +27,8 @@ instance Arrow Monad m => (Kleisli m) where
     where
       go a = (,) <$> f a <*> g a
 
-instance Monad Monad m => (Kleisli m a) where
-  return b = Kleisli (\_ -> return b)
+instance Monad m => Monad (Kleisli m a) where
+  pure b = Kleisli (\_ -> return b)
 
   fmap f (Kleisli k) = Kleisli (fmap f . k)
 

--- a/frege/control/monad/State.fr
+++ b/frege/control/monad/State.fr
@@ -73,7 +73,7 @@ abstract data StateT s m a = StateT { run ::  s -> m (a,s) } where
     public modify f = StateT (\s -> return ((); f s))
  
    
-instance Monad  (Monad m) => (StateT s m) where
+instance (Monad m) => Monad (StateT s m) where
     a >> b = a  >>=  (const b)
     return !a = StateT.StateT (\s -> return (a,s))
     (StateT.StateT x) >>= f = StateT.StateT (\s -> do
@@ -82,11 +82,11 @@ instance Monad  (Monad m) => (StateT s m) where
             StateT.StateT y ->  y s'     -- pass them to f
       )
 
-instance MonadPlus (MonadPlus m) => (StateT s m) where
+instance (MonadPlus m) => MonadPlus (StateT s m) where
     mzero = StateT.StateT (\s -> mzero)
     (StateT.StateT x1) `mplus` (StateT.StateT x2) = StateT.StateT (\s -> (x1 s) `mplus` (x2 s))
 
-instance MonadAlt (MonadAlt m) => (StateT s m) where
+instance (MonadAlt m) => MonadAlt (StateT s m) where
     pzero = StateT.StateT (\s -> pzero)
     (StateT.StateT x1) <|> (StateT.StateT x2) = StateT.StateT (\s -> (x1 s) <|> (x2 s))
     (StateT.StateT x1) <+> (StateT.StateT x2) = StateT.StateT (\s -> (x1 s) <+> (x2 s))
@@ -94,7 +94,7 @@ instance MonadAlt (MonadAlt m) => (StateT s m) where
 instance MonadTrans (StateT s) where
     lift c = StateT.StateT (\s -> c >>= (\x -> return (x;s)))
 
-instance MonadIO (MonadIO m) =>  (StateT s m) where
+instance (MonadIO m) =>  MonadIO (StateT s m) where
     liftIO = lift . liftIO
     
 promote st = StateT.StateT (\s -> return (State.run st s))

--- a/frege/control/monad/trans/EitherT.fr
+++ b/frege/control/monad/trans/EitherT.fr
@@ -12,12 +12,12 @@ data EitherT l m a = EitherT { run :: m (Either l a) }
 left :: Monad m => l -> EitherT l m a
 left = EitherT . return . Left
 
-instance Functor Functor f => (EitherT l) f where
+instance Functor f => Functor (EitherT l f) where
     fmap :: Functor γ => (δ -> α) -> EitherT β γ δ -> EitherT β γ α
     fmap f = EitherT . fmap (fmap f) . EitherT.run
 
-instance Monad Monad m => (EitherT l m) where
-    return = EitherT . return . Right
+instance Monad m => Monad (EitherT l m) where
+    pure = EitherT . pure . Right
     EitherT x >>= f = EitherT  do
         res <- x
         case res of
@@ -27,19 +27,19 @@ instance Monad Monad m => (EitherT l m) where
 instance MonadTrans (EitherT l) where
     lift = EitherT . liftM Right 
 
-instance MonadIO MonadIO m => EitherT l m where
+instance MonadIO m => MonadIO (EitherT l m) where
   liftIO = lift . liftIO
 
-instance MonadPlus (MonadPlus m) => EitherT l m where
+instance (MonadPlus m) => MonadPlus (EitherT l m) where
     mzero = EitherT mzero
     e1 `mplus` e2 = EitherT $ e1.run `mplus` e2.run 
 
-instance MonadAlt (MonadAlt m) => EitherT l m where
+instance (MonadAlt m) => MonadAlt (EitherT l m) where
     pzero = EitherT pzero
     e1 <|> e2 = EitherT $ e1.run <|> e2.run
     e1 <+> e2 = EitherT $ e1.run <+> e2.run
 
-instance Monoid (Monad m, Monoid a) => EitherT l m a where
+instance (Monad m, Monoid a) => Monoid (EitherT l m a) where
     mempty = pure mempty
     mappend = liftA2 mappend
   

--- a/frege/control/monad/trans/MaybeT.fr
+++ b/frege/control/monad/trans/MaybeT.fr
@@ -19,24 +19,24 @@ data MaybeT m a = MaybeT { run :: m (Maybe a) }
 mapMaybeT :: (m (Maybe a) -> n (Maybe b)) -> MaybeT m a -> MaybeT n b
 mapMaybeT f mt = MaybeT $ f $ MaybeT.run mt
 
-instance Functor Functor m => MaybeT m where
+instance Functor m => Functor (MaybeT m) where
     fmap f = mapMaybeT (fmap (fmap f))
 
-instance Alt  Monad m => MaybeT m where
+instance  Monad m => Alt (MaybeT m) where
       (<|>) = mplus
 
-instance Monad Monad m => MaybeT m where
-    return mt = lift $ return mt
+instance Monad m => Monad (MaybeT m) where
+    pure mt = lift $ pure mt
     x >>= f = MaybeT do
         v <- MaybeT.run x
         case v of
             Nothing -> return Nothing
             Just y  -> MaybeT.run (f y)
             
-instance MonadFail Monad m => MaybeT m where
+instance Monad m => MonadFail (MaybeT m) where
     fail _ = MaybeT (return Nothing)            
 
-instance MonadPlus Monad m => MaybeT m where
+instance Monad m =>  MonadPlus (MaybeT m) where
     mzero = MaybeT (return Nothing)
     mplus x y = MaybeT $ do
         v <- MaybeT.run x
@@ -47,5 +47,5 @@ instance MonadPlus Monad m => MaybeT m where
 instance MonadTrans MaybeT where
     lift mt = MaybeT (liftM Just mt)
 
-instance MonadIO MonadIO m => MaybeT m where
+instance MonadIO m => MonadIO (MaybeT m) where
     liftIO io = lift (liftIO io)

--- a/frege/control/monad/trans/MonadIO.fr
+++ b/frege/control/monad/trans/MonadIO.fr
@@ -18,7 +18,7 @@ package frege.control.monad.trans.MonadIO
 
 -}
 
-class MonadIO Monad m => m where
+class Monad m => MonadIO m where
     --- Lift a computation from the 'IO' monad.
     liftIO :: IO a -> m a
 

--- a/frege/data/Bits.fr
+++ b/frege/data/Bits.fr
@@ -80,7 +80,7 @@ instance Eq (BitSet a) where
 instance Ord (BitSet a) where
     ba <=> bb = ba.set <=> bb.set
 
-instance Show (Show a, Enum a) => BitSet a where
+instance (Show a, Enum a) => Show (BitSet a) where
     show bs = "{" ++ joined ", " members ++ "}" where
         members = map show bs.toList
 
@@ -99,7 +99,7 @@ Minimal complete definition: '.&.', '.|.', '.^.', 'complement',
 ('shift' or ('shiftL' and 'shiftR')), ('rotate' or ('rotateL' and 'rotateR')),
 'bitSize' and 'isSigned'.
 -}
-class Bits Num a => a where
+class Num a =>  Bits a where
     --- Bitwise \"and\"
     (.&.) :: a -> a -> a
 

--- a/frege/data/Compose.fr
+++ b/frege/data/Compose.fr
@@ -10,9 +10,9 @@ data Compose f g a = Compose { run :: f (g a) }
 compose :: f (g a) -> Compose f g a
 compose = Compose
 
-instance Functor (Functor f, Functor g) => (Compose f g) where
+instance (Functor f, Functor g) => Functor (Compose f g) where
   fmap f (Compose fga) = Compose (fmap (fmap f) fga)
 
-instance Applicative (Applicative f, Applicative g) => (Compose f g) where
+instance (Applicative f, Applicative g) => Applicative (Compose f g) where
   pure a = Compose (pure (pure a))
   Compose fgf <*> Compose fga = Compose ((<*>) <$> fgf <*> fga)

--- a/frege/data/Coproduct.fr
+++ b/frege/data/Coproduct.fr
@@ -3,6 +3,6 @@ package frege.data.Coproduct where
 
 data  Coproduct f g a = Inl (f a) | Inr (g a)
 
-instance Functor (Functor f, Functor g) => (Coproduct f g) where
+instance (Functor f, Functor g) => Functor (Coproduct f g) where
   fmap f (Inl fa) = Inl (fmap f fa)
   fmap f (Inr ga) = Inr (fmap f ga)

--- a/frege/data/Foldable.fr
+++ b/frege/data/Foldable.fr
@@ -37,7 +37,7 @@ import Data.Monoid
     >    foldr f z (Leaf x) = f x z
     >    foldr f z (Node l k r) = foldr f (f k (foldr f z r)) l
 -}
-class Foldable (Functor t) => t where
+class (Functor t) => Foldable t where
     -- nowarn: recurses deeply
     --- Combine the elements of a structure using a monoid.  
     fold :: Monoid m => t m -> m

--- a/frege/data/HashMap.fr
+++ b/frege/data/HashMap.fr
@@ -863,10 +863,10 @@ instance ListSource (HashMap k) where
     --- Note that this is not symmetric with 'fromList'!
     toList = values
 
-instance ListMonoid (Eq k) ⇒ HashMap k  where
+instance (Eq k) ⇒ ListMonoid (HashMap k)  where
     (++) = union
 
-instance Monoid (Eq k) ⇒ HashMap k v where
+instance (Eq k) ⇒ Monoid (HashMap k v) where
     --- The empty 'HashMap'.
     mempty ∷ Eq k ⇒ HashMap k v
     mempty  = HashMap.empty
@@ -874,25 +874,25 @@ instance Monoid (Eq k) ⇒ HashMap k v where
     mappend ∷ Eq k ⇒ HashMap k v → HashMap k v → HashMap k v
     mappend = union 
 
-instance Functor HashMap k where
+instance Functor (HashMap k) where
     fmap ∷ (v → u) → HashMap k v → HashMap k u
     fmap = mapValues
 
-instance Foldable HashMap k where
+instance Foldable (HashMap k) where
     foldl = foldValues
     foldr = foldrValues
 
-instance Traversable HashMap k where
+instance Traversable (HashMap k) where
     traverse f = traverseWithKey (const f) 
 
-instance ToJSON (ToJSON k, ToJSON v) ⇒ (HashMap k v) where
+instance (ToJSON k, ToJSON v) ⇒ ToJSON (HashMap k v) where
     toJSON node = case node  of
         HashMap.KV{hash, key, value}    → struct "KV" (hash, key, value)
         HashMap.CO{hash, list}          → struct "CO" (hash, list)
         HashMap.BM{subnodes, bitmap}    → struct "BM" (subnodes, bitmap)
 
 
-instance Eq (Eq k, Eq v) ⇒ HashMap k v where
+instance (Eq k, Eq v) ⇒ Eq (HashMap k v) where
     hm1 == hm2 = case hm1  of
         HashMap.KV{} →  case hm2  of
             HashMap.KV{} →  hm1.hash == hm2.hash
@@ -917,9 +917,9 @@ instance Eq (Eq k, Eq v) ⇒ HashMap k v where
             mkHash a b = (31*a)+b
 
 
-derive ArrayElement HashMap k v
+derive ArrayElement (HashMap k v)
 
-instance Show (ToJSON k, ToJSON v) ⇒ HashMap k v where
+instance (ToJSON k, ToJSON v) ⇒ Show (HashMap k v) where
     show hm = show (toJSON hm)
 
 -- Array primitives

--- a/frege/data/Ix.fr
+++ b/frege/data/Ix.fr
@@ -26,7 +26,7 @@ import frege.data.Tuples public()
 
     > rangeSize (l,u) == length (range (l,u))
 -}
-class Ix Ord a => a where
+class Ord a => Ix a where
 
     --- The list of values in the subrange defined by a bounding pair.
     range               :: (a,a) -> [a]
@@ -153,7 +153,7 @@ instance Ix () where
     index b i = unsafeIndex b i
 
 ----------------------------------------------------------------------
-instance Ix (Ix a, Ix b) => (a, b) where
+instance (Ix a, Ix b) => Ix (a, b) where
 
     range ((l1,l2),(u1,u2)) =
       [ (i1,i2) | i1 <- range (l1,u1), i2 <- range (l2,u2) ]
@@ -165,7 +165,7 @@ instance Ix (Ix a, Ix b) => (a, b) where
       inRange (l1,u1) i1 && inRange (l2,u2) i2
 
 ----------------------------------------------------------------------
-instance  Ix (Ix a1, Ix a2, Ix a3) => (a1,a2,a3)  where
+instance  (Ix a1, Ix a2, Ix a3) => Ix (a1,a2,a3)  where
 
     range ((l1,l2,l3),(u1,u2,u3)) =
         [(i1,i2,i3) | i1 <- range (l1,u1),
@@ -182,7 +182,7 @@ instance  Ix (Ix a1, Ix a2, Ix a3) => (a1,a2,a3)  where
       inRange (l3,u3) i3
 
 ----------------------------------------------------------------------
-instance  Ix (Ix a1, Ix a2, Ix a3, Ix a4) => (a1,a2,a3,a4)  where
+instance  (Ix a1, Ix a2, Ix a3, Ix a4) => Ix (a1,a2,a3,a4)  where
     range ((l1,l2,l3,l4),(u1,u2,u3,u4)) =
       [(i1,i2,i3,i4) | i1 <- range (l1,u1),
                        i2 <- range (l2,u2),
@@ -199,7 +199,7 @@ instance  Ix (Ix a1, Ix a2, Ix a3, Ix a4) => (a1,a2,a3,a4)  where
       inRange (l1,u1) i1 && inRange (l2,u2) i2 &&
       inRange (l3,u3) i3 && inRange (l4,u4) i4
 
-instance  Ix (Ix a1, Ix a2, Ix a3, Ix a4, Ix a5) => (a1,a2,a3,a4,a5)  where
+instance (Ix a1, Ix a2, Ix a3, Ix a4, Ix a5) => Ix (a1,a2,a3,a4,a5)  where
     range ((l1,l2,l3,l4,l5),(u1,u2,u3,u4,u5)) =
       [(i1,i2,i3,i4,i5) | i1 <- range (l1,u1),
                           i2 <- range (l2,u2),

--- a/frege/data/JSON.fr
+++ b/frege/data/JSON.fr
@@ -834,10 +834,10 @@ instance FromJSON String where
     parseJSON _             = fail ("A top level JSON value cannot be String")
 
 
-instance ToJSON ToJSON e ⇒ [e] where
+instance ToJSON e ⇒ ToJSON [e] where
     toJSON = Array . map toJSON 
 
-instance FromJSON (FromJSON e) ⇒ [e] where
+instance (FromJSON e) ⇒ FromJSON [e] where
     fromJSON (Array xs)
                                     -- goes 3 times through the list
                                     -- but avoids implicit construction
@@ -849,10 +849,10 @@ instance FromJSON (FromJSON e) ⇒ [e] where
     fromJSON other              = fail ("cannot decode [] from non array " ++ show other)
 
 
-instance ToJSON ToJSON e ⇒ JArray e  where
+instance ToJSON e ⇒ ToJSON (JArray e)  where
     toJSON = Array . map maybeToJSON . toMaybeList
 
-instance FromJSON (FromJSON e, ArrayElem e) ⇒ JArray e where
+instance (FromJSON e, ArrayElem e) ⇒ FromJSON (JArray e) where
     fromJSON list = arrayFromMaybeList <$> fromJSON list
 
 
@@ -860,7 +860,7 @@ instance FromJSON (FromJSON e, ArrayElem e) ⇒ JArray e where
 --- > {"Nothing" : null }
 --- > {"Just"    : v }
 --- For a more concise representation see 'maybeToJSON'
-instance ToJSON ToJSON e ⇒ Maybe e where
+instance ToJSON e ⇒ ToJSON (Maybe e) where
     toJSON = maybe nothingJSON (struct "Just")
 
 --- constant @{"Nothing" : null}@, used in encoding 'Maybe' values
@@ -874,7 +874,7 @@ private !nothingJSON = struct "Nothing"  Value.Null
 maybeToJSON ∷ ToJSON a ⇒ Maybe a → Value
 maybeToJSON = maybe Null toJSON
 
-instance FromJSON (FromJSON e) ⇒ Maybe e  where
+instance (FromJSON e) ⇒ FromJSON (Maybe e)  where
     {--
         Encoding can be:
         > {"Just": some-value}
@@ -889,31 +889,31 @@ instance FromJSON (FromJSON e) ⇒ Maybe e  where
     fromJSON v                          = Just <$> fromJSON v
 
 
-instance ToJSON (ToJSON a, ToJSON b) ⇒ (a|b)  where
+instance (ToJSON a, ToJSON b) ⇒ ToJSON (a|b)  where
     toJSON = either (struct "Left") (struct "Right")
 
 
-instance FromJSON (FromJSON a, FromJSON b) ⇒ (a|b)  where
+instance  (FromJSON a, FromJSON b) ⇒ FromJSON (a|b)  where
     fromJSON (Struct m)
         | Just v <-  lookup "Left"   m  = Left  <$> fromJSON v
         | Just v <-  lookup "Right"  m  = Right <$> fromJSON v
     fromJSON other                      = fail ("cannot decode Either from " ++ show other)
 
 
-instance ToJSON (ToJSON a, ToJSON b) ⇒ (a, b)  where
+instance  (ToJSON a, ToJSON b) ⇒ ToJSON (a, b)  where
     toJSON (a,b) = Array [toJSON a, toJSON b]
 
-instance FromJSON (FromJSON a, FromJSON b) ⇒  (a, b) where
+instance (FromJSON a, FromJSON b) ⇒ FromJSON  (a, b) where
     fromJSON (Array [va, vb]) = do
         a ← fromJSON va
         b ← fromJSON vb
         return (a,b)
     fromJSON other      = fail ("cannot decode (a,b) from " ++ show other)
 
-instance ToJSON (ToJSON a, ToJSON b, ToJSON c) ⇒  (a, b, c) where
+instance  (ToJSON a, ToJSON b, ToJSON c) ⇒ ToJSON (a, b, c) where
     toJSON (a,b,c) = Array [toJSON a, toJSON b, toJSON c]
 
-instance FromJSON (FromJSON a, FromJSON b, FromJSON c) ⇒  (a, b, c) where
+instance  (FromJSON a, FromJSON b, FromJSON c) ⇒ FromJSON (a, b, c) where
     fromJSON (Array [va, vb, vc]) = do
         a ← fromJSON va
         b ← fromJSON vb
@@ -922,13 +922,13 @@ instance FromJSON (FromJSON a, FromJSON b, FromJSON c) ⇒  (a, b, c) where
     fromJSON other      = fail ("cannot decode (a,b,c) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
-                    ToJSON d) ⇒  (a, b, c, d) where
+instance   (ToJSON a, ToJSON b, ToJSON c,
+                    ToJSON d) ⇒ ToJSON (a, b, c, d) where
     toJSON (a,b,c,d) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
-                    FromJSON d) ⇒  (a, b, c, d) where
+instance   (FromJSON a, FromJSON b, FromJSON c,
+                    FromJSON d) ⇒ FromJSON (a, b, c, d) where
     fromJSON (Array [va, vb, vc, vd]) = do
         a ← fromJSON va
         b ← fromJSON vb
@@ -938,14 +938,14 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
-                    ToJSON d, ToJSON e) ⇒  (a, b, c, d, e) where
+instance   (ToJSON a, ToJSON b, ToJSON c,
+                    ToJSON d, ToJSON e) ⇒ ToJSON (a, b, c, d, e) where
     toJSON (a,b,c,d,e) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
-                    FromJSON d, FromJSON e) ⇒  (a, b, c, d, e) where
+instance   (FromJSON a, FromJSON b, FromJSON c,
+                    FromJSON d, FromJSON e) ⇒ FromJSON (a, b, c, d, e) where
     fromJSON (Array [va, vb, vc, vd, ve]) = do
         a ← fromJSON va
         b ← fromJSON vb
@@ -956,14 +956,14 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
-                    ToJSON d, ToJSON e, ToJSON f) ⇒  (a, b, c, d, e, f) where
+instance   (ToJSON a, ToJSON b, ToJSON c,
+                    ToJSON d, ToJSON e, ToJSON f) ⇒ ToJSON (a, b, c, d, e, f) where
     toJSON (a,b,c,d,e,f) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
-                    FromJSON d, FromJSON e, FromJSON f) ⇒  (a, b, c, d, e, f) where
+instance   (FromJSON a, FromJSON b, FromJSON c,
+                    FromJSON d, FromJSON e, FromJSON f) ⇒ FromJSON (a, b, c, d, e, f) where
     fromJSON (Array [va, vb, vc, vd, ve, vf]) = do
         a ← fromJSON va
         b ← fromJSON vb
@@ -975,16 +975,16 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance   (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
-                    ToJSON g) ⇒  (a, b, c, d, e, f, g) where
+                    ToJSON g) ⇒  ToJSON (a, b, c, d, e, f, g) where
     toJSON (a,b,c,d,e,f,g) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance   (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
-                    FromJSON g) ⇒  (a, b, c, d, e, f, g) where
+                    FromJSON g) ⇒ FromJSON (a, b, c, d, e, f, g) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg]) = do
         a ← fromJSON va
         b ← fromJSON vb
@@ -997,16 +997,16 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance   (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
-                    ToJSON g, ToJSON h) ⇒  (a, b, c, d, e, f, g, h) where
+                    ToJSON g, ToJSON h) ⇒ ToJSON (a, b, c, d, e, f, g, h) where
     toJSON (a,b,c,d,e,f,g,h) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance   (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
-                    FromJSON g, FromJSON h) ⇒  (a, b, c, d, e, f, g, h) where
+                    FromJSON g, FromJSON h) ⇒ FromJSON  (a, b, c, d, e, f, g, h) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh]) = do
         a ← fromJSON va
         b ← fromJSON vb
@@ -1020,17 +1020,17 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance  (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
-                    ToJSON g, ToJSON h, ToJSON i) ⇒  (a, b, c, d, e, f, g, h, i) where
+                    ToJSON g, ToJSON h, ToJSON i) ⇒ ToJSON  (a, b, c, d, e, f, g, h, i) where
     toJSON (a,b,c,d,e,f,g,h,i) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
                             toJSON i]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
-                    FromJSON g, FromJSON h, FromJSON i) ⇒  (a, b, c, d, e, f, g, h, i) where
+                    FromJSON g, FromJSON h, FromJSON i) ⇒ FromJSON  (a, b, c, d, e, f, g, h, i) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi]) = do
         a ← fromJSON va
         b ← fromJSON vb
@@ -1045,19 +1045,19 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
-                    ToJSON j) ⇒  (a, b, c, d, e, f, g, h, i, j) where
+                    ToJSON j) ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j) where
     toJSON (a,b,c,d,e,f,g,h,i,j) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
                             toJSON i, toJSON j]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
-                    FromJSON j) ⇒  (a, b, c, d, e, f, g, h, i, j) where
+                    FromJSON j) ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj]) = do
         a ← fromJSON va
@@ -1074,19 +1074,19 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
-                    ToJSON j, ToJSON k) ⇒  (a, b, c, d, e, f, g, h, i, j, k) where
+                    ToJSON j, ToJSON k) ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
                             toJSON i, toJSON j, toJSON k]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
-                    FromJSON j, FromJSON k) ⇒  (a, b, c, d, e, f, g, h, i, j, k) where
+                    FromJSON j, FromJSON k) ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk]) = do
         a ← fromJSON va
@@ -1104,21 +1104,21 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l) where
+                    ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k, l) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
                             toJSON i, toJSON j, toJSON k, toJSON l]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l) where
+                    ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k, l) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl]) = do
         a ← fromJSON va
@@ -1137,24 +1137,24 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
                     ToJSON m)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m) where
+                    ⇒  ToJSON (a, b, c, d, e, f, g, h, i, j, k, l, m) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
                             toJSON i, toJSON j, toJSON k, toJSON l,
                             toJSON m]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
                     FromJSON m)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m) where
+                    ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm]) = do
         a ← fromJSON va
@@ -1174,24 +1174,24 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l,m) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
                     ToJSON m, ToJSON n)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n) where
+                    ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m,n) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
                             toJSON i, toJSON j, toJSON k, toJSON l,
                             toJSON m, toJSON n]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
                     FromJSON m, FromJSON n)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n) where
+                    ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm, vn]) = do
         a ← fromJSON va
@@ -1212,24 +1212,24 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l,m,n) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
                     ToJSON m, ToJSON n, ToJSON o)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) where
+                    ⇒  ToJSON (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
                             toJSON i, toJSON j, toJSON k, toJSON l,
                             toJSON m, toJSON n, toJSON o]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
                     FromJSON m, FromJSON n, FromJSON o)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) where
+                    ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm, vn, vo]) = do
         a ← fromJSON va
@@ -1251,26 +1251,26 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
                     ToJSON m, ToJSON n, ToJSON o,
                     ToJSON p)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) where
+                    ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
                             toJSON i, toJSON j, toJSON k, toJSON l,
                             toJSON m, toJSON n, toJSON o, toJSON p]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
                     FromJSON m, FromJSON n, FromJSON o,
                     FromJSON p)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) where
+                    ⇒  FromJSON (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm, vn, vo, vp]) = do
         a ← fromJSON va
@@ -1293,13 +1293,13 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
                     ToJSON m, ToJSON n, ToJSON o,
                     ToJSON p, ToJSON q)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) where
+                    ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
@@ -1307,13 +1307,13 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                             toJSON m, toJSON n, toJSON o, toJSON p,
                             toJSON q]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
                     FromJSON m, FromJSON n, FromJSON o,
                     FromJSON p, FromJSON q)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) where
+                    ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm, vn, vo, vp, vq]) = do
         a ← fromJSON va
@@ -1337,13 +1337,13 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
                     ToJSON m, ToJSON n, ToJSON o,
                     ToJSON p, ToJSON q, ToJSON r)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) where
+                    ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
@@ -1351,13 +1351,13 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                             toJSON m, toJSON n, toJSON o, toJSON p,
                             toJSON q, toJSON r]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
                     FromJSON m, FromJSON n, FromJSON o,
                     FromJSON p, FromJSON q, FromJSON r)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) where
+                    ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm, vn, vo, vp, vq, vr]) = do
         a ← fromJSON va
@@ -1382,14 +1382,14 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
                     ToJSON m, ToJSON n, ToJSON o,
                     ToJSON p, ToJSON q, ToJSON r,
                     ToJSON s)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) where
+                    ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
@@ -1397,14 +1397,14 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                             toJSON m, toJSON n, toJSON o, toJSON p,
                             toJSON q, toJSON r, toJSON s]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
                     FromJSON m, FromJSON n, FromJSON o,
                     FromJSON p, FromJSON q, FromJSON r,
                     FromJSON s)
-                    ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) where
+                    ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm, vn, vo, vp, vq, vr, 
                                              vs]) = do
@@ -1431,14 +1431,14 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
                     ToJSON m, ToJSON n, ToJSON o,
                     ToJSON p, ToJSON q, ToJSON r,
                     ToJSON s, ToJSON t)
-                ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) where
+                ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
@@ -1446,14 +1446,14 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                             toJSON m, toJSON n, toJSON o, toJSON p,
                             toJSON q, toJSON r, toJSON s, toJSON t]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
                     FromJSON m, FromJSON n, FromJSON o,
                     FromJSON p, FromJSON q, FromJSON r,
                     FromJSON s, FromJSON t)
-                ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) where
+                ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm, vn, vo, vp, vq, vr, 
                                              vs, vt]) = do
@@ -1481,14 +1481,14 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
                     ToJSON m, ToJSON n, ToJSON o,
                     ToJSON p, ToJSON q, ToJSON r,
                     ToJSON s, ToJSON t, ToJSON u)
-                ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) where
+                ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
@@ -1497,14 +1497,14 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                             toJSON q, toJSON r, toJSON s, toJSON t,
                             toJSON u]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
                     FromJSON m, FromJSON n, FromJSON o,
                     FromJSON p, FromJSON q, FromJSON r,
                     FromJSON s, FromJSON t, FromJSON u)
-                ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) where
+                ⇒ FromJSON (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm, vn, vo, vp, vq, vr, 
                                              vs, vt, vu]) = do
@@ -1533,7 +1533,7 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
@@ -1541,7 +1541,7 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON p, ToJSON q, ToJSON r,
                     ToJSON s, ToJSON t, ToJSON u,
                     ToJSON v)
-            ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) where
+            ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
@@ -1550,7 +1550,7 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                             toJSON q, toJSON r, toJSON s, toJSON t,
                             toJSON u, toJSON v]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
@@ -1558,7 +1558,7 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON p, FromJSON q, FromJSON r,
                     FromJSON s, FromJSON t, FromJSON u,
                     FromJSON v)
-            ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) where
+            ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm, vn, vo, vp, vq, vr, 
                                              vs, vt, vu, vv]) = do
@@ -1588,7 +1588,7 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
@@ -1596,7 +1596,7 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON p, ToJSON q, ToJSON r,
                     ToJSON s, ToJSON t, ToJSON u,
                     ToJSON v, ToJSON w)
-            ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w) where
+            ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
@@ -1605,7 +1605,7 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                             toJSON q, toJSON r, toJSON s, toJSON t,
                             toJSON u, toJSON v, toJSON w]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
@@ -1613,7 +1613,7 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON p, FromJSON q, FromJSON r,
                     FromJSON s, FromJSON t, FromJSON u,
                     FromJSON v, FromJSON w)
-            ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w) where
+            ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm, vn, vo, vp, vq, vr, 
                                              vs, vt, vu, vv, vw]) = do
@@ -1644,7 +1644,7 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
@@ -1652,7 +1652,7 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON p, ToJSON q, ToJSON r,
                     ToJSON s, ToJSON t, ToJSON u,
                     ToJSON v, ToJSON w, ToJSON x)
-            ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x) where
+            ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
@@ -1661,7 +1661,7 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                             toJSON q, toJSON r, toJSON s, toJSON t,
                             toJSON u, toJSON v, toJSON w, toJSON x]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
@@ -1669,7 +1669,7 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON p, FromJSON q, FromJSON r,
                     FromJSON s, FromJSON t, FromJSON u,
                     FromJSON v, FromJSON w, FromJSON x)
-            ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x) where
+            ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm, vn, vo, vp, vq, vr, 
                                              vs, vt, vu, vv, vw, vx]) = do
@@ -1701,7 +1701,7 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
@@ -1710,7 +1710,7 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON s, ToJSON t, ToJSON u,
                     ToJSON v, ToJSON w, ToJSON x,
                     ToJSON y)
-            ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y) where
+            ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
@@ -1720,7 +1720,7 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                             toJSON u, toJSON v, toJSON w, toJSON x,
                             toJSON y]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
@@ -1729,7 +1729,7 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON s, FromJSON t, FromJSON u,
                     FromJSON v, FromJSON w, FromJSON x,
                     FromJSON y)
-            ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y) where
+            ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm, vn, vo, vp, vq, vr, 
                                              vs, vt, vu, vv, vw, vx, vy]) = do
@@ -1762,7 +1762,7 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
     fromJSON other      = fail ("cannot decode (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y) from " ++ show other)
 
 
-instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
+instance (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON d, ToJSON e, ToJSON f,
                     ToJSON g, ToJSON h, ToJSON i,
                     ToJSON j, ToJSON k, ToJSON l,
@@ -1771,7 +1771,7 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                     ToJSON s, ToJSON t, ToJSON u,
                     ToJSON v, ToJSON w, ToJSON x,
                     ToJSON y, ToJSON z)
-            ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z) where
+            ⇒ ToJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z) where
     toJSON (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z) = Array [
                             toJSON a, toJSON b, toJSON c, toJSON d,
                             toJSON e, toJSON f, toJSON g, toJSON h,
@@ -1781,7 +1781,7 @@ instance ToJSON  (ToJSON a, ToJSON b, ToJSON c,
                             toJSON u, toJSON v, toJSON w, toJSON x,
                             toJSON y, toJSON z]
 
-instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
+instance  (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON d, FromJSON e, FromJSON f,
                     FromJSON g, FromJSON h, FromJSON i,
                     FromJSON j, FromJSON k, FromJSON l,
@@ -1790,7 +1790,7 @@ instance FromJSON  (FromJSON a, FromJSON b, FromJSON c,
                     FromJSON s, FromJSON t, FromJSON u,
                     FromJSON v, FromJSON w, FromJSON x,
                     FromJSON y, FromJSON z)
-            ⇒  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z) where
+            ⇒ FromJSON  (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z) where
     fromJSON (Array [va, vb, vc, vd, ve, vf, vg, vh, vi, 
                                              vj, vk, vl, vm, vn, vo, vp, vq, vr, 
                                              vs, vt, vu, vv, vw, vx, vy, vz]) = do

--- a/frege/data/MicroParsec.fr
+++ b/frege/data/MicroParsec.fr
@@ -54,7 +54,7 @@ runid p = Parser.run p
 --- run a Parser, return just the result/error
 parse p  = fmap fst . Parser.run p 
 
-instance MonadAlt  Parser s t where
+instance MonadAlt  (Parser s t) where
     --- generic failure
     pzero    = Parser.P (\pos -> (Left "parse failed", pos)) 
     --- generic success

--- a/frege/data/Monoid.fr
+++ b/frege/data/Monoid.fr
@@ -20,7 +20,7 @@ class Semigroup this where
              | n `rem` 2 == 0 = stimes (n `quot` 2) $ mappend x x
              | otherwise = mappend x $ stimes (n `quot` 2) $ mappend x x 
   
-class Monoid Semigroup this => this where
+class Semigroup this => Monoid this where
   mempty :: this 
   
   mconcat :: [this] -> this
@@ -48,7 +48,7 @@ instance Monoid () where
 
 -- Maybe ---------------------------------------------------------------------
 
-instance Monoid Semigroup a => Maybe a where
+instance Semigroup a => Monoid (Maybe a) where
   mempty = Nothing
   Nothing `mappend` b = b
   a `mappend` Nothing = a
@@ -56,11 +56,11 @@ instance Monoid Semigroup a => Maybe a where
 -- First ---------------------------------------------------------------------- 
 
 data First a = First { getFirst :: Maybe a }
-derive Show First a
-derive Eq First a
-derive Ord First a
+derive Show (First a)
+derive Eq (First a)
+derive Ord (First a)
 
-instance Monoid First a where
+instance Monoid (First a) where
   mempty = First Nothing
   First Nothing `mappend` y = y
   x `mappend` _ = x
@@ -68,11 +68,11 @@ instance Monoid First a where
 -- Last ----------------------------------------------------------------------- 
 
 data Last a = Last { getLast :: Maybe a }
-derive Show Last a
-derive Eq Last a
-derive Ord Last a
+derive Show (Last a)
+derive Eq (Last a)
+derive Ord (Last a)
 
-instance Monoid Last a where
+instance Monoid (Last a) where
   mempty = Last Nothing
   x `mappend` Last Nothing = x 
   _ `mappend` y = y
@@ -93,7 +93,7 @@ instance Monoid (a->a) where
 
 -- IO -------------------------------------------------------------------------
 
-instance Monoid Monoid a => IO a where
+instance Monoid a => Monoid (IO a) where
   mempty = return mempty 
   mappend = liftM2 mappend
 {- 

--- a/frege/data/NonEmpty.fr
+++ b/frege/data/NonEmpty.fr
@@ -18,8 +18,8 @@ protected data NonEmpty a = NonEmpty {
   neTail :: [a] --- The tail of the non-empty list.
 }
 
-derive Eq NonEmpty a
-derive Ord NonEmpty a
+derive Eq   (NonEmpty a)
+derive Ord  (NonEmpty a)
 
 infixr 6 `|:` `.:`
 
@@ -48,12 +48,12 @@ instance Foldable NonEmpty where
 instance Traversable NonEmpty where
   traverse f ne = fmap unsafeToNonEmpty $ traverse f $ toList ne
 
-instance Show Show a => NonEmpty a where
+instance Show a => Show (NonEmpty a) where
   show (NonEmpty h t) = fold1 ["|",show h, showT t, "|"] where
      showT [] = ""
      showT (x:xs) = "," ++ show x ++ showT xs 
 
-instance Semigroup NonEmpty a where
+instance Semigroup (NonEmpty a) where
   mappend xs ys = xs ++ ys
 
 --- Constructs a non-empty list with the given head and tail.

--- a/frege/data/Product.fr
+++ b/frege/data/Product.fr
@@ -5,7 +5,7 @@ import frege.Prelude hiding(product)
 
 data Product f g a = Prod (f a) (g a)
 
-instance Functor (Functor f, Functor g) => (Product f g) where
+instance (Functor f, Functor g) => Functor (Product f g) where
   fmap f (Prod fa ga) =  Prod (fmap f fa) (fmap f ga)
 
 --- view a tuple as 'Product'

--- a/frege/data/Stream.fr
+++ b/frege/data/Stream.fr
@@ -21,14 +21,14 @@ class to compare two equal streams, these functions will diverge.
 
 data Stream a = Cons a (Stream a) 
 
-derive Eq Stream a
-derive Ord Stream a
+derive Eq   (Stream a)
+derive Ord  (Stream a)
 
 infixr 13 `Cons` `<:>`  -- same precedence as (:)
 
 instance Monad Stream where
     fmap f (Cons x xs) = Cons (f x) (fmap f xs)
-    return x = repeat x
+    pure x = repeat x
     f <*> y = zipWith ($) f y
     xs >>= f = join (fmap f xs)
     join (Cons xs xss) = head xs <:> join (map tail xss)
@@ -38,7 +38,7 @@ instance Monad Stream where
     Note that 'show' returns an infinite 'String'.
     Hence you can't use this function on old fashioned computers with finite memory.
 -}
-instance Show Show a => Stream a where
+instance Show a => Show (Stream a) where
   -- dg: I'm not really sure if this makes sense...
   -- iw: Not really. Perhaps the expr undefined would deliver the result a bit faster?
   --     Judging from the perspective of a REPL user, perhaps the best would be
@@ -81,10 +81,10 @@ instance ListView Stream where
         | n <= 0 = cons
         | otherwise = take (n-1) xs
 
-instance Semigroup Semigroup a => Stream a where
+instance Semigroup a => Semigroup (Stream a) where
    xs `mappend` ys = zipWith Semigroup.mappend xs ys
    
-instance Monoid Monoid a => Stream a where
+instance Monoid a => Monoid (Stream a) where
    mempty = repeat Monoid.mempty   
 
 {-- 

--- a/frege/data/Traversable.fr
+++ b/frege/data/Traversable.fr
@@ -26,7 +26,7 @@ import frege.data.wrapper.Const
     They are included for Haskell compatibility only. In Haskell the specialized 
     functions are needed as Haskell monads are no Applicatives.      
    -}
-class Traversable (Foldable t) => t where
+class (Foldable t) => Traversable t where
     {-- Map each element of a structure to an action, evaluate
         these actions from left to right, and collect the results.
      -}

--- a/frege/data/Tree.fr
+++ b/frege/data/Tree.fr
@@ -23,8 +23,8 @@ data Tree a   = Node {
         rootLabel :: a,         --- label value
         subForest :: Forest a   --- zero or more child trees
     }
-derive Eq Tree a
-derive Show Tree a
+derive Eq (Tree a)
+derive Show (Tree a)
 type Forest a = [Tree a]
 
 instance Functor Tree where

--- a/frege/data/TreeMap.fr
+++ b/frege/data/TreeMap.fr
@@ -799,21 +799,21 @@ data TreeMap k v =
 --- 'TreeMap' can be used as array element
 derive ArrayElement (TreeMap a b)
 
-derive Show  TreeMap k v
+derive Show  (TreeMap k v)
 
 instance ListEmpty (TreeMap a) where
     null TreeMap.Nil = true
     null _ = false
     empty = TreeMap.Nil
 
-instance Monoid Ord a => TreeMap a b where
+instance Ord a => Monoid (TreeMap a b) where
     mempty = TreeMap.Nil
     mappend = union
 
-instance Functor TreeMap a where
+instance Functor (TreeMap a) where
     fmap = TreeMap.mapV
 
-instance Traversable TreeMap k where
+instance Traversable (TreeMap k) where
     {--
         _O(n)_ 
 

--- a/frege/data/Tuples.fr
+++ b/frege/data/Tuples.fr
@@ -26,75 +26,75 @@ derive Show (a, b, c, d, e, f, g);
 
 
 
-instance Semigroup (Semigroup a, Semigroup b) => (a, b) where
+instance (Semigroup a, Semigroup b) => Semigroup (a, b) where
   (a, b) `mappend` (a', b') = (a <> a', b <> b')
-instance Monoid (Monoid a, Monoid b) => (a, b) where
+instance (Monoid a, Monoid b) => Monoid (a, b) where
   mempty = (mempty, mempty) 
 
-instance Semigroup (Semigroup a, Semigroup b, Semigroup c) => (a, b, c) where
+instance (Semigroup a, Semigroup b, Semigroup c) => Semigroup (a, b, c) where
   (a, b, c) `mappend` (a', b', c') = (a <> a', b <> b', c <> c')
-instance Monoid (Monoid a, Monoid b, Monoid c) => (a, b, c) where
+instance (Monoid a, Monoid b, Monoid c) => Monoid (a, b, c) where
   mempty = (mempty, mempty, mempty) 
 
-instance Semigroup (Semigroup a, Semigroup b, Semigroup c, Semigroup d) => (a, b, c, d) where
+instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d) => Semigroup (a, b, c, d) where
   (a, b, c, d) `mappend` (a', b', c', d') = (a <> a', b <> b', c <> c', d <> d')
-instance Monoid (Monoid a, Monoid b, Monoid c, Monoid d) => (a, b, c, d) where
+instance (Monoid a, Monoid b, Monoid c, Monoid d) => Monoid (a, b, c, d) where
   mempty = (mempty, mempty, mempty, mempty) 
   
-instance Semigroup (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e) => (a, b, c, d, e) where
+instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e) => Semigroup (a, b, c, d, e) where
   (a, b, c, d, e) `mappend` (a', b', c', d', e') = (a <> a', b <> b', c <> c', d <> d', e <> e')
-instance Monoid (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e) => (a, b, c, d, e) where
+instance (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e) => Monoid (a, b, c, d, e) where
   mempty = (mempty, mempty, mempty, mempty, mempty)  
   
-instance Semigroup (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e, Semigroup f) => (a, b, c, d, e, f) where
+instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e, Semigroup f) => Semigroup (a, b, c, d, e, f) where
   (a, b, c, d, e, f) `mappend` (a', b', c', d', e', f') = (a <> a', b <> b', c <> c', d <> d', e <> e', f <> f')
-instance Monoid (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e, Monoid f) => (a, b, c, d, e, f) where
+instance (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e, Monoid f) => Monoid (a, b, c, d, e, f) where
   mempty = (mempty, mempty, mempty, mempty, mempty, mempty)     
   
-instance Semigroup (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e, Semigroup f, Semigroup g) => (a, b, c, d, e, f, g) where
+instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e, Semigroup f, Semigroup g) => Semigroup (a, b, c, d, e, f, g) where
   (a, b, c, d, e, f, g) `mappend` (a', b', c', d', e', f', g') = (a <> a', b <> b', c <> c', d <> d', e <> e', f <> f', g <> g')
-instance Monoid (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e, Monoid f, Monoid g) => (a, b, c, d, e, f, g) where
+instance (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e, Monoid f, Monoid g) => Monoid (a, b, c, d, e, f, g) where
   mempty = (mempty, mempty, mempty, mempty, mempty, mempty, mempty)  
   
 
 
-instance Functor (,,,) a b c where
+instance Functor ((,,,) a b c) where
   fmap fn (a, b, c, x) = (a, b, c, fn x)
-instance Functor (,,,,) a b c d where
+instance Functor ((,,,,) a b c d) where
   fmap fn (a, b, c, d, x) = (a, b, c, d, fn x)  
-instance Functor (,,,,,) a b c d e where
+instance Functor ((,,,,,) a b c d e) where
   fmap fn (a, b, c, d, e, x) = (a, b, c, d, e, fn x)  
-instance Functor (,,,,,,) a b c d e f where
+instance Functor ((,,,,,,) a b c d e f) where
   fmap fn (a, b, c, d, e, f, x) = (a, b, c, d, e, f, fn x)  
   
   
 
-instance Monad (Monoid a) => (,) a where
+instance (Monoid a) => Monad ((,) a) where
   return x = (mempty, x)
   (a, fn) <*> (a', x) = (a <> a', fn x)
   (a, x) >>= fn = let (a', y) = fn x in (a <> a', y)
   
-instance Monad (Monoid a, Monoid b) => (,,) a b where
+instance (Monoid a, Monoid b) => Monad ((,,) a b) where
   return x = (mempty, mempty, x)
   (a, b, fn) <*> (a', b', x) = (a <> a', b <> b', fn x)
   (a, b, x) >>= fn = let (a', b', y) = fn x in (a <> a', b <> b', y)
   
-instance Monad (Monoid a, Monoid b, Monoid c) => (,,,) a b c where
+instance (Monoid a, Monoid b, Monoid c) => Monad ((,,,) a b c) where
   return x = (mempty, mempty, mempty, x)
   (a, b, c, fn) <*> (a', b', c', x) = (a <> a', b <> b', c <> c', fn x)
   (a, b, c, x) >>= fn = let (a', b', c', y) = fn x in (a <> a', b <> b', c <> c', y)       
 
-instance Monad (Monoid a, Monoid b, Monoid c, Monoid d) => (,,,,) a b c d where
+instance (Monoid a, Monoid b, Monoid c, Monoid d) => Monad ((,,,,) a b c d) where
   return x = (mempty, mempty, mempty, mempty, x)
   (a, b, c, d, fn) <*> (a', b', c', d', x) = (a <> a', b <> b', c <> c', d <> d', fn x)
   (a, b, c, d, x) >>= fn = let (a', b', c', d', y) = fn x in (a <> a', b <> b', c <> c', d <> d', y)       
   
-instance Monad (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e) => (,,,,,) a b c d e where
+instance (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e) => Monad ((,,,,,) a b c d e) where
   return x = (mempty, mempty, mempty, mempty, mempty, x)
   (a, b, c, d, e, fn) <*> (a', b', c', d', e', x) = (a <> a', b <> b', c <> c', d <> d', e <> e', fn x)
   (a, b, c, d, e, x) >>= fn = let (a', b', c', d', e', y) = fn x in (a <> a', b <> b', c <> c', d <> d', e <> e', y)       
   
-instance Monad (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e, Monoid f) => (,,,,,,) a b c d e f where
+instance (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e, Monoid f) => Monad ((,,,,,,) a b c d e f) where
   return x = (mempty, mempty, mempty, mempty, mempty, mempty, x)
   (a, b, c, d, e, f, fn) <*> (a', b', c', d', e', f', x) = (a <> a', b <> b', c <> c', d <> d', e <> e', f <> f', fn x)
   (a, b, c, d, e, f, x) >>= fn = let (a', b', c', d', e', f', y) = fn x in (a <> a', b <> b', c <> c', d <> d', e <> e', f <> f', y)

--- a/frege/data/wrapper/Const.fr
+++ b/frege/data/wrapper/Const.fr
@@ -9,6 +9,6 @@ data Const a b = Const { get :: a }
 instance Functor (Const m) where
     fmap _ (Const v) = Const v
 
-instance Applicative Monoid m => Const m where
+instance Monoid m => Applicative (Const m) where
     pure _ = Const mempty
     Const f <*> Const v = Const (f `mappend` v)

--- a/frege/data/wrapper/Dual.fr
+++ b/frege/data/wrapper/Dual.fr
@@ -5,18 +5,18 @@ import Data.Monoid
 
 --- Provides a 'Monoid' where 'mappend' appears flipped.
 data Dual a = Dual { unwrap :: a } --- wrap a value to give a 'Dual'
-derive Show Dual a
-derive Eq Dual a
-derive Ord Dual a
+derive Show (Dual a)
+derive Eq (Dual a)
+derive Ord (Dual a)
 
 --- get the value wrapped by 'Dual' (Haskell compatibility)
 getDual = Dual.unwrap
 
-instance Semigroup Semigroup a => Dual a where
+instance Semigroup a => Semigroup  (Dual a) where
     --- > Dual "foo" <> Dual "bar" == Dual "barfoo"
     Dual x `mappend` Dual y = Dual (mappend y x)
 
-instance Monoid Monoid a => Dual a where
+instance Monoid a => Monoid (Dual a) where
     --- @Dual e@ where @e@ is the idendity of the wrapped value.
     mempty = Dual mempty
 

--- a/frege/data/wrapper/Endo.fr
+++ b/frege/data/wrapper/Endo.fr
@@ -11,7 +11,7 @@ appEndo = Endo.unwrap
 {-- 
     The 'Monoid' instance for 'Endo' has functions as objects, 
     uses '•' as operation and the identity is 'id'. -}
-instance Monoid Endo a where
+instance Monoid (Endo a) where
     --- > Endo f <> Endo g = Endo (f . g)
     Endo f `mappend` Endo g = Endo (f • g)
     --- > Endo id

--- a/frege/data/wrapper/Identity.fr
+++ b/frege/data/wrapper/Identity.fr
@@ -35,14 +35,14 @@ data Identity a = Identity { run :: a }
 
 derive Eq (Identity a)
 derive Ord (Identity a)
-instance Enum (Enum a) => Identity a where
+instance (Enum a) => Enum (Identity a) where
     succ = fmap succ
     from = Identity . from
     ord  = ord . Identity.run
     pred = fmap pred
     enumFromThenTo (Identity a) (Identity b) (Identity c) = map Identity $ enumFromThenTo a b c
     enumFromThen   (Identity a) (Identity b) = map Identity $ enumFromThen a b
-instance Show (Show a) => Identity a where
+instance (Show a) => Show (Identity a) where
     display     = display   . Identity.run
     showChars   = showChars . Identity.run
     show        = show      . Identity.run
@@ -55,10 +55,10 @@ instance Monad Identity where
     fmap f (Identity m) = Identity (f m)
 
 
-instance Semigroup Semigroup a => Identity a where
+instance Semigroup a => Semigroup (Identity a) where
    Identity x `mappend` Identity y = Identity (x `mappend` y)
 
-instance Monoid Monoid a => Identity a where
+instance Monoid a => Monoid (Identity a) where
    mempty = Identity mempty 
    
 instance ListSource Identity where

--- a/frege/data/wrapper/Num.fr
+++ b/frege/data/wrapper/Num.fr
@@ -7,21 +7,21 @@ import Data.Monoid
     'Monoid' wrapper for numbers with operation '*' and identity 1
 -}
 data Product a = Product { unwrap :: a } --- wrap a number
-derive Show Product a
-derive Eq Product a
-derive Ord Product a
+derive Show (Product a)
+derive Eq   (Product a)
+derive Ord  (Product a)
 
 --- Haskell compatibility: get the value wrapped by 'Product'
 getProduct = Product.unwrap
 
 
 --- The 'Semigroup' instance for 'Product' uses operation '*'
-instance Semigroup Num a => Product a where
+instance Num a => Semigroup (Product a) where
     --- > Product 3 <> Product 7 == Product 21@
     Product x `mappend` Product y = Product (x * y)
 
 --- The 'Monoid' instance for 'Product' has identity @1@
-instance Monoid Num a => Product a where
+instance Num a => Monoid (Product a) where
     --- > Product 1@
     mempty = Product one
 
@@ -30,21 +30,21 @@ instance Monoid Num a => Product a where
     'Monoid' wrapper for numbers with operation '+' and identity 0
 -}   
 data Sum a = Sum { unwrap :: a }    --- wrap a number
-derive Show Sum a
-derive Eq Sum a
-derive Ord Sum a
+derive Show (Sum a)
+derive Eq   (Sum a)
+derive Ord  (Sum a)
 
 --- Haskell compatibility: get the value wrapped by 'Sum'
 getSum = Sum.unwrap
 
 
 --- The 'Semigroup' instance for 'Sum' uses operation '+'
-instance Semigroup Num a => Sum a where
+instance Num a => Semigroup (Sum a) where
     --- > Sum 19 <> Sum 23 == Sum 42
     Sum x `mappend` Sum y = Sum (x + y)
   
 --- The 'Monoid' instance for 'Sum' has identity @0@
-instance Monoid Num a => Sum a where
+instance Num a => Monoid (Sum a) where
     --- > Sum 0
     mempty = Sum zero
 

--- a/frege/data/wrapper/Ord.fr
+++ b/frege/data/wrapper/Ord.fr
@@ -5,26 +5,26 @@ import Data.Monoid
 
   
 data Min a = Min { unwrap :: a }
-derive Show Min a
-derive Eq Min a
-derive Ord Min a
+derive Show (Min a)
+derive Eq   (Min a)
+derive Ord  (Min a)
 
 getMin = Min.unwrap
 
-instance Monoid (Ord a, Bounded a) => Min a where
+instance (Ord a, Bounded a) => Monoid (Min a) where
   mempty = Min maxBound
-instance Semigroup Ord a => Min a where
+instance Ord a => Semigroup (Min a) where
   Min a `mappend` Min b = Min (a `min` b)
     
   
 data Max a = Max { unwrap :: a }
-derive Show Max a
-derive Eq Max a
-derive Ord Max a
+derive Show (Max a)
+derive Eq   (Max a)
+derive Ord  (Max a)
 
 getMax = Max.unwrap
 
-instance Monoid (Ord a, Bounded a) => Max a where
+instance (Ord a, Bounded a) => Monoid (Max a) where
   mempty = Max minBound
-instance Semigroup Ord a => Max a where
+instance Ord a => Semigroup (Max a) where
   Max a `mappend` Max b = Max (a `max` b)

--- a/frege/data/wrapper/ZipList.fr
+++ b/frege/data/wrapper/ZipList.fr
@@ -29,10 +29,10 @@ instance ListView ZipList where
     length (ZipList xs) = length xs
     take n (ZipList xs) = ZipList (take n xs)
    
-instance Semigroup ZipList a where
+instance Semigroup (ZipList a) where
     mappend xs ys = xs ++ ys
 
-instance Monoid ZipList a where
+instance Monoid (ZipList a) where
     mempty = ZipList []
     
 instance F.Foldable ZipList where

--- a/frege/prelude/Math.fr
+++ b/frege/prelude/Math.fr
@@ -31,7 +31,7 @@ infixr 15  `**`
 sqr :: Num a => a -> a
 sqr x = x * x
 
-class  Floating Real r ⇒ r where
+class  Real r ⇒ Floating r where
 
     --- The value that is closer than any other to @pi@, the ratio of the circumference of a circle to its diameter.
     pi                  ∷ r

--- a/frege/prelude/Maybe.fr
+++ b/frege/prelude/Maybe.fr
@@ -85,8 +85,8 @@ instance ListEmpty Maybe where
     null _       = false
 
 
-derive Eq   Maybe a
-derive Ord  Maybe a
+derive Eq   (Maybe a)
+derive Ord  (Maybe a)
 -- derive Show Maybe a is in Text
 
 --- @true@ if and only if the argument is a 'Just' value

--- a/frege/prelude/PreludeArrays.fr
+++ b/frege/prelude/PreludeArrays.fr
@@ -282,7 +282,7 @@ instance ListSource JArray where
     toList :: JArray a -> [a]
     toList !ra = mapMaybe ra.itemAt [0..ra.length-1] 
 
-instance Eq (Eq a) ⇒ JArray a where
+instance (Eq a) ⇒ Eq (JArray a) where
     a == b
         | a.length == b.length = go (a.length-1)
         | otherwise = false
@@ -370,7 +370,7 @@ arrayCache f n = (JArray.cache f n >>= readonly id).run
     Note that 'JArray' cannot be an instance of 'ArrayElem' itself,
     because it has no fixed @java.lang.Class@ instance.
 -}
-class ArrayElem JavaType a => a where
+class JavaType a => ArrayElem a where
     --- Create a one dimensional array with elements of the instantiated type.
     native newArray "new[]"   :: Int -> ST s (ArrayOf s a)
     -- newArray :: Int -> ST s (ArrayOf s a)
@@ -407,7 +407,7 @@ class ArrayElem JavaType a => a where
     does not support passing 'Nothing', because there can be no
     @null@ in primitive arrays.
 -}
-class PrimitiveArrayElement ArrayElem a => a where
+class ArrayElem a => PrimitiveArrayElement a where
     --- Default implementation suitable for primitive types.
     --- It is an error to put 'Nothing' in a primitive array.
     setAt arr inx = setElemAt arr inx . maybe (error "cannot have null in primitive arrays") id
@@ -420,7 +420,7 @@ class PrimitiveArrayElement ArrayElem a => a where
 
 --- 'ArrayElement' is the class one derives for array elements.
 --- In addition to the base class 'ArrayElem' it also supports mutable array elements.
-class ArrayElement ArrayElem a => a where
+class ArrayElem a => ArrayElement a where
     --- Create an array of mutable items. 
     --- Such an array may never be immutable itself. 
     newArrayM  :: Int -> ST s (ArrayOf s (Mutable s a))

--- a/frege/prelude/PreludeBase.fr
+++ b/frege/prelude/PreludeBase.fr
@@ -1058,7 +1058,7 @@ data Ordering = Lt | Eq | Gt
   all elements of the type are themselves instances of 'Ord' and when the type is
   an instance of 'Eq'.
  -}
-class Ord Eq ord => ord where
+class Eq ord => Ord ord where
     {-- This operator must be defined in all instances. It compares its operands and
         returns 'Lt' if the first is lower than the second, 'Gt' if the first is
         greater than the second and 'Ordering.Eq' otherwise.
@@ -1130,7 +1130,7 @@ class Ord Eq ord => ord where
  > [a,b .. c]
  > [a,b ..]
  -}
-class Enum Ord e => e where
+class Ord e => Enum e where
     {-- @ord e@ returns the ordinal number associated with the value @e@. For
      * enumeration types, 'ord' is the same as 'constructor', for 'Int', it is the
      * identity function.
@@ -1192,7 +1192,7 @@ instance Eq () where
 {-- The 'Num' class provides the operators ('+'), ('-') and ('*') as well as
     some functions that are common for all numeric types.
     -}
-class Num Ord n => n where
+class Ord n => Num n where
     --- Computes the sum of two numbers
     (+) :: n -> n -> n
     --- Computes the difference of two numbers
@@ -1260,7 +1260,7 @@ class Num Ord n => n where
 {--
  * The 'Real' class provides the division operator ('/').
  -}
-class Real Num r => r where
+class Num r => Real r where
     --- the division operator
     (/) :: r -> r -> r
     --- convert a 'Double' to any 'Real' value
@@ -1326,7 +1326,7 @@ instance Integral Integer where
 toInteger = Integral.big
 
 --- Class 'Integral' provides division and remainder operations for integral numbers.
-class Integral Num integ => integ where
+class Num integ => Integral integ where
     --- integer division
     div, quot :: integ -> integ -> integ
     --- Haskell compatibility
@@ -1809,7 +1809,7 @@ instance Real Double where
 
 -- derive Show Ordering
 
-instance Eq Eq a => [a] where
+instance Eq a => Eq [a] where
     --- two lists are equal if their heads and tails are equal or if the lists are empty
     (a:as) == (b:bs) | a == b = as == bs 
                      | otherwise = false

--- a/frege/prelude/PreludeIO.fr
+++ b/frege/prelude/PreludeIO.fr
@@ -87,7 +87,7 @@ class JavaType e where
     This is derivable for @pure@ @native@ data types.
     -}                                
     
-class Exceptional  JavaType e => e 
+class JavaType e => Exceptional e 
 
 derive Exceptional Undefined
 derive Exceptional NoMatch
@@ -355,7 +355,7 @@ class Freezable f where
  * contains references to mutable objects. In such cases, sort of a deep cloning
  * would be required.
  -}
-class Cloneable (Freezable f) => f  where
+class (Freezable f) => Cloneable f  where
     {--
      *  @clone v@ must be a native method that works like @java.lang.Object#clone@.
      -}
@@ -374,7 +374,7 @@ class Cloneable (Freezable f) => f  where
  * which serializes its argument to a byte array and creates a new copy by
  * deserializing it from the byte array.
  -}
-class Serializable (Freezable f) => f  where
+class (Freezable f) =>  Serializable f  where
     {--
      *  @copySerializable v@ is supposed to be a native function that is
      *  implemented by @frege.runtime.Runtime.copySerializable@ at the instantiated type.

--- a/frege/prelude/PreludeList.fr
+++ b/frege/prelude/PreludeList.fr
@@ -89,7 +89,7 @@ class ListEmpty α where
     empty :: α β
 
 --- A class for types that support the (++) operator.
-class ListMonoid (ListEmpty α, ListSemigroup α)  => α
+class (ListEmpty α, ListSemigroup α)  => ListMonoid  α
 
 --- A class for types that support 'concat'
 class ListSemigroup α where
@@ -107,7 +107,7 @@ class ListSemigroup α where
     This class provides no means to construct a list. 
 
 -}
-class ListView (ListEmpty α, ListSource α) => α  where
+class (ListEmpty α, ListSource α) =>  ListView α  where
     --- converts a list-view to a list
     --  toList :: α β -> [β] -- definition from ListSource
     toList xs
@@ -248,7 +248,7 @@ instance ListSource Maybe where
     toList (Just a) = [a]
     toList Nothing  = []
 
-instance ListSource Either α where
+instance ListSource (Either α) where
     --- Singleton with element from 'Right' or empty list for 'Left'
     toList (Left _)  = []
     toList (Right a) = [a]

--- a/frege/prelude/PreludeMonad.fr
+++ b/frege/prelude/PreludeMonad.fr
@@ -94,7 +94,7 @@ class Functor f where
     --- Map a function over a 'Functor'
     fmap :: (a -> b) -> f a -> f b
 
-class Apply (Functor f) => f where
+class (Functor f) => Apply f where
     (<*>) :: f (a -> b) -> f a -> f b
 
 --- An infix synonym for 'fmap'. Left associative with precedence 4.
@@ -141,7 +141,7 @@ class Apply (Functor f) => f where
     
     Minimal complete definition: 'pure' and '<*>'.
     -}
-class Applicative  (Apply p) => p where
+class (Apply p) =>  Applicative p where
     
     --- Lift a value
     pure   :: a -> p a    
@@ -179,17 +179,17 @@ liftA4 f a b c d = f <$> a <*> b <*> c <*> d
 liftA5 :: Applicative f => (a -> b -> c -> d -> e -> g) -> f a -> f b -> f c -> f d -> f e -> f g
 liftA5 f a b c d e = f <$> a <*> b <*> c <*> d <*> e
 
-class Bind (Apply f) => f where
+class (Apply f) => Bind f where
     --- Sequentially compose two actions, passing any value produced by the first as an argument to the second.
     (>>=) :: f a -> (a -> f b) -> f b
 
-class Alt (Functor f) => f where
+class (Functor f) => Alt f where
     (<|>) :: f a -> f a -> f a
 
-class Plus (Alt f) => f where
+class (Alt f) => Plus f where
     pzero :: f a
 
-class MonadAlt (Plus f, Monad f) => f where
+class (Plus f, Monad f) => MonadAlt f where
     (<+>) :: f a -> f a -> f a
 
 {--
@@ -219,7 +219,7 @@ class MonadAlt (Plus f, Monad f) => f where
     Minimal complete definition: '>>=' and ('pure' or 'return')
     
     -}
-class Monad (Applicative m, Bind m) => m where
+class (Applicative m, Bind m) => Monad m where
     {--
         Sequentially compose two actions, discarding any value produced by the first, 
         this works like sequencing operators (such as the semicolon) in imperative languages.
@@ -247,7 +247,7 @@ class Monad (Applicative m, Bind m) => m where
     The 'MonadFail' class augments 'Monad' by adding the 'fail' operation.
     This operation is not part of the mathematical definition of a monad.
     -}   
-class MonadFail (Monad m) => m where  
+class (Monad m) => MonadFail m where  
 
     --- Fail with a message. 
     fail   :: String -> m a
@@ -257,7 +257,7 @@ class MonadFail (Monad m) => m where
 {--
     A 'Monad' with a left identity.
     -}
-class MonadZero (Monad mz) => mz where
+class (Monad mz) => MonadZero mz where
     --- This value should satisfy _left zero_: 
     --- > mzero >>= f = mzero
     mzero :: mz a
@@ -270,11 +270,11 @@ class MonadZero (Monad mz) => mz where
     > (a `mplus` b) `mplus` c = a `mplus` (b `mplus` c)
     > (a `mplus` b) >>= f = (a >>= f) `mplus` (b >>= f)
     -} 
-class MonadPlus (MonadZero mp) => mp where
+class (MonadZero mp) => MonadPlus mp where
     --- an associative operation
     mplus :: mp a -> mp a -> mp a
  
-class MonadOr (MonadZero mo) => mo where
+class (MonadZero mo) => MonadOr mo where
     -- Should satisfy 'monoid':
     --   zero `orElse` b = b;  b `orElse` zero = b
     --   (a `orElse` b) `orElse` c = a `orElse` (b `orElse` c)
@@ -488,10 +488,10 @@ instance MonadFail (ST s) where
 -- Tuples    
 -- for higher arities and Monad instances see frege.data.Tuples  
   
-instance Functor (,) a where
+instance Functor ((,) a) where
   fmap fn (a, x) = (a, fn x)
   
-instance Functor (,,) a b where
+instance Functor ((,,) a b) where
   fmap fn (a, b, x) = (a, b, fn x)
 
 instance Applicative ((->) a) where

--- a/frege/prelude/PreludeText.fr
+++ b/frege/prelude/PreludeText.fr
@@ -140,7 +140,7 @@ instance Show String where
     pure native show frege.runtime.Runtime.quoteStr :: String -> String
     display s = s
 
-instance Show  Show a => [a] where
+instance Show a => Show  [a] where
     show lst = showList lst ""     --  "[" ++ joined ", " (map Show.show lst) ++ "]"
     -- showsub = show
     -- display = show
@@ -161,8 +161,8 @@ derive Show     ()
 derive Show     (a,b)
 derive Show     (a,b,c)
 derive Show     Ordering
-derive Show     Maybe a
-derive Show     Either a b
+derive Show     (Maybe a)
+derive Show     (Either a b)
 instance Show Regex where
     show r = r.pattern
 

--- a/frege/test/QuickCheckArbitrary.fr
+++ b/frege/test/QuickCheckArbitrary.fr
@@ -108,7 +108,7 @@ class Arbitrary a where
 
 -- instances
 
-instance Arbitrary (CoArbitrary a, Arbitrary b) => (a -> b) where
+instance (CoArbitrary a, Arbitrary b) => Arbitrary (a -> b) where
   arbitrary = promote (`coarbitrary` arbitrary)
 
 instance Arbitrary () where
@@ -127,19 +127,19 @@ instance Arbitrary Ordering where
   shrink LT = [EQ]
   shrink EQ = []
 
-instance Arbitrary  Arbitrary a => (Maybe a) where
+instance Arbitrary a => Arbitrary (Maybe a) where
   arbitrary = frequency [(1, return Nothing), (3, liftM Just arbitrary)]
 
   shrink (Just x) = Nothing : [ Just x' | x' <- shrink x ]
   shrink _        = []
 
-instance Arbitrary  (Arbitrary a, Arbitrary b) =>  (Either a b) where
+instance  (Arbitrary a, Arbitrary b) =>  Arbitrary (Either a b) where
   arbitrary = oneof [liftM Left arbitrary, liftM Right arbitrary]
 
   shrink (Left x)  = [ Left  x' | x' <- shrink x ]
   shrink (Right y) = [ Right y' | y' <- shrink y ]
 
-instance Arbitrary  Arbitrary a => [a] where
+instance  Arbitrary a => Arbitrary [a] where
   arbitrary = sized gen
     where
         gen n = do  
@@ -148,16 +148,16 @@ instance Arbitrary  Arbitrary a => [a] where
 
   shrink xs = shrinkList shrink xs
 
-instance Arbitrary (ArrayElem a, Arbitrary a) ⇒ JArray a where
+instance (ArrayElem a, Arbitrary a) ⇒ Arbitrary (JArray a) where
     arbitrary = arrayFromMaybeList <$> arbitrary
 
 
-instance CoArbitrary (Ord k, CoArbitrary k, CoArbitrary v) => (TreeMap k v) where
+instance (Ord k, CoArbitrary k, CoArbitrary v) => CoArbitrary (TreeMap k v) where
     coarbitrary TreeMap.Nil = variant 0
     coarbitrary (TreeMap.Leaf k v) = variant 1 . coarbitrary k . coarbitrary v 
     coarbitrary (TreeMap.Node _ l r k v) 
         = variant 2 . l.coarbitrary . r.coarbitrary . k.coarbitrary . v.coarbitrary
-instance Arbitrary (Ord k, Arbitrary k, Arbitrary v) => (TreeMap k v) where 
+instance (Ord k, Arbitrary k, Arbitrary v) => Arbitrary (TreeMap k v) where 
     arbitrary :: (Ord k, Arbitrary k, Arbitrary v) => Gen (TreeMap k v)
     arbitrary   =  TM.fromList <$> arbitrary
 
@@ -207,16 +207,16 @@ shrinkList shr xs = concat [ removes k n xs | k <- takeWhile (>0) (iterate (`div
 --     arbitrary = arbitrarySizedFractional
 --     shrink    = shrinkRealFrac
 
-instance Arbitrary  (Arbitrary a, Arbitrary b)
-      => (a,b)
+instance  (Arbitrary a, Arbitrary b)
+      => Arbitrary (a,b)
  where
   arbitrary = liftM2 (,) arbitrary arbitrary
 
   shrink (x,y) = [ (x',y) | x' <- shrink x ]
               ++ [ (x,y') | y' <- shrink y ]
 
-instance Arbitrary  (Arbitrary a, Arbitrary b, Arbitrary c)
-      => (a,b,c)
+instance  (Arbitrary a, Arbitrary b, Arbitrary c)
+      => Arbitrary (a,b,c)
  where
   arbitrary = liftM3 (,,) arbitrary arbitrary arbitrary
 
@@ -224,8 +224,8 @@ instance Arbitrary  (Arbitrary a, Arbitrary b, Arbitrary c)
                 ++ [ (x,y',z) | y' <- shrink y ]
                 ++ [ (x,y,z') | z' <- shrink z ]
 
-instance Arbitrary (Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d)
-      => (a,b,c,d)
+instance  (Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d)
+      => Arbitrary (a,b,c,d)
  where
   arbitrary = liftM4 (,,,) arbitrary arbitrary arbitrary arbitrary
 
@@ -234,8 +234,8 @@ instance Arbitrary (Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d)
                   ++ [ (w,x,y',z) | y' <- shrink y ]
                   ++ [ (w,x,y,z') | z' <- shrink z ]
 
-instance Arbitrary  (Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d, Arbitrary e)
-      => (a,b,c,d,e)
+instance  (Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d, Arbitrary e)
+      => Arbitrary (a,b,c,d,e)
  where
   arbitrary = liftM5 (,,,,) arbitrary arbitrary arbitrary arbitrary arbitrary
 
@@ -460,7 +460,7 @@ infixr 1 `><`
 -- for the sake of non-GHC compilers, I have added definitions
 -- for coarbitrary here.
 
-instance CoArbitrary  (Arbitrary a, CoArbitrary b) =>  (a -> b) where
+instance  (Arbitrary a, CoArbitrary b) =>  CoArbitrary (a -> b) where
   coarbitrary f gen =
     do xs <- arbitrary
        coarbitrary (map f xs) gen
@@ -477,15 +477,15 @@ instance CoArbitrary Ordering where
   coarbitrary EQ = variant 0
   coarbitrary LT = variant (-1)
 
-instance CoArbitrary CoArbitrary a => (Maybe a) where
+instance CoArbitrary a => CoArbitrary (Maybe a) where
   coarbitrary Nothing  = variant 0
   coarbitrary (Just x) = variant (-1) . coarbitrary x
 
-instance CoArbitrary (CoArbitrary a, CoArbitrary b) => (Either a b) where
+instance (CoArbitrary a, CoArbitrary b) => CoArbitrary (Either a b) where
   coarbitrary (Left x)  = variant 0    . coarbitrary x
   coarbitrary (Right y) = variant (-1) . coarbitrary y
 
-instance CoArbitrary CoArbitrary a =>  [a] where
+instance CoArbitrary a => CoArbitrary  [a] where
   coarbitrary []     = variant 0
   coarbitrary (x:xs) = variant (-1) . coarbitrary (x,xs)
 
@@ -502,29 +502,29 @@ instance CoArbitrary String where
 -- instance CoArbitrary  (RealFloat a, CoArbitrary a) => (Complex a) where
 --   coarbitrary (x :+ y) = coarbitrary x >< coarbitrary y
 
-instance CoArbitrary (CoArbitrary a, CoArbitrary b)
-      => (a,b)
+instance  (CoArbitrary a, CoArbitrary b)
+      => CoArbitrary (a,b)
  where
   coarbitrary (x,y) = coarbitrary x
                    >< coarbitrary y
 
-instance CoArbitrary (CoArbitrary a, CoArbitrary b, CoArbitrary c)
-      => (a,b,c)
+instance (CoArbitrary a, CoArbitrary b, CoArbitrary c)
+      => CoArbitrary (a,b,c)
  where
   coarbitrary (x,y,z) = coarbitrary x
                      >< (coarbitrary y
                      >< coarbitrary z)
 
-instance CoArbitrary (CoArbitrary a, CoArbitrary b, CoArbitrary c, CoArbitrary d)
-      => (a,b,c,d)
+instance  (CoArbitrary a, CoArbitrary b, CoArbitrary c, CoArbitrary d)
+      => CoArbitrary (a,b,c,d)
  where
   coarbitrary (x,y,z,v) = coarbitrary x
                        >< coarbitrary y
                        >< coarbitrary z
                        >< coarbitrary v
 
-instance CoArbitrary (CoArbitrary a, CoArbitrary b, CoArbitrary c, CoArbitrary d, CoArbitrary e)
-      => (a,b,c,d,e)
+instance (CoArbitrary a, CoArbitrary b, CoArbitrary c, CoArbitrary d, CoArbitrary e)
+      => CoArbitrary (a,b,c,d,e)
  where
   coarbitrary (x,y,z,v,w) = coarbitrary x
                          >< coarbitrary y

--- a/frege/test/QuickCheckModifiers.fr
+++ b/frege/test/QuickCheckModifiers.fr
@@ -55,8 +55,8 @@ import Data.List
 -- ------------------------------------------------------------------------
 --- @Blind x@: as x, but x does not have to be in the 'Show' class.
 data Blind a = Blind a
-derive Eq   Blind a
-derive Ord  Blind a
+derive Eq   (Blind a)
+derive Ord  (Blind a)
 
 -- #ifndef NO_NEWTYPE_DERIVING
 --           , Num, Integral, Real, Enum
@@ -66,7 +66,7 @@ derive Ord  Blind a
 instance Show (Blind a) where
   show _ = "(*)"
 
-instance Arbitrary Arbitrary a => Blind a where
+instance Arbitrary a => Arbitrary (Blind a) where
   arbitrary = Blind `fmap` arbitrary
 
   shrink (Blind x) = [ Blind x' | x' <- shrink x ]
@@ -74,27 +74,23 @@ instance Arbitrary Arbitrary a => Blind a where
 -- ------------------------------------------------------------------------
 --- @Fixed x@: as x, but will not be shrunk.
 data Fixed a = Fixed a
-derive Eq   Fixed a
-derive Ord  Fixed a
-derive Show Fixed a
---  deriving ( Eq, Ord, Show, Read
--- #ifndef NO_NEWTYPE_DERIVING
---           , Num, Integral, Real, Enum
--- #endif
+derive Eq   (Fixed a)
+derive Ord  (Fixed a)
+derive Show (Fixed a)
 
-instance Arbitrary  Arbitrary a => (Fixed a) where
+instance Arbitrary a => Arbitrary (Fixed a) where
   arbitrary = Fixed `fmap` arbitrary
 
   -- no shrink function
 
--- ------------------------------------------------------------------------
--- | @Ordered xs@: guarantees that xs is ordered.
+
+--- @Ordered xs@: guarantees that xs is ordered.
 data OrderedList a = Ordered {getOrdered :: [a]}
 derive Eq   (OrderedList a)
 derive Ord  (OrderedList a)
 derive Show (OrderedList a)
 
-instance Arbitrary (Ord a, Arbitrary a) =>  (OrderedList a) where
+instance (Ord a, Arbitrary a) =>  Arbitrary (OrderedList a) where
   arbitrary = Ordered `fmap` orderedList
 
   shrink (Ordered xs) =
@@ -106,11 +102,11 @@ instance Arbitrary (Ord a, Arbitrary a) =>  (OrderedList a) where
 -- ------------------------------------------------------------------------
 ---  @NonEmpty xs@: guarantees that xs is non-empty.
 data NonEmptyList a = NonEmpty {getNonEmpty :: [a]}
-derive Eq   NonEmptyList a
-derive Ord  NonEmptyList a
-derive Show NonEmptyList a
+derive Eq   (NonEmptyList a)
+derive Ord  (NonEmptyList a)
+derive Show (NonEmptyList a)
 
-instance Arbitrary Arbitrary a => (NonEmptyList a) where
+instance Arbitrary a => Arbitrary (NonEmptyList a) where
   arbitrary = NonEmpty `fmap` (arbitrary `suchThat` (not . null))
 
   shrink (NonEmpty xs) =
@@ -122,15 +118,11 @@ instance Arbitrary Arbitrary a => (NonEmptyList a) where
 -- ------------------------------------------------------------------------
 --- @Positive x@: guarantees that @x > 0@.
 data Positive a = Positive {getPositive :: a}
-derive  Eq  Positive a
-derive  Ord Positive a
-derive  Show Positive a
---  deriving ( Eq, Ord, Show, Read
--- #ifndef NO_NEWTYPE_DERIVING
---           , Num, Integral, Real, Enum
--- #endif
+derive  Eq   (Positive a)
+derive  Ord  (Positive a)
+derive  Show (Positive a)
           
-instance Arbitrary (Num a, Ord a, Arbitrary a) => (Positive a) where
+instance (Num a, Ord a, Arbitrary a) => Arbitrary (Positive a) where
   arbitrary =
     ((Positive . abs) `fmap` (arbitrary `suchThat` (!= 0))) `suchThat` gt0
     where gt0 (Positive x) = x > fromInt 0
@@ -141,38 +133,28 @@ instance Arbitrary (Num a, Ord a, Arbitrary a) => (Positive a) where
     , x' > fromInt 0
     ]
 
--- ------------------------------------------------------------------------
+
 --- @NonZero x@: guarantees that @x != 0@.
 data NonZero a = NonZero {getNonZero :: a}
 
-derive  Eq  NonZero a
-derive  Ord NonZero a
-derive  Show  NonZero a
---  deriving ( Eq, Ord, Show, Read
--- #ifndef NO_NEWTYPE_DERIVING
---           , Num, Integral, Real, Enum
--- #endif
-          
+derive  Eq      (NonZero a)
+derive  Ord     (NonZero a)
+derive  Show    (NonZero a)
 
-instance Arbitrary (Num a, Ord a, Arbitrary a) => (NonZero a) where
+instance (Num a, Ord a, Arbitrary a) => Arbitrary (NonZero a) where
   arbitrary = fmap NonZero $ arbitrary `suchThat` (!= 0)
 
   shrink (NonZero x) = [ NonZero x' | x' <- shrink x, x' != fromInt 0 ]
 
--- ------------------------------------------------------------------------
+
 --- @NonNegative x@: guarantees that @x >= 0@.
 data NonNegative a = NonNegative {getNonNegative :: a}
 
-derive Eq   NonNegative a
-derive Ord  NonNegative a
-derive Show   NonNegative a
---  deriving ( Eq, Ord, Show, Read
--- #ifndef NO_NEWTYPE_DERIVING
---           , Num, Integral, Real, Enum
--- #endif
-          
+derive Eq       (NonNegative a)
+derive Ord      (NonNegative a)
+derive Show     (NonNegative a)
 
-instance Arbitrary (Num a, Ord a, Arbitrary a) => (NonNegative a) where
+instance (Num a, Ord a, Arbitrary a) => Arbitrary (NonNegative a) where
   arbitrary =
     (frequency
        -- why is this distrbution like this?
@@ -188,19 +170,14 @@ instance Arbitrary (Num a, Ord a, Arbitrary a) => (NonNegative a) where
     , x' >= fromInt 0
     ]
 
--- ------------------------------------------------------------------------
+
 --- @Shrink2 x@: allows 2 shrinking steps at the same time when shrinking x
 data Shrink2 a = Shrink2 a
-derive Eq Shrink2 a
-derive Ord Shrink2 a
-derive Show Shrink2 a
---  deriving ( Eq, Ord, Show, Read
--- #ifndef NO_NEWTYPE_DERIVING
---           , Num, Integral, Real, Enum
--- #endif
-          
+derive Eq   (Shrink2 a)
+derive Ord  (Shrink2 a)
+derive Show (Shrink2 a)
 
-instance Arbitrary Arbitrary a => (Shrink2 a) where
+instance Arbitrary a => Arbitrary (Shrink2 a) where
   arbitrary =
     Shrink2 `fmap` arbitrary
 
@@ -213,16 +190,16 @@ instance Arbitrary Arbitrary a => (Shrink2 a) where
    where
     shrink_x = shrink x
 
--- ------------------------------------------------------------------------
+
 ---  @Smart _ x@: tries a different order when shrinking.
 data Smart a =
   Smart Int a
 
-instance Show  Show a => (Smart a) where
+instance Show a => Show (Smart a) where
   showsPrec n (Smart _ x) = showsPrec n x
   show (Smart _ x) = show x
 
-instance Arbitrary Arbitrary a => (Smart a) where
+instance Arbitrary a => Arbitrary (Smart a) where
   arbitrary =
     do x <- arbitrary
        return (Smart 0 x)
@@ -236,52 +213,3 @@ instance Arbitrary Arbitrary a => (Smart a) where
     as     `ilv` []     = as
     (a:as) `ilv` (b:bs) = a : b : (as `ilv` bs)
 
-{-
-  shrink (Smart i x) = part0 ++ part2 ++ part1
-   where
-    ys = [ Smart i y | (i,y) <- [0..] `zip` shrink x ]
-    i' = 0 `max` (i-2)
-    k  = i `div` 10
-
-    part0 = take k ys
-    part1 = take (i'-k) (drop k ys)
-    part2 = drop i' ys
--}
-
-    -- drop a (drop b xs) == drop (a+b) xs           | a,b >= 0
-    -- take a (take b xs) == take (a `min` b) xs
-    -- take a xs ++ drop a xs == xs
-
-    --    take k ys ++ take (i'-k) (drop k ys) ++ drop i' ys
-    -- == take k ys ++ take (i'-k) (drop k ys) ++ drop (i'-k) (drop k ys)
-    -- == take k ys ++ take (i'-k) (drop k ys) ++ drop (i'-k) (drop k ys)
-    -- == take k ys ++ drop k ys
-    -- == ys
-
--- #ifndef NO_MULTI_PARAM_TYPE_CLASSES
--- --------------------------------------------------------------------------
--- -- | @Shrinking _ x@: allows for maintaining a state during shrinking.
--- data Shrinking s a =
---   Shrinking s a
--- 
--- class ShrinkState s a where
---   shrinkInit  :: a -> s
---   shrinkState :: a -> s -> [(a,s)]
--- 
--- instance Show a => Show (Shrinking s a) where
---   showsPrec n (Shrinking _ x) = showsPrec n x
--- 
--- instance (Arbitrary a, ShrinkState s a) => Arbitrary (Shrinking s a) where
---   arbitrary =
---     do x <- arbitrary
---        return (Shrinking (shrinkInit x) x)
--- 
---   shrink (Shrinking s x) =
---     [ Shrinking s' x'
---     | (x',s') <- shrinkState x s
---     ]
--- 
--- #endif /* NO_MULTI_PARAM_TYPE_CLASSES */
-
--- ------------------------------------------------------------------------
--- the end.

--- a/frege/test/QuickCheckProperty.fr
+++ b/frege/test/QuickCheckProperty.fr
@@ -75,7 +75,7 @@ instance Testable Prop where
   property (MkProp r) = return . MkProp . ioRose . return $ r
   exhaustive _ = true
 
-instance Testable Testable prop => Gen prop where
+instance Testable prop => Testable (Gen prop) where
   property mp = do p <- mp; property p
 
 {-- 
@@ -84,7 +84,7 @@ instance Testable Testable prop => Gen prop where
 morallyDubiousIOProperty :: Testable prop => IO prop -> Property
 morallyDubiousIOProperty = fmap (MkProp . ioRose . fmap Prop.unProp) . promote . fmap property
 
-instance Testable (Arbitrary a, Show a, Testable prop) => (a -> prop) where
+instance (Arbitrary a, Show a, Testable prop) => Testable (a -> prop) where
   property f = forAllShrink arbitrary shrink f
 
 -- ** Exception handling

--- a/shadow/frege/control/Category.fr
+++ b/shadow/frege/control/Category.fr
@@ -16,7 +16,7 @@ private type F = (->)
     _identity morphism for A_, such that for every morphism @f: A -> B@ we have
     > id(B) • f = f = f • id(A)   
 -}
-class Category (Semigroupoid f) => f where
+class (Semigroupoid f) => Category f where
     --- the identity morphism
     id :: f a a
 

--- a/shadow/frege/prelude/Math.fr
+++ b/shadow/frege/prelude/Math.fr
@@ -31,7 +31,7 @@ infixr 15  `**`
 sqr :: Num a => a -> a
 sqr x = x * x
 
-class  Floating Real r ⇒ r where
+class  Real r ⇒ Floating r where
 
     --- The value that is closer than any other to @pi@, the ratio of the circumference of a circle to its diameter.
     pi                  ∷ r

--- a/shadow/frege/prelude/Maybe.fr
+++ b/shadow/frege/prelude/Maybe.fr
@@ -85,8 +85,8 @@ instance ListEmpty Maybe where
     null _       = false
 
 
-derive Eq   Maybe a
-derive Ord  Maybe a
+derive Eq   (Maybe a)
+derive Ord  (Maybe a)
 -- derive Show Maybe a is in Text
 
 --- @true@ if and only if the argument is a 'Just' value

--- a/shadow/frege/prelude/PreludeArrays.fr
+++ b/shadow/frege/prelude/PreludeArrays.fr
@@ -282,7 +282,7 @@ instance ListSource JArray where
     toList :: JArray a -> [a]
     toList !ra = mapMaybe ra.itemAt [0..ra.length-1] 
 
-instance Eq (Eq a) ⇒ JArray a where
+instance (Eq a) ⇒ Eq (JArray a) where
     a == b
         | a.length == b.length = go (a.length-1)
         | otherwise = false
@@ -370,7 +370,7 @@ arrayCache f n = (JArray.cache f n >>= readonly id).run
     Note that 'JArray' cannot be an instance of 'ArrayElem' itself,
     because it has no fixed @java.lang.Class@ instance.
 -}
-class ArrayElem JavaType a => a where
+class JavaType a => ArrayElem a where
     --- Create a one dimensional array with elements of the instantiated type.
     native newArray "new[]"   :: Int -> ST s (ArrayOf s a)
     -- newArray :: Int -> ST s (ArrayOf s a)
@@ -407,7 +407,7 @@ class ArrayElem JavaType a => a where
     does not support passing 'Nothing', because there can be no
     @null@ in primitive arrays.
 -}
-class PrimitiveArrayElement ArrayElem a => a where
+class ArrayElem a => PrimitiveArrayElement a where
     --- Default implementation suitable for primitive types.
     --- It is an error to put 'Nothing' in a primitive array.
     setAt arr inx = setElemAt arr inx . maybe (error "cannot have null in primitive arrays") id
@@ -420,7 +420,7 @@ class PrimitiveArrayElement ArrayElem a => a where
 
 --- 'ArrayElement' is the class one derives for array elements.
 --- In addition to the base class 'ArrayElem' it also supports mutable array elements.
-class ArrayElement ArrayElem a => a where
+class ArrayElem a => ArrayElement a where
     --- Create an array of mutable items. 
     --- Such an array may never be immutable itself. 
     newArrayM  :: Int -> ST s (ArrayOf s (Mutable s a))

--- a/shadow/frege/prelude/PreludeBase.fr
+++ b/shadow/frege/prelude/PreludeBase.fr
@@ -1058,7 +1058,7 @@ data Ordering = Lt | Eq | Gt
   all elements of the type are themselves instances of 'Ord' and when the type is
   an instance of 'Eq'.
  -}
-class Ord Eq ord => ord where
+class Eq ord => Ord ord where
     {-- This operator must be defined in all instances. It compares its operands and
         returns 'Lt' if the first is lower than the second, 'Gt' if the first is
         greater than the second and 'Ordering.Eq' otherwise.
@@ -1130,7 +1130,7 @@ class Ord Eq ord => ord where
  > [a,b .. c]
  > [a,b ..]
  -}
-class Enum Ord e => e where
+class Ord e => Enum e where
     {-- @ord e@ returns the ordinal number associated with the value @e@. For
      * enumeration types, 'ord' is the same as 'constructor', for 'Int', it is the
      * identity function.
@@ -1192,7 +1192,7 @@ instance Eq () where
 {-- The 'Num' class provides the operators ('+'), ('-') and ('*') as well as
     some functions that are common for all numeric types.
     -}
-class Num Ord n => n where
+class Ord n => Num n where
     --- Computes the sum of two numbers
     (+) :: n -> n -> n
     --- Computes the difference of two numbers
@@ -1260,7 +1260,7 @@ class Num Ord n => n where
 {--
  * The 'Real' class provides the division operator ('/').
  -}
-class Real Num r => r where
+class Num r => Real r where
     --- the division operator
     (/) :: r -> r -> r
     --- convert a 'Double' to any 'Real' value
@@ -1326,7 +1326,7 @@ instance Integral Integer where
 toInteger = Integral.big
 
 --- Class 'Integral' provides division and remainder operations for integral numbers.
-class Integral Num integ => integ where
+class Num integ => Integral integ where
     --- integer division
     div, quot :: integ -> integ -> integ
     --- Haskell compatibility
@@ -1809,7 +1809,7 @@ instance Real Double where
 
 -- derive Show Ordering
 
-instance Eq Eq a => [a] where
+instance Eq a => Eq [a] where
     --- two lists are equal if their heads and tails are equal or if the lists are empty
     (a:as) == (b:bs) | a == b = as == bs 
                      | otherwise = false

--- a/shadow/frege/prelude/PreludeIO.fr
+++ b/shadow/frege/prelude/PreludeIO.fr
@@ -87,7 +87,7 @@ class JavaType e where
     This is derivable for @pure@ @native@ data types.
     -}                                
     
-class Exceptional  JavaType e => e 
+class JavaType e => Exceptional e 
 
 derive Exceptional Undefined
 derive Exceptional NoMatch
@@ -355,7 +355,7 @@ class Freezable f where
  * contains references to mutable objects. In such cases, sort of a deep cloning
  * would be required.
  -}
-class Cloneable (Freezable f) => f  where
+class (Freezable f) => Cloneable f  where
     {--
      *  @clone v@ must be a native method that works like @java.lang.Object#clone@.
      -}
@@ -374,7 +374,7 @@ class Cloneable (Freezable f) => f  where
  * which serializes its argument to a byte array and creates a new copy by
  * deserializing it from the byte array.
  -}
-class Serializable (Freezable f) => f  where
+class (Freezable f) =>  Serializable f  where
     {--
      *  @copySerializable v@ is supposed to be a native function that is
      *  implemented by @frege.runtime.Runtime.copySerializable@ at the instantiated type.

--- a/shadow/frege/prelude/PreludeList.fr
+++ b/shadow/frege/prelude/PreludeList.fr
@@ -89,7 +89,7 @@ class ListEmpty α where
     empty :: α β
 
 --- A class for types that support the (++) operator.
-class ListMonoid (ListEmpty α, ListSemigroup α)  => α
+class (ListEmpty α, ListSemigroup α)  => ListMonoid  α
 
 --- A class for types that support 'concat'
 class ListSemigroup α where
@@ -107,7 +107,7 @@ class ListSemigroup α where
     This class provides no means to construct a list. 
 
 -}
-class ListView (ListEmpty α, ListSource α) => α  where
+class (ListEmpty α, ListSource α) =>  ListView α  where
     --- converts a list-view to a list
     --  toList :: α β -> [β] -- definition from ListSource
     toList xs
@@ -248,7 +248,7 @@ instance ListSource Maybe where
     toList (Just a) = [a]
     toList Nothing  = []
 
-instance ListSource Either α where
+instance ListSource (Either α) where
     --- Singleton with element from 'Right' or empty list for 'Left'
     toList (Left _)  = []
     toList (Right a) = [a]

--- a/shadow/frege/prelude/PreludeMonad.fr
+++ b/shadow/frege/prelude/PreludeMonad.fr
@@ -94,7 +94,7 @@ class Functor f where
     --- Map a function over a 'Functor'
     fmap :: (a -> b) -> f a -> f b
 
-class Apply (Functor f) => f where
+class (Functor f) => Apply f where
     (<*>) :: f (a -> b) -> f a -> f b
 
 --- An infix synonym for 'fmap'. Left associative with precedence 4.
@@ -141,7 +141,7 @@ class Apply (Functor f) => f where
     
     Minimal complete definition: 'pure' and '<*>'.
     -}
-class Applicative  (Apply p) => p where
+class (Apply p) =>  Applicative p where
     
     --- Lift a value
     pure   :: a -> p a    
@@ -179,17 +179,17 @@ liftA4 f a b c d = f <$> a <*> b <*> c <*> d
 liftA5 :: Applicative f => (a -> b -> c -> d -> e -> g) -> f a -> f b -> f c -> f d -> f e -> f g
 liftA5 f a b c d e = f <$> a <*> b <*> c <*> d <*> e
 
-class Bind (Apply f) => f where
+class (Apply f) => Bind f where
     --- Sequentially compose two actions, passing any value produced by the first as an argument to the second.
     (>>=) :: f a -> (a -> f b) -> f b
 
-class Alt (Functor f) => f where
+class (Functor f) => Alt f where
     (<|>) :: f a -> f a -> f a
 
-class Plus (Alt f) => f where
+class (Alt f) => Plus f where
     pzero :: f a
 
-class MonadAlt (Plus f, Monad f) => f where
+class (Plus f, Monad f) => MonadAlt f where
     (<+>) :: f a -> f a -> f a
 
 {--
@@ -219,7 +219,7 @@ class MonadAlt (Plus f, Monad f) => f where
     Minimal complete definition: '>>=' and ('pure' or 'return')
     
     -}
-class Monad (Applicative m, Bind m) => m where
+class (Applicative m, Bind m) => Monad m where
     {--
         Sequentially compose two actions, discarding any value produced by the first, 
         this works like sequencing operators (such as the semicolon) in imperative languages.
@@ -247,7 +247,7 @@ class Monad (Applicative m, Bind m) => m where
     The 'MonadFail' class augments 'Monad' by adding the 'fail' operation.
     This operation is not part of the mathematical definition of a monad.
     -}   
-class MonadFail (Monad m) => m where  
+class (Monad m) => MonadFail m where  
 
     --- Fail with a message. 
     fail   :: String -> m a
@@ -257,7 +257,7 @@ class MonadFail (Monad m) => m where
 {--
     A 'Monad' with a left identity.
     -}
-class MonadZero (Monad mz) => mz where
+class (Monad mz) => MonadZero mz where
     --- This value should satisfy _left zero_: 
     --- > mzero >>= f = mzero
     mzero :: mz a
@@ -270,11 +270,11 @@ class MonadZero (Monad mz) => mz where
     > (a `mplus` b) `mplus` c = a `mplus` (b `mplus` c)
     > (a `mplus` b) >>= f = (a >>= f) `mplus` (b >>= f)
     -} 
-class MonadPlus (MonadZero mp) => mp where
+class (MonadZero mp) => MonadPlus mp where
     --- an associative operation
     mplus :: mp a -> mp a -> mp a
  
-class MonadOr (MonadZero mo) => mo where
+class (MonadZero mo) => MonadOr mo where
     -- Should satisfy 'monoid':
     --   zero `orElse` b = b;  b `orElse` zero = b
     --   (a `orElse` b) `orElse` c = a `orElse` (b `orElse` c)
@@ -488,10 +488,10 @@ instance MonadFail (ST s) where
 -- Tuples    
 -- for higher arities and Monad instances see frege.data.Tuples  
   
-instance Functor (,) a where
+instance Functor ((,) a) where
   fmap fn (a, x) = (a, fn x)
   
-instance Functor (,,) a b where
+instance Functor ((,,) a b) where
   fmap fn (a, b, x) = (a, b, fn x)
 
 instance Applicative ((->) a) where

--- a/shadow/frege/prelude/PreludeText.fr
+++ b/shadow/frege/prelude/PreludeText.fr
@@ -140,7 +140,7 @@ instance Show String where
     pure native show frege.runtime.Runtime.quoteStr :: String -> String
     display s = s
 
-instance Show  Show a => [a] where
+instance Show a => Show  [a] where
     show lst = showList lst ""     --  "[" ++ joined ", " (map Show.show lst) ++ "]"
     -- showsub = show
     -- display = show
@@ -161,8 +161,8 @@ derive Show     ()
 derive Show     (a,b)
 derive Show     (a,b,c)
 derive Show     Ordering
-derive Show     Maybe a
-derive Show     Either a b
+derive Show     (Maybe a)
+derive Show     (Either a b)
 instance Show Regex where
     show r = r.pattern
 

--- a/tests/hcm/ClassInstSyntax.fr
+++ b/tests/hcm/ClassInstSyntax.fr
@@ -1,0 +1,23 @@
+--- Check Haskell class and instance synax
+module tests.hcm.ClassInstSyntax where
+
+class A a where
+    aop :: a -> a
+
+class A b ⇒ B b where
+    bop ∷ b → b
+
+class (Eq c, B c) => C c where
+    cop ∷ c -> c
+
+instance A (Maybe a) where
+    aop = id
+
+instance A (Maybe b) => B (Maybe b) where
+    bop = id
+
+instance (Eq Int, A (Maybe c), Eq c) => 
+    C (Maybe c) where
+        cop = id  
+
+foo = cop (Just 42)

--- a/tests/qc/HM.fr
+++ b/tests/qc/HM.fr
@@ -4,7 +4,7 @@ module tests.qc.HM where
 import Test.QuickCheck
 import Data.HashMap H hiding(!!)
 
-instance Arbitrary (Eq k, Arbitrary k, Arbitrary v) => (HashMap k v) where
+instance  (Eq k, Arbitrary k, Arbitrary v) => Arbitrary (HashMap k v) where
     arbitrary = fromList <$> arbitrary 
 
 --- invariants are met before and after insert

--- a/tests/qc/PreludeProperties.fr
+++ b/tests/qc/PreludeProperties.fr
@@ -64,7 +64,7 @@ funs = elements (map Fun [(Int.+), (Int.subtract), Int.min, Int.max])
 tupleLists = arbitrary :: Gen [(Int, String)]
 
 data Fun a = Fun a
-instance Show Fun a where
+instance Show (Fun a) where
     show f = "<function>"
 
 data Small = SA | SB | SC | SD | SE | SF | SG | SH | SI | SJ | SK | SL | SM


### PR DESCRIPTION
This is a change that breaks source code compatibility in many cases where you have classes and instances defined. 

You need at least frege3.23.365 to compile the new syntax.

Here is a brief cheat sheet of the change:

    --- old                                                             --- new
    class C X c => c                                             class X c => C c
    instance C (A x, B x) => T x                           instance (A x, B x) => C (T x)
    derive Eq T x y                                               derive Eq (T x y)

Note that if the instantiated type is syntactically a type application like `Maybe a`, 
it must be written in parentheses. 

