### PR TITLE
Removed unused variables, renamed remaining ones. Build all things in build/ and subfolders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ frege/Version.fr
 y.*
 frege/Scrap.fr
 shadow/META-INF/
+lib/
 
 #################
 ## Eclipse

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ before_script:
   - curl -L -o fregec.jar https://github.com/Frege/frege/releases/download/3.23.288/frege3.23.365-g185c1b5.jar
 
 script:
-  - make runtime fregec.jar dist
+  - make dist

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ PRELUDE  = \
 #	shadow Prelude files in the order they must be compiled
 SPRELUDE  = $(addprefix shadow/, $(PRELUDE))
 
-.PHONY: all clean diffs dist distclean docu fregec.jar fregec6.jar fregec7.jar runtime sanitycheck savejava shadow-prelude test test.jar tools
+.PHONY: all clean diffs dist distclean docu fregec.jar fregec6.jar fregec7.jar rebuild runtime sanitycheck savejava shadow-prelude test tools
 
 all: runtime compiler fregec.jar
 	@echo "[1;42mMaking $@[0m"
@@ -183,7 +183,7 @@ $(BUILD)/fregec6.jar: fallback.jar savejava
 #	Avoid recompilation of everything, just remake the compiler with itself and jar it.
 #	One should have a fallback.jar, just in case ....
 #
-test-jar: $(BUILD)/fallback.jar
+rebuild: $(BUILD)/fallback.jar
 	@echo "[1;43mMaking $@[0m"
 	$(FREGEC2) -make frege.compiler.Main frege.ide.Utilities
 	$(RM) $(BUILD)/fregec.jar

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ BUILD_AFREGE_COMPILER = $(BUILD_AFREGE)/compiler
 
 BUILD_BFREGE          = $(BUILD)/bfrege
 BUILD_BFREGE_COMPILER = $(BUILD_BFREGE)/compiler
+FREGEC_VERSION        = 3.23.365-g185c1b5
 
 JAVAC    = javac -encoding UTF-8
 YACC     = `which byacc || which byaccj || which pbyacc || false`
@@ -100,7 +101,7 @@ clean:
 
 distclean: clean
 	@echo "[1;42mMaking $@[0m"
-	$(RM) frege/Version.fr fallback.jar fregec.jar lib y.output y.tab.c
+	$(RM) dist frege/Version.fr fallback.jar fregec.jar lib y.output y.tab.c
 
 sanitycheck:
 	@echo "[1;42mMaking $@[0m"
@@ -108,7 +109,7 @@ sanitycheck:
 
 lib/fregec.jar:
 	$(MKDIR) lib
-	curl -H 'Accept: application/vnd.github.v3.raw' -kL -o $@ https://github.com/Frege/frege/releases/download/3.23.288/frege3.23.401-g7c45277.jar
+	curl -H 'Accept: application/vnd.github.v3.raw' -kL -o $@ https://github.com/Frege/frege/releases/download/3.23.288/frege$(FREGEC_VERSION).jar
 
 dist: $(BUILD)/fregec.jar
 	@echo "[1;42mMaking $@[0m"
@@ -121,10 +122,6 @@ $(BUILD)/fregec.jar: test
 	jar -cf $@ -C $(BUILD) frege
 	jar -uvfe $@ frege.compiler.Main
 	java -jar $@ -version
-
-$(BUILD)/fallback.jar: $(BUILD)/fregec.jar
-	@echo "[1;43mMaking $@[0m"
-	$(CP) $< $@
 
 fregec7.jar: $(BUILD)/fregec7.jar
 

--- a/Makefile
+++ b/Makefile
@@ -21,273 +21,262 @@
 
 .SUFFIXES: .class .fr
 
-JAVAC = javac -encoding UTF-8
-YACC =`which byacc || which byaccj || which pbyacc || false`
-JAVA = java "-Dfrege.javac=internal"
+DOC                   = ../frege.github.com/doc
+BUILD                 = build
+BUILD6                = $(BUILD)/build6
+BUILD7                = $(BUILD)/build7
+BUILD_TEST            = $(BUILD)/test
+BUILD_FREGE           = $(BUILD)/frege
+BUILD_FREGE_COMPILER  = $(BUILD_FREGE)/compiler
+BUILD_FREGE_TOOLS     = $(BUILD_FREGE)/tools
+FREGE_COMPILER        = frege/compiler
 
