### PR TITLE
Compile regression tests in a dedicated directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ DOC                   = ../frege.github.com/doc
 BUILD                 = build
 BUILD7                = $(BUILD)7
 BUILD_TEST            = $(BUILD)/test
+BUILD_REGRESSION      = $(BUILD)/regression
 BUILD_FREGE           = $(BUILD)/frege
 BUILD_FREGE_COMPILER  = $(BUILD_FREGE)/compiler
 BUILD_FREGE_TOOLS     = $(BUILD_FREGE)/tools
@@ -164,10 +165,12 @@ test: compiler
 
 regression: 
 	@echo We assume we have a compiler.
-	$(JAVAC) -d $(BUILD) tests/comp/*.java
-	$(FREGECC) -make tests/comp/*.fr
+	$(RM) -rf $(BUILD_REGRESSION)
+	$(MKDIR)  $(BUILD_REGRESSION)
+	$(JAVAC)   -d $(BUILD_REGRESSION) tests/comp/*.java
+	$(FREGECC) -d $(BUILD_REGRESSION) -make tests/comp/*.fr
 	@echo Now we check whether all difficult code that had an issue earlier will still run
-	for i in `echo tests/comp/*.fr | sed 's/\//./g' | sed 's/\.fr//g'` ;do  echo; echo $$i -------------------;if $(JAVA) -cp build $$i ;then echo $$i OK; else echo $$i FAILED; exit 1;fi; done 
+	for i in `echo tests/comp/*.fr | sed 's/\//./g' | sed 's/\.fr//g'` ;do  echo; echo $$i -------------------;if $(JAVA) -cp $(BUILD_REGRESSION):$(BUILD) $$i ;then echo $$i OK; else echo $$i FAILED; exit 1;fi; done 
 
 # 	$(BUILD_FREGE_TOOLS)/Doc.class $(BUILD_FREGE_TOOLS)/YYgen.class $(BUILD_FREGE_TOOLS)/LexConvt.class
 tools: $(BUILD_FREGE_COMPILER)/Main.class


### PR DESCRIPTION
`make regression` re-compiles some classes for example `frege/runtime/Meta.class`.
Since in the `regression` target `-target` is not specified at fregec/javac, the classes are replaced with version 53.0 i.e. Java9 class files.

This commit avoids it by using a dedicated directory for the regression tests.