### PR TITLE
review completeness and compatibility for Data.Char

### DIFF
--- a/frege/data/Char.fr
+++ b/frege/data/Char.fr
@@ -2,21 +2,22 @@
 module Data.Char where
 
 import frege.Prelude hiding (ord, chr, isNumber)
+import frege.prelude.PreludeText
 
 private type C = Char
 
 --- The general categories for unicode characters and code points.
 data GeneralCategory = UNASSIGNED | UPPERCASE_LETTER | LOWERCASE_LETTER
-                        | TITLECASE_LETTER | MODIFIER_LETTER | OTHER_LETTER
-                        | NON_SPACING_MARK | ENCLOSING_MARK | COMBINING_SPACING_MARK
-                        | DECIMAL_DIGIT_NUMBER | LETTER_NUMBER | OTHER_NUMBER
-                        | SPACE_SEPARATOR | LINE_SEPARATOR | PARAGRAPH_SEPARATOR
-                        | CONTROL | FORMAT | CATEGORY17 | PRIVATE_USE | SURROGATE
-                        | DASH_PUNCTUATION | START_PUNCTUATION | END_PUNCTUATION
-                        | CONNECTOR_PUNCTUATION | OTHER_PUNCTUATION
-                        | MATH_SYMBOL | CURRENCY_SYMBOL | MODIFIER_SYMBOL
-                        | OTHER_SYMBOL 
-                        | INITIAL_QUOTE_PUNCTUATION | FINAL_QUOTE_PUNCTUATION
+                     | TITLECASE_LETTER | MODIFIER_LETTER | OTHER_LETTER
+                     | NON_SPACING_MARK | ENCLOSING_MARK | COMBINING_SPACING_MARK
+                     | DECIMAL_DIGIT_NUMBER | LETTER_NUMBER | OTHER_NUMBER
+                     | SPACE_SEPARATOR | LINE_SEPARATOR | PARAGRAPH_SEPARATOR
+                     | CONTROL | FORMAT | CATEGORY17 | PRIVATE_USE | SURROGATE
+                     | DASH_PUNCTUATION | START_PUNCTUATION | END_PUNCTUATION
+                     | CONNECTOR_PUNCTUATION | OTHER_PUNCTUATION
+                     | MATH_SYMBOL | CURRENCY_SYMBOL | MODIFIER_SYMBOL
+                     | OTHER_SYMBOL 
+                     | INITIAL_QUOTE_PUNCTUATION | FINAL_QUOTE_PUNCTUATION
 
 --- return the general category of a 'Char'
 generalCategory :: Char -> GeneralCategory
@@ -147,3 +148,44 @@ digitToInt c = Char.digit c 16
 --- For other number bases than 16, see 'Char.forDigit'
 intToDigit d = Char.forDigit d 16
 
+isLetter :: Char -> Bool
+isLetter c = case generalCategory c of
+    UPPERCASE_LETTER        -> True
+    LOWERCASE_LETTER        -> True
+    TITLECASE_LETTER        -> True
+    MODIFIER_LETTER         -> True
+    OTHER_LETTER            -> True
+    _                       -> False
+
+isDec :: Char -> Bool
+isDec c = c >= '0' && c <= '9'
+
+protectEsc :: (Char -> Bool) -> ShowS -> ShowS
+protectEsc p f = f . cont . unpacked
+    where {
+        cont (s@(c:_)) | p c       = "\\&" ++ packed s
+                       | otherwise = packed s
+    } 
+
+asciiTab :: [String]
+asciiTab = -- Using an array drags in the array module.  listArray ('\NUL', ' ')
+           ["NUL", "SOH", "STX", "ETX", "EOT", "ENQ", "ACK", "BEL",
+            "BS",  "HT",  "LF",  "VT",  "FF",  "CR",  "SO",  "SI",
+            "DLE", "DC1", "DC2", "DC3", "DC4", "NAK", "SYN", "ETB",
+            "CAN", "EM",  "SUB", "ESC", "FS",  "GS",  "RS",  "US",
+            "SP"]
+
+showLitChar :: Char -> ShowS
+showLitChar c s | c > '\u007F' =  showChar '\\' (protectEsc isDec (shows (ord c)) s)
+showLitChar '\u007F'         s =  showString "\\DEL" s
+showLitChar '\\'             s =  showString "\\\\" s
+showLitChar c s | c >= ' '     =  showChar c s
+showLitChar '\u0061'         s =  showString "\\a" s
+showLitChar '\b'             s =  showString "\\b" s
+showLitChar '\f'             s =  showString "\\f" s
+showLitChar '\n'             s =  showString "\\n" s
+showLitChar '\r'             s =  showString "\\r" s
+showLitChar '\t'             s =  showString "\\t" s
+showLitChar '\u0076'         s =  showString "\\v" s
+showLitChar '\u000E'         s =  protectEsc (== 'H') (showString "\\SO") s
+showLitChar c                s =  showString (packed $ '\\' : (unpacked $ asciiTab!!(ord c))) s


### PR DESCRIPTION
Relate to #230, add `isLetter` and `showLitChar `.

just leave alone `lexLitChar` and `readLitChar` for now because they are related to the lexer according to [here](https://github.com/ghc/ghc/blob/master/libraries/base/GHC/Read.hs#L52), so maybe next PR will work this out.