+BUILD_AFREGE          = $(BUILD)/afrege
+BUILD_AFREGE_COMPILER = $(BUILD_AFREGE)/compiler
 
-DOC  = ../frege.github.com/doc
-DOCF = doc/frege/compiler
-DIR1 = build/afrege
-PREL1  = $(DIR1)/prelude
-COMPF1  = $(DIR1)/compiler
-LIBF1   = $(DIR1)/lib
-DATA1   = $(DIR1)/data
-CONTROL1 = $(DIR1)/control
-LIBJ1   = $(DIR1)/j
-TOOLSF1 = $(DIR1)/tools
-DIR2 = build/bfrege
-PREL2   = $(DIR2)/prelude
-COMPF2  = $(DIR2)/compiler
-LIBF2   = $(DIR2)/lib
-DATA2   = $(DIR2)/data
-LIBJ2   = $(DIR2)/j
-TOOLSF2 = $(DIR2)/tools
-DIR  = build/frege
-PREL    = $(DIR)/prelude
-COMPF   = $(DIR)/compiler
-LIBF    = $(DIR)/lib
-DATA   = $(DIR)/data
-LIBJ    = $(DIR)/j
-TOOLSF  = $(DIR)/tools
-COMPS   = frege/compiler
+BUILD_BFREGE          = $(BUILD)/bfrege
+BUILD_BFREGE_COMPILER = $(BUILD_BFREGE)/compiler
 
-
-FREGE    = $(JAVA) -Xss4m -Xmx1800m -cp build
+JAVAC    = javac -encoding UTF-8
+YACC     = `which byacc || which byaccj || which pbyacc || false`
+JAVA     = java -Dfrege.javac=internal
+CP       = cp -pf
+RM       = rm -fr
+MKDIR    = mkdir -p
+FREGE    = $(JAVA) -Xss4m -Xmx1800m -cp $(BUILD)
 
 #	compile using the fregec.jar in the working directory
-FREGECJ  = $(FREGE)  -jar fregec.jar  -d build -hints
+FREGECJ  = $(FREGE) -jar lib/fregec.jar -d $(BUILD) -hints
 
 #	compile compiler1 with fregec.jar, uses prelude sources from shadow/
 FREGEC0  = $(FREGECJ) -prefix a -sp shadow:.
 
 #	compile compiler2 with compiler1
-FREGEC1  = $(FREGE) afrege.compiler.Main -d build -hints -target 1.7 -inline -prefix b
+FREGEC1  = $(FREGE) afrege.compiler.Main -d $(BUILD) -hints -target 1.7 -inline -prefix b
 
 #	compile final compiler with compiler2
-FREGEC2  = $(FREGE) bfrege.compiler.Main -d build -hints -target 1.7 -O
+FREGEC2  = $(FREGE) bfrege.compiler.Main -d $(BUILD) -hints -target 1.7 -O
 
 #	final compiler
-FREGECC  = $(FREGE) frege.compiler.Main  -d build -hints -target 1.7 -O
+FREGECC  = $(FREGE) frege.compiler.Main -d $(BUILD) -hints -target 1.7 -O
 
-#	shadow Prelude files in the order they must be compiled
-SPRELUDE  =  shadow/frege/prelude/PreludeBase.fr \
-		shadow/frege/control/Semigroupoid.fr shadow/frege/control/Category.fr \
-		shadow/frege/prelude/PreludeList.fr shadow/frege/prelude/PreludeMonad.fr \
-		shadow/frege/prelude/Maybe.fr \
-		shadow/frege/prelude/PreludeIO.fr \
-		shadow/frege/prelude/PreludeArrays.fr \
-		shadow/frege/java/Lang.fr \
-		shadow/frege/java/util/Regex.fr \
-		shadow/frege/prelude/PreludeText.fr \
-		shadow/frege/prelude/Math.fr shadow/frege/java/lang/Math.fr
 #	Prelude files in the order they must be compiled
