### PR TITLE
Change the native type File to pure native

### DIFF
--- a/frege/compiler/Classtools.fr
+++ b/frege/compiler/Classtools.fr
@@ -68,8 +68,8 @@ makeClassLoader pathelems  = do
     where 
         toURL :: String -> ST s URL
         toURL str = do
-            f <- File.new str
-            u <- readonly File.toURI f
+            let f = File.new str
+                u = File.toURI f
             case u.toURL of
               Right url -> return url
               Left exc  -> throwST exc

--- a/frege/compiler/Main.fr
+++ b/frege/compiler/Main.fr
@@ -303,8 +303,8 @@ openFilePrinter suffix = do
     g <- getSTT
     let target = targetPath g suffix
     pw <- liftIO do
-        file <- File.new target
-        parentFile <- file.getParentFile
+        let file = File.new target
+            parentFile = file.getParentFile
         case parentFile of
             Just dir ->  dir.mkdirs    -- make sure all directories are there
             Nothing -> return false
@@ -402,10 +402,10 @@ processDirs fs = concat <$> mapM process fs
     where
         process :: String -> StIO [Either (Pack, String) String]
         process f = do
-            file    <- liftIO $ File.new f
+            let file = File.new f
             regular <- liftIO $ file.isFile
             dir     <- liftIO $ file.isDirectory
-            absolute <- liftIO $ file.isAbsolute
+            let absolute = file.isAbsolute
             if regular then return [Right f]
             else if dir then liftIO $ fmap Right <$> walk file
             else do
@@ -447,12 +447,10 @@ processDirs fs = concat <$> mapM process fs
                                         
 --- check if argument is a file
 packfile :: String -> IO Bool
-packfile f = do
-    is <- File.new f
-    is.isFile
+packfile f = File.isFile $ File.new f
 
 --- walk a directory and return all Frege source files found.
-walk :: MutableIO File -> IO [String]
+walk :: File -> IO [String]
 walk file = do
     isd      <- file.isDirectory
     if isd
@@ -461,13 +459,13 @@ walk file = do
         case subfiles of
             Just files -> do
                 ls <- readonly toList files
-                let subwalk f = File.new file f >>= walk 
+                let subwalk f = walk $ File.new file f
                 concat <$> mapM subwalk ls
             Nothing    -> return []
     else do
         regular  <- file.isFile
         readable <- file.canRead
-        name     <- file.getPath
+        let name = file.getPath
         if regular && readable && name ~ ´\.fr$´
         then return [name]
         else return [] 
@@ -484,11 +482,10 @@ resolvePackSP g pack = do
 
 --- Look up a (relative) file name in source path
 resolveSP :: Global -> String -> IO (Maybe String)
-resolveSP g path = do 
-    paths <- mapM File.new g.options.sourcePath
-            >>= mapM (flip File.new path) 
-            >>= filterM _.isFile
-            >>= mapM    _.getPath
+resolveSP g path = do
+    paths <- pure . (map File.getPath)
+         <=< filterM File.isFile
+           $ map (flip File.new path . File.new) g.options.sourcePath
     return (listToMaybe paths)
 
  
@@ -811,7 +808,7 @@ makeone mvar tree (p, todo) = do
 
 --- Interpret the argument as path name and return the last modification time of the corresponding 'File'
 --- Should be 0 if the file doesn't exist.
-lastMod s = liftIO $ (File.new s >>= _.lastModified)                        
+lastMod s = liftIO $ File.lastModified $ File.new s
 
 --- The action that re-builds a source if needed 
 compileAfterDeps :: TodoList -> Global -> Maybe Pack -> StIO Todo

--- a/frege/compiler/common/CompilerOptions.fr
+++ b/frege/compiler/common/CompilerOptions.fr
@@ -256,7 +256,7 @@ scanOpts opts ("-d":xs)  | null xs || head xs ~ ´^-´ = do
     IO.stderr.println "option -d must be followed by a directory name."
     IO.return Nothing
 scanOpts opts ("-d":dir:args) = do
