### PR TITLE
Change Input/OutputStream and "finally" to ST

### DIFF
--- a/frege/java/IO.fr
+++ b/frege/java/IO.fr
@@ -5,6 +5,7 @@
 protected package frege.java.IO where
 
 import frege.java.Lang public(IOException, PrintStream)
+import frege.java.Lang as Lang' (Byte, Exception) -- private imports
 import frege.prelude.PreludeBase
 import frege.prelude.PreludeIO
 import frege.prelude.PreludeText
@@ -24,7 +25,10 @@ derive Exceptional EOFException
 
 
 --- frege equivalent of @java.io.OutputStream@
-data OutputStream = native java.io.OutputStream
+data OutputStream = native java.io.OutputStream where
+    native write :: Mutable s OutputStream -> ArrayOf s Byte -> ST s () throws IOException
+                  | Mutable s OutputStream -> ArrayOf s Byte -> Int -> Int -> ST s () throws IOException
+                  | Mutable s OutputStream -> Int -> ST s () throws IOException
 
 --- frege equivalent of @java.io.FileOutputStream@
 data FileOutputStream = native java.io.FileOutputStream where
@@ -41,7 +45,10 @@ data FileOutputStream = native java.io.FileOutputStream where
     --- Writes the specified *byte* to this file output stream.  
     native write :: MutableIO FileOutputStream -> Int -> IO ()
                     throws IOException
-                                                
+
+--- frege equivalent of @java.lang.AutoCloseable@
+data AutoCloseable = native java.lang.AutoCloseable where
+    native close :: Mutable s AutoCloseable -> ST s () throws Exception
 
 --- frege equivalent of @java.io.Closeable@
 data Closeable = native java.io.Closeable where
@@ -124,6 +131,8 @@ data PrintWriter = native java.io.PrintWriter where
                     |  File -> IOMutable PrintWriter throws FileNotFoundException
                     |  File -> String -> IOMutable PrintWriter 
                                 throws FileNotFoundException, UnsupportedEncodingException
+                    |  Mutable s OutputStream -> STMutable s PrintWriter
+                    |  Mutable s OutputStream -> Bool -> STMutable s PrintWriter
                     |  Mutable s Writer -> STMutable s PrintWriter
                     |  Mutable s Writer -> Bool -> STMutable s PrintWriter
 
@@ -173,7 +182,15 @@ data StringWriter = native java.io.StringWriter where
 -- Input Streams & Readers
 -- ----------------------------------------------------------------------------
 
-data InputStream = native java.io.InputStream
+data InputStream = native java.io.InputStream where
+    native available :: Mutable s InputStream -> ST s Int throws IOException
+    native mark :: Mutable s InputStream -> Int -> ST s ()
+    native markSupported :: Mutable s InputStream -> ST s Bool
+    native read :: Mutable s InputStream -> ST s Int throws IOException
+                 | Mutable s InputStream -> ArrayOf s Byte -> ST s Int throws IOException
+                 | Mutable s InputStream -> ArrayOf s Byte -> Int -> Int -> ST s Int throws IOException
+    native reset :: Mutable s InputStream -> ST s () throws IOException
+    native skip :: Mutable s InputStream -> Long -> ST s Long throws IOException
 
 data FileInputStream = native java.io.FileInputStream where
     native new :: File -> IOMutable FileInputStream 
@@ -182,6 +199,8 @@ data FileInputStream = native java.io.FileInputStream where
                     throws FileNotFoundException
 
 data Reader = native java.io.Reader where
+    native mark :: Mutable s Reader -> Int -> ST s () throws IOException
+    native markSupported :: Mutable s Reader -> ST s Bool
     {--
         Reads a single character and returns it as 'Int' in the range 0 to 65535.
         Returns -1 if the end of the stream has been reached.
@@ -189,7 +208,12 @@ data Reader = native java.io.Reader where
         Throws 'IOException' if an I/O error occurs.
     -}
     native read :: Mutable s Reader -> ST s Int throws IOException