-PRELUDE  =  frege/prelude/PreludeBase.fr \
-		frege/control/Semigroupoid.fr frege/control/Category.fr \
-		frege/prelude/PreludeList.fr frege/prelude/PreludeMonad.fr \
+PRELUDE  = \
+		frege/prelude/PreludeBase.fr \
+		frege/control/Semigroupoid.fr \
+		frege/control/Category.fr \
+		frege/prelude/PreludeList.fr \
+		frege/prelude/PreludeMonad.fr \
 		frege/prelude/Maybe.fr \
 		frege/prelude/PreludeIO.fr \
 		frege/prelude/PreludeArrays.fr \
 		frege/java/Lang.fr \
 		frege/java/util/Regex.fr \
 		frege/prelude/PreludeText.fr \
-		frege/prelude/Math.fr frege/java/lang/Math.fr
+		frege/prelude/Math.fr \
+		frege/java/lang/Math.fr
 
-all:  runtime compiler fregec.jar
+#	shadow Prelude files in the order they must be compiled
+SPRELUDE  = $(addprefix shadow/, $(PRELUDE))
+
+.PHONY: all clean diffs dist distclean docu runtime sanitycheck savejava shadow-prelude test test.jar tools
+
+all: runtime compiler fregec.jar
+	@echo "[1;42mMaking $@[0m"
 
 shadow-prelude:
+	@echo "[1;43mMaking $@[0m"
 	jar -cf shadow.jar $(PRELUDE)
 	cd shadow && jar -xf ../shadow.jar
-	rm shadow.jar
+	$(RM) shadow.jar
+
+$(BUILD):
+	@echo "[1;42mMaking $@[0m"
+	$(MKDIR) $@
 
 clean:
-	rm -rf build/afrege build/bfrege build/frege
-	rm -rf build
-	mkdir build
+	@echo "[1;42mMaking $@[0m"
+	$(RM) $(BUILD)
 
+distclean: clean
+	@echo "[1;42mMaking $@[0m"
+	$(RM) frege/Version.fr lib y.output y.tab.c
 
 sanitycheck:
+	@echo "[1;42mMaking $@[0m"
 	$(JAVA) -version
 
+lib/fregec.jar:
+	$(MKDIR) lib
+	curl -H 'Accept: application/vnd.github.v3.raw' -kL -o $@ https://github.com/Frege/frege/releases/download/3.23.288/frege3.23.401-g7c45277.jar
+
 dist: fregec.jar
+	@echo "[1;42mMaking $@[0m"
 	perl scripts/mkdist.pl
 
 fregec.jar: test
-	jar  -cf    fregec.jar -C build frege
-	jar  -uvfe  fregec.jar frege.compiler.Main
+	@echo "[1;43mMaking $@[0m"
+	jar -cf fregec.jar -C $(BUILD) frege
+	jar -uvfe fregec.jar frege.compiler.Main
 	java -jar fregec.jar -version
-	cp fregec.jar fallback.jar
 
-fregec7.jar:  savejava
+fallback.jar: fregec.jar
+	@echo "[1;43mMaking $@[0m"
+	$(CP) $< $@
+
+fregec7.jar: savejava
+	@echo "[1;43mMaking $@[0m"
 	@echo The following will probably only work if you just made a compiler
-	rm -rf build7
-	mkdir build7
+	$(RM) $(BUILD7)
+	$(MKDIR) $(BUILD7)
 	@echo You can ignore the compiler warning.
-	$(JAVAC) -J-Xmx1g -source 1.7 -target 1.7 -sourcepath save -d build7 \
-	    save/frege/compiler/Main.java
-	jar -cf   fregec7.jar -C build7 frege
-	jar -uvfe fregec7.jar frege.compiler.Main
+	$(JAVAC) -J-Xmx1g -source 1.7 -target 1.7 -sourcepath save -d $(BUILD7) save/$(FREGE_COMPILER)/Main.java
+	jar -cf $@ -C $(BUILD7) frege
+	jar -uvfe $@ frege.compiler.Main
 	@echo Looks good .... let us try to make the tools and library ... 
