### PR TITLE
Modify instance Show HashMap not to depend on ToJSON

### DIFF
--- a/frege/data/HashMap.fr
+++ b/frege/data/HashMap.fr
@@ -926,8 +926,8 @@ instance (Eq k, Eq v) ⇒ Eq (HashMap k v) where
 
 derive ArrayElement (HashMap k v)
 
-instance (ToJSON k, ToJSON v) ⇒ Show (HashMap k v) where
-    show hm = show (toJSON hm)
+instance (Show k, Show v) => Show (HashMap k v) where
+    show hm = "fromList " ++ show (each hm)
 
 -- Array primitives
 


### PR DESCRIPTION
Resolves #371 

The shown string will have prefix "fromList", just like Haskell's one does.