-    
+                 | Mutable s Reader -> ArrayOf s Char -> ST s Int throws IOException
+                 | Mutable s Reader -> ArrayOf s Char -> Int -> Int -> ST s Int throws IOException
+    native ready :: Mutable s Reader -> ST s Bool throws IOException
+    native reset :: Mutable s Reader -> ST s () throws IOException
+    native skip :: Mutable s Reader -> Long -> ST s Long throws IOException
+
     {--
         Read the next character from the input stream.
         Throws 'EOFException' if the end of the stream has been reached, or 'IOException' if

--- a/frege/java/IO.fr
+++ b/frege/java/IO.fr
@@ -44,12 +44,12 @@ data FileOutputStream = native java.io.FileOutputStream where
                                                 
 
 --- frege equivalent of @java.io.Closeable@
-data Closeable = native java.io.Closeable where    
-    native close :: MutableIO Closeable -> IO () throws IOException
+data Closeable = native java.io.Closeable where
+    native close :: Mutable s Closeable -> ST s () throws IOException
 
 --- frege equivalent of @java.io.Flushable@
 data Flushable = native java.io.Flushable where
-    native flush :: MutableIO Flushable -> IO () throws IOException
+    native flush :: Mutable s Flushable -> ST s () throws IOException
 
 --- forward declaration of URI
 protected data URI = pure native java.net.URI
@@ -94,38 +94,38 @@ instance Serializable File
 instance Show File where show = File.getPath
 
 data Writer = native java.io.Writer where
-    native write :: MutableIO Writer -> Int -> IO () throws IOException
-                 |  MutableIO Writer -> String -> IO () throws IOException
-                 |  MutableIO Writer -> String -> Int -> Int -> IO () throws IOException
-    putChar :: MutableIO Writer -> Char -> IO ()
+    native write :: Mutable s Writer -> Int -> ST s () throws IOException
+                 |  Mutable s Writer -> String -> ST s () throws IOException
+                 |  Mutable s Writer -> String -> Int -> Int -> ST s () throws IOException
+    putChar :: Mutable s Writer -> Char -> ST s ()
     putChar w c = write w (ord c)
 
 data OutputStreamWriter = native java.io.OutputStreamWriter where
-    native new :: MutableIO OutputStream -> String -> IOMutable OutputStreamWriter
+    native new :: Mutable s OutputStream -> String -> STMutable s OutputStreamWriter
                                 throws UnsupportedEncodingException
 
 data PrintWriter = native java.io.PrintWriter where
     --- print a 'String'
-    native print    :: MutableIO PrintWriter -> String -> IO ()
+    native print    :: Mutable s PrintWriter -> String -> ST s ()
     --- print a 'String' followed by a line terminator, or just a line terminator
-    native println  :: MutableIO PrintWriter -> String -> IO ()
-                    |  MutableIO PrintWriter -> IO ()
+    native println  :: Mutable s PrintWriter -> String -> ST s ()
+                    |  Mutable s PrintWriter -> ST s ()
     --- format and print 1 to 9 values, see 'String.format' 
-    native printf{} :: MutableIO PrintWriter -> String -> a -> IO ()
-                    |  MutableIO PrintWriter -> String -> a -> b -> IO ()
-                    |  MutableIO PrintWriter -> String -> a -> b -> c -> IO ()
-                    |  MutableIO PrintWriter -> String -> a -> b -> c -> d -> IO ()
-                    |  MutableIO PrintWriter -> String -> a -> b -> c -> d -> e -> IO ()
-                    |  MutableIO PrintWriter -> String -> a -> b -> c -> d -> e -> f -> IO ()
-                    |  MutableIO PrintWriter -> String -> a -> b -> c -> d -> e -> f -> g -> IO ()
-                    |  MutableIO PrintWriter -> String -> a -> b -> c -> d -> e -> f -> g -> h -> IO ()
-                    |  MutableIO PrintWriter -> String -> a -> b -> c -> d -> e -> f -> g -> h -> i -> IO ()
+    native printf{} :: Mutable s PrintWriter -> String -> a -> ST s ()
+                    |  Mutable s PrintWriter -> String -> a -> b -> ST s ()
+                    |  Mutable s PrintWriter -> String -> a -> b -> c -> ST s ()
+                    |  Mutable s PrintWriter -> String -> a -> b -> c -> d -> ST s ()
+                    |  Mutable s PrintWriter -> String -> a -> b -> c -> d -> e -> ST s ()
+                    |  Mutable s PrintWriter -> String -> a -> b -> c -> d -> e -> f -> ST s ()
+                    |  Mutable s PrintWriter -> String -> a -> b -> c -> d -> e -> f -> g -> ST s ()
+                    |  Mutable s PrintWriter -> String -> a -> b -> c -> d -> e -> f -> g -> h -> ST s ()
+                    |  Mutable s PrintWriter -> String -> a -> b -> c -> d -> e -> f -> g -> h -> i -> ST s ()
     native new      :: String -> IOMutable PrintWriter throws FileNotFoundException
                     |  File -> IOMutable PrintWriter throws FileNotFoundException
                     |  File -> String -> IOMutable PrintWriter 
                                 throws FileNotFoundException, UnsupportedEncodingException
-                    |  MutableIO Writer -> IOMutable PrintWriter
-                    |  MutableIO Writer -> Bool -> IOMutable PrintWriter
+                    |  Mutable s Writer -> STMutable s PrintWriter
+                    |  Mutable s Writer -> Bool -> STMutable s PrintWriter
 
 --- nowarn: Don't warn because of constantness
 --- The standard output 'PrintWriter'
@@ -165,7 +165,7 @@ data StringWriter = native java.io.StringWriter where
     --- get the content of a 'StringWriter' as 'String'    
     native toString :: Mutable s StringWriter -> ST s String
     --- make a 'PrintWriter' that prints to this 'StringWriter'
-    printer :: MutableIO StringWriter -> IOMutable PrintWriter
+    printer :: Mutable s StringWriter -> STMutable s PrintWriter
     printer this = PrintWriter.new this -- IOMut PrintWriter
 
             
@@ -188,24 +188,24 @@ data Reader = native java.io.Reader where
         
         Throws 'IOException' if an I/O error occurs.
     -}