-	$(JAVA) -Xmx1g -Xss4m -Dfrege.javac="javac -source 1.7 -target 1.7" -jar fregec7.jar -d build7 -nocp -fp build7 -make \
+	$(JAVA) -Xmx1g -Xss4m -Dfrege.javac="javac -source 1.7 -target 1.7" -jar $@ -d $(BUILD7) -nocp -fp $(BUILD7) -make \
 	    frege/StandardTools.fr frege/StandardLibrary.fr
 	@echo Still running? Now we have it almost .... 
-	cp frege/tools/yygenpar-fr frege/tools/YYgenparM-fr frege/tools/fregedoc.html build7/frege/tools
-	jar -cf   fregec7.jar -C build7 frege
-	jar -uvfe fregec7.jar frege.compiler.Main
-	cp fregec7.jar ../eclipse-plugin/lib/fregec.jar
- 
+	$(CP) frege/tools/yygenpar-fr frege/tools/YYgenparM-fr frege/tools/fregedoc.html $(BUILD7)/frege/tools
+	jar -cf $@ -C $(BUILD7) frege
+	jar -uvfe $@ frege.compiler.Main
+	$(CP) $@ ../eclipse-plugin/lib/fregec.jar
+
 fregec6.jar: fallback.jar savejava
+	@echo "[1;43mMaking $@[0m"
 	@echo The following will probably only work if you just made a fregec.jar
 	@echo Adapting the sources for dumb old java6 ....
-	cp frege/runtime/Concurrent.java6 save/frege/runtime/Concurrent.java
-	cp frege/runtime/Runtime.java6    save/frege/runtime/Runtime.java
-	cp frege/runtime/CompilerSupport.java6    save/frege/runtime/CompilerSupport.java
-	rm -rf build6
-	mkdir build6
+	$(CP) frege/runtime/Concurrent.java6 save/frege/runtime/Concurrent.java
+	$(CP) frege/runtime/Runtime.java6 save/frege/runtime/Runtime.java
+	$(CP) frege/runtime/CompilerSupport.java6 save/frege/runtime/CompilerSupport.java
+	$(RM) $(BUILD6)
+	$(MKDIR) $(BUILD6)
 	@echo You can ignore the compiler warning.
-	$(JAVAC) -J-Xmx1g -source 1.6 -target 1.6 -sourcepath save -d build6 \
-	    save/frege/compiler/Main.java
-	jar -cf   fregec6.jar -C build6 frege
-	jar -uvfe fregec6.jar frege.compiler.Main
+	$(JAVAC) -J-Xmx1g -source 1.6 -target 1.6 -sourcepath save -d $(BUILD6) save/$(FREGE_COMPILER)/Main.java
+	jar -cf $@ -C $(BUILD6) frege
+	jar -uvfe $@ frege.compiler.Main
 	@echo Looks good .... let us try to make the tools and library ... 
 	grep -v ForkJoin frege/StandardLibrary.fr >save/StandardLibrary.fr
-	$(JAVA) -Xmx1g -Xss4m -Dfrege.javac="javac -source 1.6 -target 1.6" -jar fregec6.jar -d build6 -nocp -fp build6 -make \
+	$(JAVA) -Xmx1g -Xss4m -Dfrege.javac="javac -source 1.6 -target 1.6" -jar $@ -d $(BUILD6) -nocp -fp $(BUILD6) -make \
 	    frege/StandardTools.fr save/StandardLibrary.fr
 	@echo Still running? Now we have it almost .... 
-	cp frege/tools/yygenpar-fr frege/tools/YYgenparM-fr frege/tools/fregedoc.html build6/frege/tools
-	jar -cf   fregec6.jar -C build6 frege
-	jar -uvfe fregec6.jar frege.compiler.Main
+	$(CP) frege/tools/yygenpar-fr frege/tools/YYgenparM-fr frege/tools/fregedoc.html $(BUILD6)/frege/tools
+	jar -cf $@ -C $(BUILD6) frege
+	jar -uvfe $@ frege.compiler.Main
 	@echo
 	@echo !-------------- PLEASE NOTE ----------------------------------------------
