### PR TITLE
Ix QC generators changed to avoid too much discarded tests

### DIFF
--- a/tests/qc/Ix.fr
+++ b/tests/qc/Ix.fr
@@ -14,80 +14,113 @@ smallInts = choose (0, 10000)
 
 smallIntegers = choose (toInteger 0, toInteger 10000)
 
-smallPairs = do
+leftPairs = do
     a<-choose (0, 100)
     b<-choose (0, 100)
     return (a,b)
 
-smallTriples = do
+rightPairs = do
+    a<-choose (90, 200)
+    b<-choose (90, 200)
+    return (a,b)
+
+allPairs = do
+    a<-choose (0, 200)
+    b<-choose (0, 200)
+    return (a,b)
+
+leftTriples = do
     a<-choose (0, 10)
     b<-choose (0, 10)
     c<-choose (0, 10)
     return (a,b,c)
+
+allTriples = do
+    a<-choose (0, 20)
+    b<-choose (0, 20)
+    c<-choose (0, 20)
+    return (a,b,c)
+
+rightTriples = do
+    a<-choose (9, 20)
+    b<-choose (9, 20)
+    c<-choose (9, 20)
+    return (a,b,c)
+
+smallPairs = allPairs
+smallTriples = allTriples
 
 gte g l = g `suchThat` (>=l)
 
 between g l u = (gte g l) `suchThat` (<=u)
 
 ---inRange (l,u) i == elem i (range (l,u))
