### PR TITLE
put back naming alias for Data.Maybe

### DIFF
--- a/frege/data/Maybe.fr
+++ b/frege/data/Maybe.fr
@@ -40,15 +40,7 @@
 package Data.Maybe where
 
 import frege.Prelude public(
-        Maybe(Nothing, Just)
-      , maybe,
-      , isJust
-      , isNothing
-      , unJust
-      , fromJust
-      , fromMaybe
-      , listToMaybe
-      , maybeToList
-      , catMaybes
-      , mapMaybe
+        Maybe(Nothing, Just),
+        maybe, isJust, isNothing, unJust fromJust,
+        fromMaybe, listToMaybe, maybeToList, catMaybes, mapMaybe
     )


### PR DESCRIPTION
@Ingo60 sorry again that i did not compile locally before send pull request since i though CI server will check the code.

and after compiled locally, i find some issues about #302 that i added a duplicate comma after `maybe` and broke the naming alias for `unJust` and `fromJust`, now it is cool and i also leave leading commas style alone as you mentioned.

![image](https://cloud.githubusercontent.com/assets/6234553/18201329/28a9b952-713c-11e6-8347-d4ba2d82d1ae.png)
