### PR TITLE
Fix "make runtime" to respect TARGET

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ compiler1: $(FREGE_COMPILER)/grammar/Frege.fr frege/Version.fr
 runtime:
 	@echo "[1;42mMaking $@[0m"
 	mkdir -p build
-	[ "$(TARGET)" = "1.7" ] || $(JAVAC) -d build frege/run8/*.java
+	[ "$(TARGET)" = "1.7" ] || $(JAVAC) -d build -source 1.8 -target 1.8 frege/run8/*.java
 	$(JAVAC) -d build -nowarn -source 1.7 -target 1.7 frege/runtime/*.java frege/run/*.java frege/run7/*.java
 	@echo Runtime is complete.
 


### PR DESCRIPTION
`make runtime` produces 53.0 (JDK9) class files if compiled with javac from JDK9, which is incompatible with java from JDK8.

This PR makes sure that those classes are compiled in 52.0 (JDK8) by specifying `-source 1.8 -target 1.8`.

The other make targets don't need changes because they already have `-source` and `-target` options.