-p_inRange_iff_elem_of_range g = forAll g (\l ->
-        forAll (gte g l) (\u ->
-            forAll g (\i ->
+p_inRange_iff_elem_of_range g1 g2 g3 = forAll g1 (\l ->
+        forAll (gte g2 l) (\u ->
+            forAll g3 (\i ->
                 inRange (l,u) i == elem i (range (l,u))
             )
         )
     )
 
-p_inRange_iff_elem_of_range_bools = p_index_i_gets_i bools
-p_inRange_iff_elem_of_range_chars = p_index_i_gets_i chars
-p_inRange_iff_elem_of_range_smallInts = p_index_i_gets_i smallInts
-p_inRange_iff_elem_of_range_smallIntegers = p_index_i_gets_i smallIntegers
-p_inRange_iff_elem_of_range_smallPairs = p_index_i_gets_i smallPairs
-p_inRange_iff_elem_of_range_smallTriples = p_index_i_gets_i smallTriples
+p_inRange_iff_elem_of_range' g = p_inRange_iff_elem_of_range g g g
+
+p_inRange_iff_elem_of_range_bools = p_inRange_iff_elem_of_range' bools
+p_inRange_iff_elem_of_range_chars = p_inRange_iff_elem_of_range' chars
+p_inRange_iff_elem_of_range_smallInts = p_inRange_iff_elem_of_range' smallInts
+p_inRange_iff_elem_of_range_smallIntegers = p_inRange_iff_elem_of_range' smallIntegers
+p_inRange_iff_elem_of_range_smallPairs = p_inRange_iff_elem_of_range leftPairs rightPairs allPairs
+p_inRange_iff_elem_of_range_smallTriples = p_inRange_iff_elem_of_range leftTriples rightTriples allTriples
 
 --- @range (l,u) !! index (l,u) i == i@ , when @inRange (l,u) i@
-p_index_i_gets_i g = forAll g (\l ->
-        forAll (gte g l) (\u ->
-            forAll (between g l u) (\i ->
+p_index_i_gets_i g1 g2 g3 = forAll g1 (\l ->
+        forAll (gte g2 l) (\u ->
+            forAll (between g3 l u) (\i ->
                 inRange (l,u) i ==> range (l,u) !! index (l,u) i == i
             )
         )
     )
 
-p_index_i_gets_i_bools = p_index_i_gets_i bools
-p_index_i_gets_i_chars = p_index_i_gets_i chars
-p_index_i_gets_i_smallInts = p_index_i_gets_i smallInts
-p_index_i_gets_i_smallIntegers = p_index_i_gets_i smallIntegers
-p_index_i_gets_i_smallPairs = p_index_i_gets_i smallPairs
-p_index_i_gets_i_smallTriples = p_index_i_gets_i smallTriples
+p_index_i_gets_i' g = p_index_i_gets_i g g g
+
+p_index_i_gets_i_bools = p_index_i_gets_i' bools
+p_index_i_gets_i_chars = p_index_i_gets_i' chars
+p_index_i_gets_i_smallInts = p_index_i_gets_i' smallInts
+p_index_i_gets_i_smallIntegers = p_index_i_gets_i' smallIntegers
+p_index_i_gets_i_smallPairs = p_index_i_gets_i leftPairs rightPairs allPairs
+p_index_i_gets_i_smallTriples = p_index_i_gets_i leftTriples rightTriples allTriples
 
 --- map (index (l,u)) (range (l,u)) == [0..rangeSize (l,u)-1]
-p_index_0_until_rangeSize gen = forAll gen (\l ->
-         forAll (gte gen l) (\u ->
+p_index_0_until_rangeSize g1 g2 = forAll g1 (\l ->
+         forAll (gte g2 l) (\u ->
                  map (index (l,u)) (range (l,u)) == [0..rangeSize (l,u)-1]
              )
          )
 
-p_index_0_until_rangeSize_bools = p_index_i_gets_i bools
-p_index_0_until_rangeSize_chars = p_index_i_gets_i chars
-p_index_0_until_rangeSize_smallInts = p_index_i_gets_i smallInts
-p_index_0_until_rangeSize_smallIntegers = p_index_i_gets_i smallIntegers
-p_index_0_until_rangeSize_smallPairs = p_index_i_gets_i smallPairs
-p_index_0_until_rangeSize_smallTriples = p_index_i_gets_i smallTriples
+p_index_0_until_rangeSize' g = p_index_0_until_rangeSize g g
+
+p_index_0_until_rangeSize_bools = p_index_0_until_rangeSize' bools
+p_index_0_until_rangeSize_chars = p_index_0_until_rangeSize' chars
+p_index_0_until_rangeSize_smallInts = p_index_0_until_rangeSize' smallInts
+p_index_0_until_rangeSize_smallIntegers = p_index_0_until_rangeSize' smallIntegers
+p_index_0_until_rangeSize_smallPairs = p_index_0_until_rangeSize leftPairs rightPairs
+p_index_0_until_rangeSize_smallTriples = p_index_0_until_rangeSize leftTriples rightTriples
 
 --- rangeSize (l,u) == length (range (l,u))
-p_rangeSize gen = forAll gen (\l ->
-         forAll (gte gen l) (\u ->
+p_rangeSize g1 g2 = forAll g1 (\l ->
+         forAll (gte g2 l) (\u ->
                  rangeSize (l,u) == length (range (l,u))
              )
          )
 
-p_rangeSize_bools = p_index_i_gets_i bools
-p_rangeSize_chars = p_index_i_gets_i chars
-p_rangeSize_smallInts = p_index_i_gets_i smallInts
-p_rangeSize_smallIntegers = p_index_i_gets_i smallIntegers
-p_rangeSize_smallPairs = p_index_i_gets_i smallPairs
-p_rangeSize_smallTriples = p_index_i_gets_i smallTriples
+p_rangeSize' g = p_rangeSize g g
+
+p_rangeSize_bools = p_rangeSize' bools
+p_rangeSize_chars = p_rangeSize' chars
+p_rangeSize_smallInts = p_rangeSize' smallInts
+p_rangeSize_smallIntegers = p_rangeSize' smallIntegers
+p_rangeSize_smallPairs = p_rangeSize leftPairs rightPairs
+p_rangeSize_smallTriples = p_rangeSize leftTriples rightTriples
 
 
 


### PR DESCRIPTION
In tests with pairs and triples two or three generators are used to increase probability of generating example satisfying assumptions.

`p_index_0_until_rangeSize_xxx` were not calling right property check.