### PR TITLE
fixed #186: No longer show usage on invalid directory.

### DIFF
--- a/frege/compiler/common/CompilerOptions.fr
+++ b/frege/compiler/common/CompilerOptions.fr
@@ -254,13 +254,13 @@ scanOpts opts ("-d":dir:args) = do
                     if canWrite then scanOpts opts.{dir} args
                         else do
                             IO.stderr.println ("directory " ++ dir ++ " is not writable.")
-                            IO.return Nothing
+                            IO.return false
                 else do
                     IO.stderr.println ("directory " ++ dir ++ " is not readable.")
-                    IO.return Nothing
+                    IO.return false
         else do
             IO.stderr.println (dir ++ " is not a directory.")
-            IO.return Nothing
+            IO.return false
 scanOpts opts ("-sp":xs) | null xs || head xs ~ ´^-´ = do
     IO.stderr.println "option -sp must be followed by source path."
     IO.return Nothing


### PR DESCRIPTION
If java arguments are correct, but there's an issue with the directory, do not show usage.