### PR TITLE
Fix #284: Mangle named fields for Java

### DIFF
--- a/frege/compiler/gen/java/Common.fr
+++ b/frege/compiler/gen/java/Common.fr
@@ -683,6 +683,8 @@ lambdaArgDef g attr sigmas argNms = zipWith (argdef attr) sigmas argNms
 {--
     Substitute java member names in constructor fields.
     The resulting list satisfies @all (isJust . Field.name)@
+
+    The named fields are 'mangled' so that they are valid names in java.
     -}
 namedFields ∷ [ConField QName] → [ConField QName]
 namedFields flds = zipWith nf flds memNames

--- a/frege/compiler/gen/java/Common.fr
+++ b/frege/compiler/gen/java/Common.fr
@@ -15,6 +15,7 @@ import Compiler.common.AnnotateG(annoG)
 import Compiler.common.Errors as E()
 import Compiler.common.Types as CT(substSigma, substTau, )
 import Compiler.common.JavaName
+import Compiler.common.Mangle(mangled)
 
 import Compiler.enums.Flags(TRACEZ, TRACEG)
 import Compiler.enums.RFlag(RValue)
@@ -687,7 +688,7 @@ namedFields ∷ [ConField QName] → [ConField QName]
 namedFields flds = zipWith nf flds memNames
     where
         nf :: ConField QName -> String -> ConField QName
-        nf field member = field.{name <- Just . maybe member ("mem$" ++)}
+        nf field member = field.{name <- Just . maybe member (("mem$" ++) . mangled)}
 
 mkMember  Field{pos, name = Just mem, doc, vis, strict=s, typ} (_,_,jt,_) 
             = JMember {attr = attrs [JFinal, JPublic],

--- a/tests/comp/Issue284.fr
+++ b/tests/comp/Issue284.fr
@@ -1,0 +1,4 @@
+--- https://github.com/Frege/frege/issues/284 Issue 284
+module tests.comp.Issue284 where
+
+data Generic' c = Generic' { unGeneric' :: Maybe c }

--- a/tests/comp/Issue284a.fr
+++ b/tests/comp/Issue284a.fr
@@ -1,7 +1,9 @@
 --- https://github.com/Frege/frege/issues/284 Issue 284
-module tests.comp.Issue284 where
+---
+--- Tests that imported record can be used even if mangled.
+module tests.comp.Issue284a where
 
-data Generic' c = Generic' { unGeneric' :: Maybe c }
+import tests.comp.Issue284 (Generic')
 
 access :: Generic' a -> Maybe a
 access x = x.unGeneric'

--- a/tests/qc/Record.fr
+++ b/tests/qc/Record.fr
@@ -1,0 +1,68 @@
+--- Test properties of record data types
+module tests.qc.Record where
+
+import frege.test.QuickCheck
+
+data Int1 = Int1 { field :: Int }
+
+p_setInt1 = property $ \x -> let d = Int1 { field = x } in d.field == x
+
+
+--- An alias of @a -> b@ to define @instance Show@
+newtype F a b = F (a -> b)
+instance Show (F a b) where
+  show _ = "<function>"
+instance (CoArbitrary a, Arbitrary b) => Arbitrary (F a b) where
+  arbitrary = F <$> arbitrary
+
+
+--- @value'@ will be mangled to @mem$value$tick@. Will this work?
+data Mangled a = Mangled { value' :: a }
+derive Show (Mangled a)
+
+instance (Arbitrary a) => Arbitrary (Mangled a) where
+  arbitrary = do
+      value' <- arbitrary
+      return Mangled { value' }
+
+p_accessMangled = property $ \(x :: Mangled Int) -> let Mangled a = x in a == x.value'
+p_matchMangled  = property $ \(x@Mangled{value'} :: Mangled Int) -> value' == x.value'
+-- make test: java.lang.NoSuchFieldException: p_matchMangled' while checking property tests.qc.Record.p_matchMangled'
+-- p_matchMangled' = property $ \(x@Mangled{value'=a} :: Mangled Int) -> a == x.value'
+p_matchMangledA = property $ \(x@Mangled{value'=a} :: Mangled Int) -> a == x.value'
+p_updateMangled = property $ \(b :: Bool) (x :: Mangled Int) -> let y = x.{ value' = b } in y.value' == b
+p_changeMangled = property $ \(F f :: F Int Bool) (x :: Mangled Int) -> let y = x.{ value' <- f } in y.value' == f (x.value')
+
+
+data Mangled3 a b = Mangled3 { value :: a, value' :: b, value'' :: Int }
+derive Show (Mangled3 a b)
+
+instance (Arbitrary a, Arbitrary b) => Arbitrary (Mangled3 a b) where
+  arbitrary = do
+      value <- arbitrary
+      value' <- arbitrary
+      value'' <- arbitrary
+      return Mangled3 { value, value', value'' }
+
+p_accessMangled3 = property $ \(x :: Mangled3 Int Bool) -> let Mangled3 a b c = x in
+    a == x.value  &&
+    b == x.value' &&
+    c == x.value''
+p_matchMangled3  = property $ \(x@Mangled3{value, value', value''} :: Mangled3 Long Bool) ->
+    value   == x.value  &&
+    value'  == x.value' &&
+    value'' == x.value''
+p_matchMangled3A = property $ \(x@Mangled3{value=a, value'=b, value''=c} :: Mangled3 Char ()) ->
+    a == x.value  &&
+    b == x.value' &&
+    c == x.value''
+p_updateMangled3 = property $ \(a :: Int) (b :: Bool) (c :: Int) (x :: Mangled3 Char Long) ->
+    let y = x.{ value = a, value' = b, value'' = c } in
+    a == y.value  &&
+    b == y.value' &&
+    c == y.value''
+p_changeMangled3 = property $ \(F f :: F Int [Bool]) (F g :: F Char String) (F h :: F Int Int) (x :: Mangled3 Int Char) ->
+    let y = x.{ value <- f, value' <- g, value'' <- h } in
+    y.value   == f (x.value) &&
+    y.value'  == g (x.value') &&
+    y.value'' == h (x.value'')


### PR DESCRIPTION
Fixes #284 

This PR fixes #284 by mangling named fields of records type so that they have valid names in generated Java files.

`frege.compiler.gen.java.Common.namedFields` appears to be used in the following places:

- `frege.compiler.gen.java.Common.mkMember` for Java field declarations
- `frege.compiler.gen.java.DataCode.conDecls` for assignments in Java constructors
- `frege.compiler.gen.java.Match.match` for field accesses

At all of the places, name mangling is needed. This PR modifies `namedFields` itself to fix them all.