### PR TITLE
Fix regression of -ascii

### DIFF
--- a/frege/compiler/common/Binders.fr
+++ b/frege/compiler/common/Binders.fr
@@ -42,7 +42,7 @@ jtvNames g
 !mathJtvNames =  ["𝓐", "𝓑", "𝓒", "𝓓", "𝓔", "𝓕", "𝓖", "𝓗", "𝓘", 
                          "𝓙", "𝓚", "𝓛", "𝓜", "𝓝", "𝓞", "𝓟", "𝓠", "𝓡", 
                          "𝓢", "𝓣", "𝓤", "𝓥", "𝓦", "𝓧", "𝓨", "𝓩", "Ω"]
-!asciiJtvNames = map ctos ['A' .. 'Z']
+!asciiJtvNames = map (("g" ++) . ctos) ['A' .. 'Z']
 
 jtvArray g
     | isOn flags USEUNICODE = mathJtvArray


### PR DESCRIPTION
Recompiling Frege with a fresh `fregec.jar` fails to compile `PreludeMonad.fr`.

```
make fetch-fregec.jar && make clean fregec.jar && make clean fregec.jar
```

First I thought `Lazy.B`, `Lazy.D`, etc. conflicted with the ascii generics variables. But after that I checked that qualified names in Java doesn't conflict with generics variables. So I'm not sure why.

The reason why the compiler doesn't fail at the first `make` is that `-ascii` flag is added to the Makefile variable `FREGECJ`. The older `fregec.jar` uses mathematical characters for gvars even if `-ascii` is specified, so no error there. A new `fregec.jar` is "correctly" compiled and then fails at the second `make`.

This PR prefixes generated ASCII gvars with "g". It fixes the error.
The lower letter is deliberately chosen because as a name of type, `gA` is much less likely to conflict with other types than `GA`.

As of now, there is `AnnotationG.GA`, but it is a `newtype` so it doesn't appear in Java.

***

By the way, I found something interesting:

```fr.hs
foo :: [abc] -> [abc]
foo xs = xs
```

compiles to:

```java
final public static <abc> PreludeBase.TList<abc> foo(final PreludeBase.TList<abc> arg$1) {
  return arg$1;
}
```

I didn't used `-ascii` flag. So if a type variable in Frege is longer than 1 character, it is put into Java code as-is (except mangling symbols such as ticks).

This leads me thinking that as long as the generated gvars don't conflict with classes in Frege standard library, it's ok. Users of Frege can choose other type variables if ever they encontered conflicts.
