### PR TITLE
showChar should not add redundant quotes around character

### DIFF
--- a/frege/prelude/PreludeText.fr
+++ b/frege/prelude/PreludeText.fr
@@ -206,7 +206,7 @@ shows = showsPrec 0
 
 --- Haskell compatibility
 showChar :: Char -> String -> String
-showChar = showsPrec 0
+showChar = (++) . ctos
 
 --- Haskell compatibility
 showString :: String -> String -> String


### PR DESCRIPTION
frege> show 'a'
'a'

frege> length (show 'a')
3

When in ghci:
Prelude A> showChar 'a' ""
"a"
Prelude A> length (showChar 'a' "")
1