-    f     <- File.new dir
+    let f = File.new dir
     isdir <- f.isDirectory
     if isdir then do
             canRead <- f.canRead
@@ -279,7 +279,7 @@ scanOpts opts ("-sp":path:args) = do
     let ps = pathRE.splitted path
     let pschecked = map peCheck ps
         peCheck pe = do
-            f      <- File.new pe
+            let f = File.new pe
             exists <- f.exists
             readable <- f.canRead
             isdir  <- f.isDirectory
@@ -307,7 +307,7 @@ scanOpts opts ("-fp":path:args) = do
     let pschecked = map peCheck ps
         peCheck pe = do
             let isjar = String.toUpperCase pe ~ ´\.(ZIP|JAR)$´
-            f      <- File.new pe
+                f = File.new pe
             exists <- f.exists
             readable <- f.canRead
             isdir  <- f.isDirectory

--- a/frege/java/IO.fr
+++ b/frege/java/IO.fr
@@ -30,9 +30,9 @@ data OutputStream = native java.io.OutputStream
 data FileOutputStream = native java.io.FileOutputStream where
     --- > FileOutputStream.new file true 
     --- writes to the end of a file rather than the beginning
-    native new :: MutableIO File -> IOMutable FileOutputStream
+    native new :: File -> IOMutable FileOutputStream
                     throws FileNotFoundException
-                | MutableIO File -> Bool -> IOMutable FileOutputStream
+                | File -> Bool -> IOMutable FileOutputStream
                     throws FileNotFoundException
                 | String -> IOMutable FileOutputStream
                     throws FileNotFoundException
@@ -54,10 +54,11 @@ data Flushable = native java.io.Flushable where
 --- forward declaration of URI
 protected data URI = pure native java.net.URI
 
-data File = native java.io.File where
-    native new                :: String -> STMutable s File
-                              |  Mutable s File -> String -> STMutable s File
+data File = pure native java.io.File where
+    pure native new           :: String -> File
+                              |  File -> String -> File
     pure native toURI         :: File -> URI
+    --- warning: [deprecation] Use 'getPath' instead
     pure native getPathF  getPath    :: File -> String
     
     --- Separator for elements of a path name, i.e. "/" on Unix
@@ -67,30 +68,30 @@ data File = native java.io.File where
     pure native pathSeparator    java.io.File.pathSeparator
                               :: String
     --- The (relative) path name. Not necessarily valid.
-    native getPath       :: MutableIO File -> IO String
-    native getName       :: MutableIO File -> IO String
-    native canRead       :: MutableIO File -> IO Bool
-    native canWrite      :: MutableIO File -> IO Bool
-    native isAbsolute    :: MutableIO File -> IO Bool
-    native isDirectory   :: MutableIO File -> IO Bool
-    native isFile        :: MutableIO File -> IO Bool
-    native exists        :: MutableIO File -> IO Bool
-    native mkdirs        :: MutableIO File -> IO Bool
-    native delete        :: MutableIO File -> IO Bool
-    native renameTo      :: MutableIO File -> MutableIO File -> IO Bool
-    native lastModified  :: MutableIO File -> IO Long
-    native getParentFile :: MutableIO File -> IO (Maybe (MutableIO File))
-    native list          :: MutableIO File -> IO (Maybe (MutableIO (JArray String)))
+    pure native getPath       :: File -> String
+    pure native getName       :: File -> String
+    native canRead            :: File -> IO Bool
+    native canWrite           :: File -> IO Bool
+    pure native isAbsolute    :: File -> Bool
+    native isDirectory        :: File -> IO Bool
+    native isFile             :: File -> IO Bool
+    native exists             :: File -> IO Bool
+    native mkdirs             :: File -> IO Bool
+    native delete             :: File -> IO Bool
+    native renameTo           :: File -> File -> IO Bool
+    native lastModified       :: File -> IO Long
+    pure native getParentFile :: File -> Maybe File
+    native list               :: File -> IO (Maybe (MutableIO (JArray String)))
     --- Create an empty file in the default temp directory.
     --- > createTempFile "abc" ".suffix"
     --- The prefix must be at least 3 characters long!
     native createTempFile java.io.File.createTempFile
