### PR TITLE
Implement System.Environment to fix #227

### DIFF
--- a/frege/StandardLibrary.fr
+++ b/frege/StandardLibrary.fr
@@ -78,4 +78,4 @@ import Lib.PP public()
 import Test.QuickCheck public()
 
 import System.Random public()
- 
+import System.Environment public()

--- a/frege/java/Lang.fr
+++ b/frege/java/Lang.fr
@@ -84,7 +84,10 @@ derive Exceptional NoSuchFieldException
 data IllegalAccessException = pure native java.lang.IllegalAccessException
 derive Exceptional IllegalAccessException
 
-data IllegalArgumentException = pure native java.lang.IllegalArgumentException
+data IllegalArgumentException = pure native java.lang.IllegalArgumentException where
+    --- temporary 'new' name until name lookup bug fixed
+    pure native newIAE new :: String -> IllegalArgumentException
+                            | String -> Throwable -> IllegalArgumentException
 derive Exceptional IllegalArgumentException
 
 data SecurityException = pure native java.lang.SecurityException

--- a/frege/system/Environment.fr
+++ b/frege/system/Environment.fr
@@ -1,0 +1,37 @@
+{--
+    This package provides compatible definitions for Haskell 2010's
+    System.Environment but mostly they do not translate to a Java
+    environment.
+
+    getEnv can be made to work once it is wired into how main is
+    executed (it's currently a stub and will be updated after Ingo
+    has completed a rewrite of main / runMain).
+
+    getProgName really has no equivalent in the Java world since
+    it is based on the UNIX idea of an executable name or the
+    symbolic link to an executable. For now it arbitrarily returns
+    an empty string (returning "java" or "java.exe" would be just
+    as (in)accurate).
+
+    getEnv is specified to fail with System.IO.Error.isDoesNotExistError
+    if no such environment variable exists, but Frege uses Java
+    exceptions so instead we throw an IllegalArgumentException.
+    Using the underlying (Java) System.getenv is recommended
+    since that returns Maybe String instead
+--}
+module frege.system.Environment where
+
+import frege.java.Lang
+
+getArgs :: IO [String]
+getArgs = return []
+
+getProgName :: IO String
+getProgName = return ""
+
+getEnv :: String -> IO String
+getEnv s =
+    case System.getenv s of
+        -- temporary 'new' name until name lookup bug fixed
+        Nothing -> throwIO (IllegalArgumentException.newIAE s)
+        Just v  -> return v

--- a/shadow/frege/java/Lang.fr
+++ b/shadow/frege/java/Lang.fr
@@ -84,7 +84,10 @@ derive Exceptional NoSuchFieldException
 data IllegalAccessException = pure native java.lang.IllegalAccessException
 derive Exceptional IllegalAccessException
 
-data IllegalArgumentException = pure native java.lang.IllegalArgumentException
+data IllegalArgumentException = pure native java.lang.IllegalArgumentException where
+    --- temporary 'new' name until name lookup bug fixed
+    pure native newIAE new :: String -> IllegalArgumentException
+                            | String -> Throwable -> IllegalArgumentException
 derive Exceptional IllegalArgumentException
 
 data SecurityException = pure native java.lang.SecurityException

--- a/tests/qc/Environment.fr
+++ b/tests/qc/Environment.fr
@@ -1,0 +1,28 @@
+--- Test properties of the 'Environment' module
+module tests.qc.Environment where
+
+import System.Environment as E
+import Test.QuickCheck
+
+-- since we don't (yet) have Test.QuickCheck.Monadic we will cheat here
+-- and use IO.performUnsafe since these functions doen't actually have
+-- any side effects (despite their IO types)
+
+-- this may break once real main arguments are wired in, depending on
+-- how the tests are actually invoked:
+p_getArgsEmpty = once ( IO.performUnsafe (getArgs) == [] )
+
+p_getProgNameEmpty = once ( IO.performUnsafe (getProgName) == "" )
+
+-- PATH should be available even on Windows so this should be a safe test:
+p_getEnvPathOk = once ( IO.performUnsafe (getEnv "PATH") /= "" )
+
+-- this should yield an environment variable name that we will never have:
+noSuchEnv = "NoSuchEnvironmentVariable"
+
+-- getEnv throws IllegalArgumentException with the name of the unknown
+-- environment variable as the message value:
+accept :: IllegalArgumentException -> IO String
+accept t = return ("IAE" ++ t.getMessage)
+
+p_getEnvUnknownThrows = once ( IO.performUnsafe (getEnv noSuchEnv `catch` accept) == "IAE" ++ noSuchEnv )


### PR DESCRIPTION
`getArgs` is stubbed until Ingo rewrites how main is invoked.
`getProgName` is stubbed with no sensible result on the JVM.
`getEnv` throws IllegalArgumentException if the environment variable does not exist.

Added `newIAE` constructor to `IllegalArgumentException` until Ingo fixes the name lookup bug.