### PR TITLE
detect gnu-time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ JAVA     = java -Dfrege.javac=internal
 CP       = cp -pf
 RM       = rm -rf
 MKDIR    = mkdir -p
-FREGE    = /usr/bin/time -f "%E %Mk" $(JAVA) -Xss4m -Xmx2222m -cp $(BUILD)
+TIME     = `which gtime || which time || false`
+FREGE    = ${TIME} -f "%E %Mk" $(JAVA) -Xss4m -Xmx2222m -cp $(BUILD)
 
 #	compile using the fregec.jar in the working directory
 FREGECJ  = $(FREGE) -jar fregec.jar -d $(BUILD) -hints


### PR DESCRIPTION
when build locally on OSX, there is no format flag `-f` for the executable `/usr/bin/time`, so maybe it is better to auto detect `gnu-time` first.