-	@echo !  The new compiler will itself generate java6 classes if run in a JDK6.  
-	@echo !  Unfortunately, the Java 6 compiler may not understand proper Java.     
-	@echo !  To avoid those problems, use this JAR always thus:                     
-	@echo !      java  -Dfrege.javac=\"javac -source 1.6 -target 1.6\" -jar fregec6.jar ...  
-	@echo !  where javac is a JDK-7 compiler!                                       
+	@echo ! The new compiler will itself generate java6 classes if run in a JDK6.
+	@echo ! Unfortunately, the Java 6 compiler may not understand proper Java.
+	@echo ! To avoid those problems, use this JAR always thus:
+	@echo !    java -Dfrege.javac=\"javac -source 1.6 -target 1.6\" -jar fregec6.jar ...
+	@echo ! where javac is a JDK-7 compiler!
 	@echo !-------------------------------------------------------------------------
 	@echo
-	
+
 #
 #	Avoid recompilation of everything, just remake the compiler with itself and jar it.
 #	One should have a fallback.jar, just in case ....
 #
 test-jar: fallback.jar
+	@echo "[1;43mMaking $@[0m"
 	$(FREGEC2) -make frege.compiler.Main frege.ide.Utilities
-	jar  -cf    fregec.jar -C build frege
-	jar  -uvfe  fregec.jar frege.compiler.Main
-	cp fregec.jar  ../eclipse-plugin/lib/fregec.jar
-
+	$(RM) fregec.jar
+	jar -cf fregec.jar -C $(BUILD) frege
+	jar -uvfe fregec.jar frege.compiler.Main
+	$(CP) fregec.jar ../eclipse-plugin/lib/fregec.jar
 
 test: compiler
-	$(FREGECC)  -make  frege/StandardLibrary.fr
-	rm -rf buildt
-	mkdir -p buildt
-	$(FREGECC)  -d buildt  tests/qc
-	$(JAVA) -Xss4m -cp build frege.tools.Quick -v buildt
-	rm -rf buildt
+	@echo "[1;42mMaking $@[0m"
+	$(FREGECC) -make frege/StandardLibrary.fr
+	$(RM) -rf $(BUILD_TEST)
+	$(MKDIR) $(BUILD_TEST)
+	$(FREGECC) -d $(BUILD_TEST) tests/qc
+	$(JAVA) -Xss4m -cp $(BUILD) frege.tools.Quick -v $(BUILD_TEST)
 
+$(BUILD_FREGE)/PreludeProperties.class: frege/PreludeProperties.fr $(BUILD_FREGE_COMPILER)/Main.class
+	@echo "[1;43mMaking $@[0m"
+	$(FREGECC) -make frege/PreludeProperties.fr
 
-$(DIR)/PreludeProperties.class:  frege/PreludeProperties.fr $(COMPF)/Main.class
-	$(FREGECC) -make  frege/PreludeProperties.fr
-
-# 	$(TOOLSF)/Doc.class $(TOOLSF)/YYgen.class $(TOOLSF)/LexConvt.class
-tools: $(COMPF)/Main.class
-	$(FREGECC) -make  frege/StandardTools.fr
+# 	$(BUILD_FREGE_TOOLS)/Doc.class $(BUILD_FREGE_TOOLS)/YYgen.class $(BUILD_FREGE_TOOLS)/LexConvt.class
+tools: $(BUILD_FREGE_COMPILER)/Main.class
+	$(FREGECC) -make frege/StandardTools.fr
 
 #
 # final compiler
 #
-compiler: $(COMPF)/Main.class 
-	cp frege/tools/yygenpar-fr frege/tools/YYgenparM-fr frege/tools/fregedoc.html build/frege/tools
+compiler: $(BUILD_FREGE_COMPILER)/Main.class
+	@echo "[1;42mMaking $@[0m"
+	$(CP) frege/tools/yygenpar-fr frege/tools/YYgenparM-fr frege/tools/fregedoc.html $(BUILD_FREGE)/tools
 	@echo Compiler ready
 
