### PR TITLE
Remove the superclass Functor from Foldable

### DIFF
--- a/frege/data/Foldable.fr
+++ b/frege/data/Foldable.fr
@@ -37,7 +37,7 @@ import Data.Monoid
     >    foldr f z (Leaf x) = f x z
     >    foldr f z (Node l k r) = foldr f (f k (foldr f z r)) l
 -}
-class (Functor t) => Foldable t where
+class Foldable t where
     -- nowarn: recurses deeply
     --- Combine the elements of a structure using a monoid.  
     fold :: Monoid m => t m -> m

--- a/frege/data/Traversable.fr
+++ b/frege/data/Traversable.fr
@@ -26,7 +26,7 @@ import frege.data.wrapper.Const
     They are included for Haskell compatibility only. In Haskell the specialized 
     functions are needed as Haskell monads are no Applicatives.      
    -}
-class (Foldable t) => Traversable t where
+class (Functor t, Foldable t) => Traversable t where
     {-- Map each element of a structure to an action, evaluate
         these actions from left to right, and collect the results.
      -}


### PR DESCRIPTION
`Foldable` loses the superclass `Functor` and `Traversable` gains it as they do in Haskell.

Please see [this SO question of mine](https://stackoverflow.com/questions/47629536/why-does-foldable-inherit-from-functor-in-frege) for the conversation and examples.

This breaks existing instances of `Foldable` if it uses the ["All in one" instance declarations](https://github.com/Frege/frege/wiki/Differences-between-Frege-and-Haskell#all-in-one-instance-declarations) to define the members of `Functor`s.