-                         :: String -> String -> IOMutable File
+                         :: String -> String -> IO File
                                                 throws IOException
 
 instance Serializable File
 
-instance Show File where show = File.getPathF
+instance Show File where show = File.getPath
 
 data Writer = native java.io.Writer where
     native write :: MutableIO Writer -> Int -> IO () throws IOException
@@ -120,8 +121,8 @@ data PrintWriter = native java.io.PrintWriter where
                     |  MutableIO PrintWriter -> String -> a -> b -> c -> d -> e -> f -> g -> h -> IO ()
                     |  MutableIO PrintWriter -> String -> a -> b -> c -> d -> e -> f -> g -> h -> i -> IO ()
     native new      :: String -> IOMutable PrintWriter throws FileNotFoundException
-                    |  MutableIO File -> IOMutable PrintWriter throws FileNotFoundException
-                    |  MutableIO File -> String -> IOMutable PrintWriter 
+                    |  File -> IOMutable PrintWriter throws FileNotFoundException
+                    |  File -> String -> IOMutable PrintWriter 
                                 throws FileNotFoundException, UnsupportedEncodingException
                     |  MutableIO Writer -> IOMutable PrintWriter
                     |  MutableIO Writer -> Bool -> IOMutable PrintWriter
@@ -175,7 +176,7 @@ data StringWriter = native java.io.StringWriter where
 data InputStream = native java.io.InputStream
 
 data FileInputStream = native java.io.FileInputStream where
-    native new :: MutableIO File -> IOMutable FileInputStream 
+    native new :: File -> IOMutable FileInputStream 
                     throws FileNotFoundException
                 | String  -> IOMutable FileInputStream 
                     throws FileNotFoundException
@@ -253,7 +254,7 @@ openReader fileName = do
     -}
 openWriter :: String -> IOMutable PrintWriter
 openWriter fileName = do