-$(COMPF)/grammar/Frege.class: frege/compiler/grammar/Frege.fr $(COMPF)/common/Desugar.class
-	$(FREGEC2) -make frege/compiler/grammar/Frege.fr
-frege/compiler/grammar/Frege.fr: frege/compiler/grammar/Frege.y
+$(BUILD_FREGE_COMPILER)/grammar/Frege.class: $(FREGE_COMPILER)/grammar/Frege.fr $(BUILD_FREGE_COMPILER)/common/Desugar.class
+	@echo "[1;43mMaking $@[0m"
+	$(FREGEC2) -make $(FREGE_COMPILER)/grammar/Frege.fr
+
+$(FREGE_COMPILER)/grammar/Frege.fr: $(FREGE_COMPILER)/grammar/Frege.y
+	@echo "[1;43mMaking $@[0m"
 	@echo We should have 5 shift/reduce conflicts in the grammar.
-	$(YACC) -v frege/compiler/grammar/Frege.y
-	$(FREGE) -cp fregec.jar frege.tools.YYgen -m State  frege/compiler/grammar/Frege.fr
+	$(YACC) -v $<
+	$(FREGE) -cp fregec.jar frege.tools.YYgen -m State $@
 
 frege/Version.fr: .git/index
-	perl scripts/mkversion.pl >frege/Version.fr
+	@echo "[1;43mMaking $@[0m"
+	perl scripts/mkversion.pl > $@
 
-$(COMPF)/Main.class: compiler2
-	( test -d $(DIR) -a $(COMPF2)/Main.class -nt $(COMPF)/Main.class && rm -rf $(COMPF) $(TOOLSF) $(DIR)/prelude ) || true
-	$(FREGEC2)  -make frege.compiler.Main frege/StandardTools.fr
+$(BUILD_FREGE_COMPILER)/Main.class: compiler2
+	@echo "[1;43mMaking $@[0m"
+	( test -d $(BUILD_FREGE) -a $(BUILD_BFREGE_COMPILER)/Main.class -nt $(BUILD_FREGE_COMPILER)/Main.class && \
+	    $(RM) $(BUILD_FREGE_COMPILER) $(BUILD_FREGE_TOOLS) $(BUILD_FREGE)/prelude ) || true
+	$(FREGEC2) -make frege.compiler.Main frege/StandardTools.fr
 
 compiler2: compiler1
-	( test -d $(DIR2) -a $(COMPF1)/Main.class -nt $(COMPF2)/Main.class && rm -rf $(DIR2) ) || true
+	@echo "[1;42mMaking $@[0m"
+	( test -d $(BUILD_BFREGE) -a $(COMPF1)/Main.class -nt $(BUILD_BFREGE_COMPILER)/Main.class && $(RM) $(BUILD_BFREGE) ) || true
 	$(FREGEC1) -v -make frege.compiler.Main
 	@echo stage 2 compiler ready
 