-    native read :: MutableIO Reader -> IO Int throws IOException
+    native read :: Mutable s Reader -> ST s Int throws IOException
     
     {--
         Read the next character from the input stream.
         Throws 'EOFException' if the end of the stream has been reached, or 'IOException' if
         an I/O error occurs.
     -}
-    getChar :: MutableIO Reader -> IO Char
+    getChar :: Mutable s Reader -> ST s Char
     getChar rdr = do
         i <- rdr.read
-        if i < 0 then throwIO (EOFException.new "getChar") else return (chr i) 
+        if i < 0 then throwST (EOFException.new "getChar") else return (chr i)
 
 data InputStreamReader = native java.io.InputStreamReader where
-    native new :: MutableIO InputStream -> String -> IOMutable InputStreamReader
+    native new :: Mutable s InputStream -> String -> STMutable s InputStreamReader
                     throws UnsupportedEncodingException
     
 data BufferedReader = native java.io.BufferedReader where
-    native new :: MutableIO Reader -> IOMutable BufferedReader
+    native new :: Mutable s Reader -> STMutable s BufferedReader
     {--
         Reads a line of text. A line is considered to be terminated 
         by any one of a line feed ("\n"), a carriage return ("\r"), 
@@ -217,10 +217,10 @@ data BufferedReader = native java.io.BufferedReader where
 
         [Throws:] IOException - If an I/O error occurs
     -}
-    native readLine :: MutableIO BufferedReader -> IO (Maybe String)
+    native readLine :: Mutable s BufferedReader -> ST s (Maybe String)
                     throws IOException
     --- read all lines and return them as list, close reader afterwards
-    getLines :: MutableIO BufferedReader -> IO [String]
+    getLines :: Mutable s BufferedReader -> ST s [String]
     getLines br = go []  where
         go acc = do
             xms <- br.readLine
@@ -232,8 +232,8 @@ data BufferedReader = native java.io.BufferedReader where
         Reads the next line from a buffered reader using 'BufferedReader.readLine', 
         and returns the string or throws 'EOFException' on end of file. 
         -}       