-    file <- File.new fileName
+    let file = File.new fileName
     PrintWriter.new file "UTF-8"
 
 {--

--- a/frege/java/Util.fr
+++ b/frege/java/Util.fr
@@ -141,7 +141,7 @@ instance Serializable (AbstractMapSimpleImmutableEntry k v)
 
 -- forward declarations, we don't want to import java.io here
 protected data Reader = native java.io.Reader
-protected data File   = native java.io.File
+protected data File   = pure native java.io.File
 protected data FileNotFoundException = pure native java.io.FileNotFoundException
 
 {--
@@ -404,15 +404,15 @@ data AbstractSequentialList e = native java.util.AbstractSequentialList where
 -}
 data Formatter = native java.util.Formatter where
 
-  native new :: MutableIO File -> String -> IOMutable Formatter throws FileNotFoundException, UnsupportedEncodingException
-              | MutableIO File -> IOMutable Formatter throws FileNotFoundException
+  native new :: File -> String -> IOMutable Formatter throws FileNotFoundException, UnsupportedEncodingException
+              | File -> IOMutable Formatter throws FileNotFoundException
               | String -> String -> Locale -> STMutable s Formatter throws FileNotFoundException, UnsupportedEncodingException
               | String -> String -> STMutable s Formatter throws FileNotFoundException, UnsupportedEncodingException
               | String -> STMutable s Formatter throws FileNotFoundException
               | MutableIO OutputStream -> String -> IOMutable Formatter throws UnsupportedEncodingException
               | MutableIO OutputStream -> IOMutable Formatter
               | MutableIO PrintStream -> IOMutable Formatter
-              | MutableIO File -> String -> Locale -> IOMutable Formatter throws FileNotFoundException, UnsupportedEncodingException
+              | File -> String -> Locale -> IOMutable Formatter throws FileNotFoundException, UnsupportedEncodingException
               | () -> STMutable s Formatter
               | MutableIO OutputStream -> String -> Locale -> IOMutable Formatter throws UnsupportedEncodingException
               | Mutable s Appendable -> Locale -> STMutable s Formatter
@@ -1239,8 +1239,8 @@ data Scanner = native java.util.Scanner where
               | Mutable s Readable -> STMutable s Scanner
               -- MutableIO Reader -> IOMutable Scanner
               | MutableIO InputStream -> String -> IOMutable Scanner
-              | Mutable s File -> String -> STMutable s Scanner throws FileNotFoundException
-              | Mutable s File -> STMutable s Scanner throws FileNotFoundException
+              | File -> String -> STMutable s Scanner throws FileNotFoundException
+              | File -> STMutable s Scanner throws FileNotFoundException
               | String -> STMutable s Scanner
               | Mutable s ReadableByteChannel -> STMutable s Scanner
               | Mutable s ReadableByteChannel -> String -> STMutable s Scanner

--- a/frege/java/lang/Processes.fr
+++ b/frege/java/lang/Processes.fr
@@ -72,7 +72,7 @@ data  Process = native java.lang.Process where
     native exec "java.lang.Runtime.getRuntime().exec" 
             :: ArrayOf RealWorld String             -- command 
                -> Maybe (ArrayOf RealWorld String)  -- environment
-               -> Maybe (MutableIO File)            -- working directory
+               -> Maybe File                        -- working directory
                -> IOMutable Process                        -- result
                 throws IOException               
             |  String -> IOMutable Process                 -- poor mans exec
@@ -206,17 +206,17 @@ data Redirect = native java.lang.ProcessBuilder.Redirect where
     native inherit "java.lang.ProcessBuilder.Redirect.INHERIT" :: MutableIO Redirect
     
     --- Returns the 'File' source or destination associated with this redirect, or null if there is no such file.
-    native file :: MutableIO Redirect -> IO (Maybe (MutableIO File))
+    native file :: MutableIO Redirect -> IO (Maybe File)
     
     --- Redirect to read from the specified 'File'.
-    native from java.lang.ProcessBuilder.Redirect.from :: MutableIO File -> IOMutable Redirect
+    native from java.lang.ProcessBuilder.Redirect.from :: File -> IOMutable Redirect
     
     --- Redirect to write to the specified file, discarding previous content, if any.
-    native to java.lang.ProcessBuilder.Redirect.to :: MutableIO File -> IOMutable Redirect
+    native to java.lang.ProcessBuilder.Redirect.to :: File -> IOMutable Redirect
     
     --- Redirect to append to the specified file.
     --- Each write operation first advances the position to the end of the file and then writes the requested data.
-    native appendTo java.lang.ProcessBuilder.Redirect.appendTo :: MutableIO File -> IOMutable Redirect
+    native appendTo java.lang.ProcessBuilder.Redirect.appendTo :: File -> IOMutable Redirect
       
 {--
     The 'ProcessBuilder' type is used to create operating system processes.
@@ -305,7 +305,7 @@ data ProcessBuilder = native java.lang.ProcessBuilder where
     new xs = JArray.genericFromList xs >>= newFromArray
     
     ---  set the working directory
-    native directory :: MutableIO ProcessBuilder -> MutableIO File -> IOMutable ProcessBuilder
+    native directory :: MutableIO ProcessBuilder -> File -> IOMutable ProcessBuilder
     
     --- inherit the standard input, output and error from the current process
     native inheritIO :: MutableIO ProcessBuilder -> IOMutable ProcessBuilder
@@ -320,14 +320,14 @@ data ProcessBuilder = native java.lang.ProcessBuilder where
     --- redirect standard input
     native redirectInput 
             :: MutableIO ProcessBuilder -> MutableIO Redirect -> IOMutable ProcessBuilder
-            |  MutableIO ProcessBuilder -> MutableIO File -> IOMutable ProcessBuilder
+            |  MutableIO ProcessBuilder -> File -> IOMutable ProcessBuilder
     
     --- redirect standard output
     native redirectOutput 
             :: MutableIO ProcessBuilder -> MutableIO Redirect -> IOMutable ProcessBuilder
-            |  MutableIO ProcessBuilder -> MutableIO File -> IOMutable ProcessBuilder
+            |  MutableIO ProcessBuilder -> File -> IOMutable ProcessBuilder
     
     --- redirect standard error
     native redirectError 
             :: MutableIO ProcessBuilder -> MutableIO Redirect -> IOMutable ProcessBuilder
-            |  MutableIO ProcessBuilder -> MutableIO File -> IOMutable ProcessBuilder
+            |  MutableIO ProcessBuilder -> File -> IOMutable ProcessBuilder

--- a/frege/java/util/Jar.fr
+++ b/frege/java/util/Jar.fr
@@ -6,7 +6,7 @@ import Java.Util(Enumeration, Set)
 import Java.util.Zip(ZipEntry, ZipFile)
 
 data JarFile = native java.util.jar.JarFile where
-    native new              ∷ MutableIO File -> IOMutable JarFile 
+    native new              ∷ File -> IOMutable JarFile 
                                 throws IOException
     native entries          ∷ MutableIO JarFile -> IOMutable (Enumeration JarEntry)
     --- get the 'JarEntry' for the specified name, or 'Nothing' if not found.

--- a/frege/java/util/Zip.fr
+++ b/frege/java/util/Zip.fr
@@ -9,7 +9,7 @@ derive Exceptional ZipException
 
 
 data ZipFile = native java.util.zip.ZipFile where
-    native new     :: MutableIO File -> IOMutable ZipFile throws ZipException, IOException
+    native new     :: File -> IOMutable ZipFile throws ZipException, IOException
     native entries' entries :: MutableIO ZipFile -> IOMutable (Enumeration (extends (MutableIO ZipEntry)))
     entries ∷ MutableIO ZipFile → IOMutable (Enumeration (MutableIO ZipEntry))
     entries zip = zip.entries'

--- a/frege/lib/Modules.fr
+++ b/frege/lib/Modules.fr
@@ -71,12 +71,12 @@ classPath = (pathRE.splitted • fromMaybe "." • System.getProperty) "java.cla
     Ignores 'ClassNotFoundException's and the strange 'Error's
     that can happen during class loading.  
     -}
-dirWalk :: MutableIO ClassLoader -> String -> MutableIO File -> IO [(String, String)]
+dirWalk :: MutableIO ClassLoader -> String -> File -> IO [(String, String)]
 dirWalk loader sofar file = do
     isd  <- file.isDirectory
     isf  <- file.isFile
-    name <- file.getName
-    let subof "" x = x
+    let name = file.getName
+        subof "" x = x
         subof a  x = a ++ "." ++ x
     if isf 
     then do
@@ -93,7 +93,7 @@ dirWalk loader sofar file = do
                 Nothing    -> return []
                 Just files -> do
                     ls <- readonly toList files
-                    let subwalk f = File.new file f >>= dirWalk loader (subof sofar f)
+                    let subwalk f = dirWalk loader (subof sofar f) $ File.new file f
                     mapM subwalk ls >>= return . concat 
         else return []
 
@@ -101,7 +101,7 @@ dirWalk loader sofar file = do
 --- If the argument is neither a directory nor a ZIP/JAR file, an empty list is returned.
 walkThing arg = do
         loader  <- CT.makeClassLoader [arg]
-        what    <- File.new arg
+        let what = File.new arg
         isdir   <- what.isDirectory
         if isdir 
             then dirWalk loader "" what

--- a/frege/tools/Doc.fr
+++ b/frege/tools/Doc.fr
@@ -124,7 +124,7 @@ main args = do
 scanOpts :: DocOpts -> [String] -> IO (Maybe (DocOpts, [String]))
 scanOpts opt [] = usage >> (return $ Just (opt, []))
 scanOpts opt ("-d" : docdir : rest) = do
-    dd <- File.new docdir
+    let dd = File.new docdir
     dir <- dd.isDirectory
     wri <- dd.canWrite
     if dir
@@ -146,7 +146,7 @@ scanOpts opts ("-cp":path:args) = do
     let pschecked = map peCheck ps
         peCheck pe = do
             let isjar = String.toUpperCase pe ~ ´\.(ZIP|JAR)$´
-            f      <- File.new pe
+                f = File.new pe
             exists <- f.exists
             readable <- f.canRead
             isdir  <- f.isDirectory
@@ -202,7 +202,7 @@ usage = mapM_ stderr.println [
     
 docThing :: Global -> String -> IO [Global]
 docThing global arg = do
-    f <- File.new arg
+    let f = File.new arg
     directory <- f.isDirectory
     regular   <- f.isFile
     
@@ -220,7 +220,7 @@ docThing global arg = do
             (_, g) <- StIO.run (work arg) global
             return [g]
 
-docArch :: Global -> MutableIO File ->  IO [Global]
+docArch :: Global -> File ->  IO [Global]
 docArch opts f = do
         j <- ZipFile.new f 
         ns <- j.entries
@@ -244,7 +244,7 @@ docArch opts f = do
             withoutClass = path.replaceFirst ´\.class$´ ""
     zipex :: ZipException -> IO [Global]
     zipex zex = do
-        path <- f.getName
+        let path = f.getName
         stderr.println zex.show
         stderr.println ("(is " ++ path ++ " not a valid ZIP or JAR file?)")
         return []
@@ -253,9 +253,9 @@ docArch opts f = do
         stderr.println iox.show
         return []            
                                     
-docDir :: Global -> MutableIO File -> [String] -> IO [Global]
+docDir :: Global -> File -> [String] -> IO [Global]
 docDir opts f pcs = do
-    name <- f.getPath
+    -- let name = f.getPath
     -- stderr.println ("Entering " ++ name)
     mbcontent <- f.list
     case mbcontent of
@@ -266,9 +266,9 @@ docDir opts f pcs = do
             return (concat globs)
     
 
-docDirEntry :: Global -> MutableIO File -> [String] -> String -> IO [Global]
+docDirEntry :: Global -> File -> [String] -> String -> IO [Global]
 docDirEntry opts f pcs ent = do
-    f <- File.new f ent
+    let f = File.new f ent
     directory <- f.isDirectory
     regular   <- f.isFile
     if directory then do

--- a/frege/tools/MakeDocIndex.fr
+++ b/frege/tools/MakeDocIndex.fr
@@ -29,7 +29,7 @@ private metahtml = ["fregedoc.html", "prefix-frame.html", "index.html",
 --- walk a directory and get all HTML files
 findHtml ∷ String → IO [(String, String)]
 findHtml dir = do
-        fdir ← File.new dir
+        let fdir = File.new dir
         walk [] fdir  
     where
         -- strip leading "dir" and path separators from path
@@ -40,7 +40,7 @@ findHtml dir = do
             else s 
         makeslashy s = if File.separator == "/" then s
             else s.replaceAll separatorRE "/"
-        walk ∷ [(String, String)] → MutableIO File → IO [(String, String)]
+        walk ∷ [(String, String)] → File → IO [(String, String)]
         walk acc fd = do
             isdir ← fd.isDirectory
             if isdir then do
@@ -48,11 +48,11 @@ findHtml dir = do
                 case subfiles of
                     Nothing     = return acc
                     Just array  = readonly _.toList array
-                                    >>= mapM (File.new fd)
+                                    >>= pure . map (File.new fd)
                                     >>= foldM walk acc
             else do
-                p ← fd.getParentFile >>= maybe (return "") _.getPath
-                n ← fd.getName
+                let p = maybe "" _.getPath $ fd.getParentFile
+                    n = fd.getName
                 -- stderr.print (show (p, n))
                 if  not (isMeta n) && n ~ htmlAtEnd
                 then do
@@ -126,20 +126,20 @@ printFregeDoc doc  = do
                 lines  ← InputStreamReader.new stream "UTF-8"  
                         >>= BufferedReader.new
                         >>= _.getLines
-                p   ← fileIn doc "fregedoc.html" >>= openWriter
+                p   ← openWriter $ fileIn doc "fregedoc.html"
                 mapM_ p.println lines
                 p.close
 
 --- compute the path of a file in a certain directory
-fileIn :: String → String → IO String
-fileIn dir f = do
-    d   ← File.new dir
-    f   ← File.new d f
-    f.getPath
+fileIn :: String -> String -> String
+fileIn dir f =
+    let d = File.new dir
+        f' = File.new d f
+    in f'.getPath
 
 --- make the @prefix-frame.html@ file
 makePrefixFrame doc paths = do
-    p   ← fileIn doc "prefix-frame.html" >>= openWriter
+    p   ← openWriter $ fileIn doc "prefix-frame.html"
     let frames = map (wrap "li" . frameElem) paths
         ul     = wrap "ul" (joined "\n" frames)
     mapM_ p.println [
@@ -161,7 +161,7 @@ makePrefixFrame doc paths = do
 
 makeFrame :: String -> String -> [(String, String)] -> IO ()
 makeFrame doc prefix elems = do
-    p   ← fileIn doc (prefixFrame prefix) >>= openWriter
+    p   ← openWriter $ fileIn doc (prefixFrame prefix)
     let links  = map (wrap "li" . uncurry linkElem) elems
         ul     = wrap "ul" (joined "\n" links)
     mapM_ p.println [

--- a/frege/tools/Quick.fr
+++ b/frege/tools/Quick.fr
@@ -168,7 +168,7 @@ getOpt options xs = return (options, xs)
 
 checkThing :: Options -> String -> IO Counter
 checkThing opts arg = do
-    f <- File.new arg
+    let f = File.new arg
     directory <- f.isDirectory
     regular   <- f.isFile
     

--- a/frege/tools/Splitter.fr
+++ b/frege/tools/Splitter.fr
@@ -236,7 +236,7 @@ split args = do
                         dotP.waitFor
                         let browsercmd = fromMaybe "google-chrome" (System.getProperty "browser")
                             browser = ´\s+´.splitted browsercmd
-                        svg       <- tmp.getPath
+                            svg = tmp.getPath
                         browserPB <- ProcessBuilder.new (browser ++ [svg])
                         browserPB <- browserPB.inheritIO
                         browserP  <- browserPB.start
@@ -336,7 +336,7 @@ newMod :: Global -> String -> IOMutable PrintWriter
 newMod g pack = do
     let target = targetPath g pack ".fr"
     stderr.println ("target is " ++ target)
-    parent <- File.new target >>= _.getParentFile
+    let parent = File.getParentFile $ File.new target
     case parent of
         Just dir ->  dir.mkdirs    -- make sure all directories are there
         Nothing  ->  return false
@@ -345,12 +345,12 @@ newMod g pack = do
 appMod :: Global -> String -> IOMutable PrintWriter
 appMod g pack = do
     let target = targetPath g pack ".fr"
-    f <- File.new target
+        f = File.new target
     neu <- not <$> f.exists
     if neu
     then stderr.println ("creating new " ++ target)
     else stderr.println ("appending to " ++ target)
-    parent <- f.getParentFile
+    let parent = f.getParentFile
     case parent of
         Just dir ->  dir.mkdirs    -- make sure all directories are there
         Nothing  ->  return false

--- a/frege/tools/YYgen.fr
+++ b/frege/tools/YYgen.fr
@@ -932,7 +932,7 @@ cantwrite s fex = do
 ;
 
 mainIO monadic file = do
-        newFile <- File.new file
+        let newFile = File.new file
         stdout <- PrintWriter.new newFile "UTF-8" 
         tlines <- fileContent "y.tab.c"
         olines <- fileContent "y.output"

--- a/frege/tools/doc/Utilities.fr
+++ b/frege/tools/doc/Utilities.fr
@@ -593,9 +593,9 @@ packToFileRef p g = do
         let target = g.options.dir ++ "/"
                     ++ packToFile (g.unpack g.thisPack) ".html"
         
-        ftarg  <- File.new target
-        parent <- ftarg.getParentFile
-        dpfFile <- File.new dpf
+        let ftarg = File.new target
+            parent = ftarg.getParentFile
+            dpfFile = File.new dpf
         rawdir <- relPath parent (Just dpfFile)
         let cooked = substituteAll rawdir ´/\./´ "/"
         return cooked
@@ -609,20 +609,20 @@ packToFileRef p g = do
  * > relPath "foo"   "foo/x.html"  == "."
  * > relPath "foo"   "bar/z.html"  == "../foo"
  -}
-relPath :: Maybe (MutableIO File) -> Maybe (MutableIO File) -> IO String
+relPath :: Maybe File -> Maybe File -> IO String
 relPath (dir@Just d) (file@Just f) = do
     isfile <- f.isFile
     -- stderr << "relPath: " << d.getPath << " and " << f.getPath << " file=" << isfile << "\n";
     if isfile
         then do
-            p  <- f.getParentFile
+            let p = f.getParentFile
             up <- relPath dir p
             -- stderr << "result: " << up ++ "/" ++ getName f << "\n";
-            name <- f.getName
+            let name = f.getName
             IO.return (up ++ "/" ++ name)
         else do
-            dpath <- d.getPath
-            fpath <- f.getPath
+            let dpath = d.getPath
+                fpath = f.getPath
             if dpath == fpath
                 then IO.return "."
                 else do
@@ -631,8 +631,8 @@ relPath (dir@Just d) (file@Just f) = do
                     let common = [ x | x <- dps, x `elem` fps ]
                     case common of
                         [] -> do
-                            dpath <- d.getPath
-                            fpath <- f.getPath
+                            -- let dpath = d.getPath
+                            --     fpath = f.getPath
                             -- stderr << dpath << " and " << fpath << " have no common parent.\n"
                             IO.return "."
                         (p:_) -> do
@@ -644,27 +644,27 @@ relPath (dir@Just d) (file@Just f) = do
   where
         parents Nothing = IO.return []
         parents (Just f) = do
-                parent <- File.getParentFile f
+                let parent = File.getParentFile f
                 ps     <- parents parent
-                path   <- File.getPath f
+                let path   = File.getPath f
                 IO.return (path : ps)
 
         upsteps p (Just d) = do
-                path <- File.getPath d
+                let path = File.getPath d
                 if p == path then IO.return "." else do
-                    parent <- File.getParentFile d
+                    let parent = File.getParentFile d
                     upp    <- upsteps p parent
                     IO.return  ("../" ++ upp)
         upsteps p _ = error "upsteps _ Nothing"
 
         toCommon p (Just f) = do
-            path <- File.getPath f
+            let path = File.getPath f
             -- stderr << "toCommon: " << p << " and " << File.getPath f << "\n"
             if (path == p) then IO.return "."
               else do
-                parent <- File.getParentFile f
+                let parent = File.getParentFile f
                 x <- toCommon p parent
-                name <- File.getName f
+                let name = File.getName f
                 IO.return (if x == "." then name else x ++ "/" ++ name)
         toCommon p Nothing = error ("Can't reach common dir " ++ p)
 relPath _ _ = error "relPath: both args must be Just"

--- a/tests/comp/TDNR.fr
+++ b/tests/comp/TDNR.fr
@@ -4,15 +4,16 @@ module tests.comp.TDNR where
 import Java.Net(URI, URL)
 
  
-x =  _.startsWith "/" <$> (File.new "/tmp" >>= _.getPath)
+x =  _.startsWith "/" $ _.getPath $ File.new "/tmp"
 
 
-y =  _.toURL <$> (File.new "/tmp" >>= readonly _.toURI)             -- didn't
+y =  _.toURL $ _.toURI $ File.new "/tmp"
+    -- _.toURL <$> (File.new "/tmp" >>= readonly _.toURI)           -- before changing File to pure
     -- (File.new "/tmp" >>= readonly _.toURI >>= pure . _.toURL)    -- did typecheck before 3.25.49
                                                                     -- clearly showing left-right bias
 
 main :: IO Bool
 main = do 
-    x >>= println 
-    y >>= println . either Throwable.show _.toString
+    println x
+    println . either Throwable.show _.toString $ y
     pure true


### PR DESCRIPTION
The native data type `java.IO.File` is now declared `pure native`.

Resolves #367 