-
-
-SOURCES  =      $(COMPS)/Scanner.fr   $(COMPS)/Classtools.fr \
-		$(COMPS)/types/Positions.fr $(COMPS)/enums/Flags.fr \
-		$(COMPS)/types/Global.fr      $(COMPS)/Utilities.fr \
-		$(COMPS)/GUtil.fr \
-		$(COMPS)/Main.fr      $(COMPS)/Grammar.fr   $(COMPS)/Grammar.y \
-		$(COMPS)/Fixdefs.fr   $(COMPS)/Import.fr    $(COMPS)/Enter.fr \
-		$(COMPS)/TAlias.fr    \
-		$(COMPS)/Javatypes.fr $(COMPS)/Kinds.fr \
-		$(COMPS)/Transdef.fr  $(COMPS)/Classes.fr \
-		$(COMPS)/Transform.fr \
-		$(COMPS)/tc/Methods.fr $(COMPS)/tc/Patterns.fr \
-		$(COMPS)/Typecheck.fr \
-		$(COMPS)/tc/Util.fr \
-		$(COMPS)/gen/Util.fr  $(COMPS)/gen/Const.fr \
-		$(COMPS)/gen/Bindings.fr $(COMPS)/gen/Match.fr \
-		$(COMPS)/GenMeta.fr   $(COMPS)/GenJava7.fr
-
-
-CLASSES  =       $(COMPF1)/Scanner.class   $(COMPF1)/Classtools.class \
-		$(COMPF1)/types/Positions.class \
-		$(COMPF1)/types/Global.class      $(COMPF1)/Utilities.class \
-		$(COMPF1)/GUtil.class	$(COMPF1)/Grammar.class \
-		$(COMPF1)/Fixdefs.class   $(COMPF1)/Import.class \
-		$(COMPF1)/gen/Const.class  $(COMPF1)/gen/Util.class \
-		$(COMPF1)/Enter.class \
-		$(COMPF1)/Javatypes.class $(COMPF1)/Kinds.class $(COMPF1)/Transdef.class \
-		$(COMPF1)/tc/Util.class   \
-		$(COMPF1)/TAlias.class    $(COMPF1)/Classes.class \
-		$(COMPF1)/tc/Methods.class $(COMPF1)/tc/Patterns.class \
-		$(COMPF1)/Typecheck.class $(COMPF1)/Transform.class \
-		$(COMPF1)/gen/Bindings.class $(COMPF1)/gen/Match.class \
-		$(COMPF1)/GenMeta.class   $(COMPF1)/GenJava7.class
-
-
-compiler1: frege/compiler/grammar/Frege.fr frege/Version.fr 
-	$(FREGEC0)  -make frege.compiler.Main
+compiler1: $(FREGE_COMPILER)/grammar/Frege.fr frege/Version.fr
+	@echo "[1;42mMaking $@[0m"
+	$(FREGEC0) -make frege.compiler.Main
 	@echo stage 1 compiler ready
 
 runtime:
