### PR TITLE
Fix #345: Supress an invalid generics argument for ListEmpty.empty

### DIFF
--- a/frege/compiler/gen/java/VarCode.fr
+++ b/frege/compiler/gen/java/VarCode.fr
@@ -1289,7 +1289,8 @@ genExpr rflg rm ex binds = do
                             | Just (SymC {tau}) <- g.findit tynm 
                             = do
                                 let targs  =  map (boxed . tauJT g . substTau subst) 
-                                                (filter ((!= tau.var) . _.var) sym.typ.tvars)
+                                                . filter (not . null . TreeMap.lookupS subst . _.var)
+                                                . filter ((!= tau.var) . _.var) $ sym.typ.tvars
                                     inst   = JInvoke get (tail ctxs)
                                     get    = JExMem  (head ctxs) (latinF ++ mangled base) targs
                                     bind   = (newBind g ret inst).{jtype = retjt}

--- a/tests/comp/Issue345.fr
+++ b/tests/comp/Issue345.fr
@@ -1,0 +1,84 @@
+--- https://github.com/Frege/frege/issues/345 Issue 345
+module tests.comp.Issue345 where
+
+--- fine
+leer ∷ ListEmpty α ⇒ α β
+leer = empty
+
+--- fails
+ganzLeer ∷ ListEmpty a ⇒ a b
+ganzLeer = empty
+
+foo :: (ListEmpty m) => m a
+foo = empty
+
+class MyEmpty m where
+  myEmpty :: m a
+
+bar :: (MyEmpty m) => m a
+bar = myEmpty
+
+data Foo = Foo (Maybe Int)
+
+-- the following doesn't compile
+
+polymorphic :: (ListEmpty m) => m a
+polymorphic = empty
+
+concrete1 :: [a]
+concrete1 = empty
+
+concrete2 :: String
+concrete2 = empty
+
+concrete2a :: String
+concrete2a = (empty :: String)
+
+concrete2b :: String
+concrete2b = empty ++ (empty :: String) -- same if operands are flipped
+
+concrete2c :: String
+concrete2c = "" ++ (empty :: String)  -- same if operands are flipped
+
+foo1 :: Foo
+foo1 = Foo (empty :: Maybe Int)
+
+-- the following does compile
+
+concrete2d :: String
+concrete2d = "" ++ empty  -- same if operands are flipped
+
+concrete2e :: String
+concrete2e = empty ++ empty
+
+foo2 :: Foo
+foo2 = Foo empty
+
+-- other special typeclasses
+
+lsemi :: (ListSemigroup m) => m a -> m a -> m a
+lsemi as bs = as ++ bs
+
+lsrc :: (ListSource m) => m a -> [a]
+lsrc a = toList a
+
+lsrc' :: (ListSource m) => m a -> [a]
+lsrc' = toList
+
+lmono :: (ListMonoid m) => [m a] -> m a
+lmono as = concat as
+
+lview :: (ListView m) => m a -> a
+lview xs =
+  -- try as many member functions as possible
+  case uncons . tail . take 1 . drop 1 $ xs of
+    Just (a, e) -> const a (length e)
+    Nothing -> head xs
+
+-- combined with non-special typeclasses
+
+fooM :: (Monad m, ListEmpty m) => m Int
+fooM = empty >>= \_ -> return 1
+
+fooMy :: (Monad m, MyEmpty m, ListEmpty m) => m Int
+fooMy = empty >>= \_ -> myEmpty >>= \_ -> return 1


### PR DESCRIPTION
Fixes #345 

During the GenCode pass,

```hs
empty :: ListEmpty α => α β
```

is replaced with its lower kinded counterpart

```hs
empty :: ListEmpty α => α
```

If the compiler encounters a type annotation in a source code like

```hs
:: ListEmpty m => m a
```

Two sigmas `α` (`sym.typ`) and `m a` (`ft`) are unified to create a substitution mapping `[α -> m]` (`subst`).
Note that `β -> a` is missing because of the lowering.

When generating java expressions, each bounded type parameter is substituted by the above mapping.
Since β is contained in bounded type parameters (`sym.typ.tvars`), substitution fails and is left as is.
This is why `<β>` appears in generated java code.

The following code

```hs
ganzLeer :: ListEmpty α => α β
```

worked because `β` coincided with the leftover `<β>`.

The other functions whose kinds are lowered don't suffer from this issue because they will retain `β` even after lowering.

For example,

```hs
toList :: (ListSource α) => α β -> [β]
```

is lowered to

```hs
toList :: (ListSource α) => α -> [β]
```

Then its sigma is unified with, say, `m a -> [a]`.
`a` in `m a` is discarded, but `m` unifies with `α` and `a` in `[a]` unifies with `β` in `[β]`, forming the desired mapping `[α -> m, β -> a]`.

This commit tries to fix this problem by filtering out missing type parameters (`β`) during Java code generation.