-    getLine :: MutableIO BufferedReader -> IO String
-    getLine br = readLine br >>= maybe (throwIO (EOFException.new "getLine")) return
+    getLine :: Mutable s BufferedReader -> ST s String
+    getLine br = readLine br >>= maybe (throwST (EOFException.new "getLine")) return
     
 
 {-- 

--- a/frege/prelude/PreludeBase.fr
+++ b/frege/prelude/PreludeBase.fr
@@ -2188,18 +2188,20 @@ native module where {
         }
 
         /**
-         * <p>Run an IO action but make sure another one is run, even if the first one
+         * <p>Run an ST action but make sure another one is run, even if the first one
          * is interrupted.</p>
          */
-        public static<A,B> A doFinally(
-                Func.U<frege.runtime.Phantom.RealWorld,A> result, 
-                Func.U<frege.runtime.Phantom.RealWorld,B> after) {
+        public static<S,A,B> A doFinally(
+                Func.U<S,A> result,
+                Func.U<S,B> after) {
             final A r;
             try {
-                r = PreludeBase.TST.performUnsafe(result).call();
+                final Func.U<Object,A> ia = RunTM.<Func.U<Object,A>>cast(result);
+                r = PreludeBase.TST.<A>run(ia).call();
             }
             finally  {
-                final B b = PreludeBase.TST.performUnsafe(after).call();
+                final Func.U<Object,B> ib = RunTM.<Func.U<Object,B>>cast(after);
+                final B b = PreludeBase.TST.<B>run(ib).call();
             }
             return r;
         }

--- a/frege/prelude/PreludeIO.fr
+++ b/frege/prelude/PreludeIO.fr
@@ -294,28 +294,14 @@ readonly  = Mutable.readonly
 mutable x = Mutable.Mutable x
  
 
---- They type for mostly mutable values that are tied to the 'IO' monad.
-{--
-    For java types that are *mutable only* so that they always would occur 
-    wrapped into 'MutableIO', the convention is to
-    declare them as
-    
-    > data Thing = mutable native org.mut.impure.Thing
-    
-    and just write @Thing@ everywhere.
-    The type checker will check the rules for native functions  
-    _as if_ @Thing@ was 'MutableIO' @Thing@.
-    
-    However, normal type unification does not take the mutable status into account, so
-    @Mutable a m@ will never unify with @Thing@. 
-    -}
+--- The type for mostly mutable values that are tied to the 'IO' monad.
 type MutableIO = Mutable RealWorld
 
---- They type of 'IO' actions that return a mutable value of type _d_
+--- The type of 'IO' actions that return a mutable value of type _d_
 --- This is an abbreviation for @ST RealWorld (Mutable RealWorld d)@ 
 type IOMutable d = IO (MutableIO d)
 
---- They type of 'ST' actions that return a mutable value of type _d_
+--- The type of 'ST' actions that return a mutable value of type _d_
 --- This is an abbreviation for @ST s (Mutable s d)@ 
 type STMutable s d = ST s (Mutable s d)
 

--- a/frege/prelude/PreludeIO.fr
+++ b/frege/prelude/PreludeIO.fr
@@ -175,7 +175,7 @@ catch action handler = doCatch javaClass action handler
     > action `catch` handler1 `catch` handler2 `finally` always
     
     -}
-native finally PreludeBase.WrappedCheckedException.doFinally{a,b}  :: IO a -> IO b -> IO a
+native finally PreludeBase.WrappedCheckedException.doFinally{}  :: ST s a -> ST s b -> ST s a
 
 private native throwRT PreludeBase.WrappedCheckedException.throwST 
     :: PreludeBase.Throwable -> ST s ()


### PR DESCRIPTION
This PR mainly modifies `frege.java.IO` so that users can use it more comfortably.

- The following native types were changed to have `ST` members instead of `IO`s:
  - Closeable
  - Flushable
  - Writer
  - OutputStreamWriter
  - PrintWriter
  - StringWriter
  - Reader
  - InputStreamReader
  - BufferedReader

The abstract super classes/interfaces don't necessarily do I/O. The prime example is `ByteArrayInputStream` (doesn't exist in the Frege library yet). Having super class members declared as `IO` forbids using such classes in semi-pure contexts, and users are forced to declare all of the needed native `ST` methods by their own.

Purity is preserved as long as values that do I/O is in `MutableIO`. All subclasses currently declared in the Frege library satisfy that (e.g. all of the constructors of `FileInputStream` produce `MutableIO`).

The other smaller changes are:
- Added `AutoCloseable`
- Added more `ST` members
- Changed `finally` from `IO` to `ST`
- Removed the explanation of `mutable native`