-	mkdir -p build
-	$(JAVAC) -d build -source 1.7 -target 1.7 frege/runtime/*.java frege/run/*.java
+	@echo "[1;42mMaking $@[0m"
+	$(JAVAC) -d $(BUILD) -source 1.7 -target 1.7 frege/runtime/*.java frege/run/*.java
 	@echo Runtime is complete.
 
-
-
 #
-#   Documentation
+#	Documentation
 #
-
-
-doc/index.html: $(RUNTIME)
-
+doc/index.html: runtime
 
 docu: fregec.jar
+	@echo "[1;42mMaking $@[0m"
 	javadoc -private -sourcepath . -d $(DOC) -encoding UTF-8 frege.runtime
 	$(JAVA) -cp fregec.jar frege.tools.Doc -v -d $(DOC) -x frege.compiler,frege.runtime,frege.S,frege.V,frege.PreludePr,frege.run fregec.jar
 	$(JAVA) -cp fregec.jar frege.tools.MakeDocIndex $(DOC)
 
-
 #
-#   Difference between 2 compilers
-#   The output of the first must have been stored in "save" (see "savejava")
-#   Compares all java files in save/frege with those in build/frege
+#	Difference between 2 compilers
+#	The output of the first must have been stored in "save" (see "savejava")
+#	Compares all java files in save/frege with those in $(BUILD_FREGE)
 #
 diffs:
-	diff -b -r -x "*.class" -I "This code was generated with the frege compiler version" -I "^ +source=" save  build
+	@echo "[1;42mMaking $@[0m"
+	diff -b -r -x "*.class" -I "This code was generated with the frege compiler version" -I "^ +source=" save $(BUILD)
 
 savejava:
+	@echo "[1;42mMaking $@[0m"
 	perl scripts/savejava.pl
+
+compiler compiler1 compiler2 fregec.jar runtime: $(BUILD)
+
+compiler1 \
+compiler2 \
+$(BUILD_FREGE_COMPILER)/Main.class \
+$(FREGE_COMPILER)/grammar/Frege.fr \
+$(BUILD_FREGE_COMPILER)/grammar/Frege.class: lib/fregec.jar
+
+test \
+tools \
+$(BUILD_FREGE)/PreludeProperties.class: fregec.jar

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ clean:
 
 distclean: clean
 	@echo "[1;42mMaking $@[0m"
-	$(RM) frege/Version.fr lib y.output y.tab.c
+	$(RM) frege/Version.fr fallback.jar fregec.jar lib y.output y.tab.c
 
 sanitycheck:
 	@echo "[1;42mMaking $@[0m"
@@ -277,6 +277,4 @@ $(BUILD_FREGE_COMPILER)/Main.class \
 $(FREGE_COMPILER)/grammar/Frege.fr \
 $(BUILD_FREGE_COMPILER)/grammar/Frege.class: lib/fregec.jar
 
-test \
-tools \
-$(BUILD_FREGE)/PreludeProperties.class: fregec.jar
+compiler2: runtime

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ $(FREGE_COMPILER)/grammar/Frege.fr: $(FREGE_COMPILER)/grammar/Frege.y
 	@echo "[1;43mMaking $@[0m"
 	@echo We should have 5 shift/reduce conflicts in the grammar.
 	$(YACC) -v $<
-	$(FREGE) -cp fregec.jar frege.tools.YYgen -m State $@
+	$(FREGE) -cp lib/fregec.jar frege.tools.YYgen -m State $@
 
 frege/Version.fr: .git/index
 	@echo "[1;43mMaking $@[0m"

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ clean:
 
 distclean: clean
 	@echo "[1;42mMaking $@[0m"
-	$(RM) dist frege/Version.fr fallback.jar fregec.jar lib y.output y.tab.c
+	$(RM) dist frege/Version.fr fregec.jar lib y.output y.tab.c
 
 sanitycheck:
 	@echo "[1;42mMaking $@[0m"
@@ -110,14 +110,13 @@ sanitycheck:
 lib/fregec.jar:
 	$(MKDIR) lib
 	curl -H 'Accept: application/vnd.github.v3.raw' -kL -o $@ https://github.com/Frege/frege/releases/download/3.23.288/frege$(FREGEC_VERSION).jar
+	$(CP) $@ .
 
-dist: $(BUILD)/fregec.jar
+dist: fregec.jar
 	@echo "[1;42mMaking $@[0m"
 	perl scripts/mkdist.pl
 
-fregec.jar: $(BUILD)/fregec.jar
-
-$(BUILD)/fregec.jar: test
+fregec.jar: test
 	@echo "[1;43mMaking $@[0m"
 	jar -cf $@ -C $(BUILD) frege
 	jar -uvfe $@ frege.compiler.Main

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ $(BUILD)/fregec7.jar: savejava
 
 fregec6.jar: $(BUILD)/fregec6.jar
 
-$(BUILD)/fregec6.jar: fallback.jar savejava
+$(BUILD)/fregec6.jar: fregec.jar savejava
 	@echo "[1;43mMaking $@[0m"
 	@echo The following will probably only work if you just made a fregec.jar
 	@echo Adapting the sources for dumb old java6 ....
@@ -178,15 +178,14 @@ $(BUILD)/fregec6.jar: fallback.jar savejava
 
 #
 #	Avoid recompilation of everything, just remake the compiler with itself and jar it.
-#	One should have a fallback.jar, just in case ....
 #
-rebuild: $(BUILD)/fallback.jar
+rebuild:
 	@echo "[1;43mMaking $@[0m"
 	$(FREGEC2) -make frege.compiler.Main frege.ide.Utilities
 	$(RM) $(BUILD)/fregec.jar
 	jar -cf $(BUILD)/fregec.jar -C $(BUILD) frege
 	jar -uvfe $(BUILD)/fregec.jar frege.compiler.Main
-	$(CP) $(BUILD)/fregec.jar ../eclipse-plugin/lib/fregec.jar
+	#$(CP) $(BUILD)/fregec.jar ../eclipse-plugin/lib/fregec.jar
 
 test: compiler
 	@echo "[1;42mMaking $@[0m"


### PR DESCRIPTION
Fetching current fregec jar files from github.com, placing it in lib folder.
Generally using more GNU make features.

Building Java 6 version in build/build6;
Building Java 7 version in build/build7.
Building test files in build/test.

No explicit removing of temporary files and folder; they are removed with the targets clean and distclean.
