### PR TITLE
Relax JArray constraints and add more consistent interface

### DIFF
--- a/frege/prelude/PreludeArrays.fr
+++ b/frege/prelude/PreludeArrays.fr
@@ -167,6 +167,23 @@ data JArray a = native "java.lang.Object" where
         Can not be used with arrays of primitive values.
     -}
     native       genericSetAt  java.lang.reflect.Array.set {} :: Mutable s (JArray a) -> Int -> Maybe a -> ST s ()
+    {--
+        Modify the element at a certain index of a mutable array by
+        function application.
+
+        This will throw an
+        'IndexOutOfBoundsException' if the index is lower than 0 or
+        greater or equal to the length of the array.
+
+        Because in general, an array may contain @null@s. The values
+        passed to the function are wrapped in 'Maybe's, as usual.
+
+        Can not be used with arrays of primitive values.
+     -}
+    genericModifyAt :: Mutable s (JArray a) -> Int -> (Maybe a -> Maybe a) -> ST s ()
+    genericModifyAt this i f =
+        this.genericGetAt i >>= \a ->
+        this.genericSetAt i (f a)
 
     {-- 
         Get the array element at a certain index of a mutable array and
@@ -176,7 +193,7 @@ data JArray a = native "java.lang.Object" where
         'IndexOutOfBoundsException' if the index is lower than 0 or
         greater or equal to the length of the array.
 
-        Unlike with 'JArray.getAt' the element *must not be @null@*.
+        Unlike with 'JArray.genericGetAt' the element *must not be @null@*.
 
         The user is expected to prove that the
         element cannot be @null@ or else risk a @NullPointerException@.
@@ -195,6 +212,26 @@ data JArray a = native "java.lang.Object" where
         Can not be used with arrays of primitive values.
     -}
     native   genericSetElemAt  java.lang.reflect.Array.set {} :: Mutable s (JArray a) -> Int -> a -> ST s ()
+
+    {--
+        Modify the element at a certain index of a mutable array by
+        function application.
+
+        This will throw an
+        'IndexOutOfBoundsException' if the index is lower than 0 or
+        greater or equal to the length of the array.
+
+        Unlike with 'JArray.genericModifyAt' the element *must not be @null@*.
+
+        The user is expected to prove that the
+        element cannot be @null@ or else risk a @NullPointerException@.
+
+        Can not be used with arrays of primitive values.
+     -}
+    genericModifyElemAt :: Mutable s (JArray a) -> Int -> (a -> a) -> ST s ()
+    genericModifyElemAt this i f =
+        this.genericGetElemAt i >>= \a ->
+        this.genericSetElemAt i (f a)
 
     {--
         Create a mutable array from a finite list.
@@ -218,20 +255,53 @@ data JArray a = native "java.lang.Object" where
         mapM_ (uncurry (JArray.genericSetElemAt arr))  xs
         return arr
 
+    {--
+        Modify a mutable array by applying a function to all its elements.
 
-    --- Modify a mutable array by applying a function to all its elements.
-    --- Can not be used with arrays of primitive values.
-    genericModify :: ArrayElement α => (α->α) -> ArrayOf β α -> ST β ()
+        @null@ values are represented as 'Nothing', as usual.
+
+        Can not be used with arrays of primitive values.
+    -}
+    genericModify :: (Maybe a -> Maybe a) -> ArrayOf s a -> ST s ()
     genericModify f dest = do
-            max <- dest.getLength
-            mapM_ (modifyAt f dest) [0..max-1]
+        max <- dest.getLength
+        mapM_ (\i -> dest.genericModifyAt i f) [0..max-1]
 
-    --- Equivalent of 'fold' for mutable arrays.
-    --- Can not be used with arrays of primitive values.
-    genericFold :: ArrayElement α => (β->α->β) -> β -> ArrayOf γ α -> ST γ β
+    {--
+        Modify a mutable array by applying a function to all its elements.
+
+        @null@ elements are skipped.
+
+        Can not be used with arrays of primitive values.
+    -}
+    genericModifyElem :: (a -> a) -> ArrayOf s a -> ST s ()
+    genericModifyElem f dest = do
+        max <- dest.getLength
+        mapM_ (\i -> dest.genericModifyAt i $ fmap f) [0..max-1]
+
+    {--
+        Equivalent of 'fold' for mutable arrays.
+
+        @null@ values are represented as 'Nothing', as usual.
+
+        Can not be used with arrays of primitive values.
+    -}
+    genericFold :: (b -> Maybe a -> b) -> b -> ArrayOf s a -> ST s b
     genericFold f acc arr = arr.getLength >>= foldM collect acc . enumFromTo 0 . pred
         where
-            collect acc i = ArrayElement.getAt arr i >>= (return . maybe acc (f acc))
+            collect acc i = arr.genericGetAt i >>= return . f acc
+
+    {--
+        Equivalent of 'fold' for mutable arrays.
+
+        @null@ elements are skipped.
+
+        Can not be used with arrays of primitive values.
+      -}
+    genericFoldElem :: (b -> a -> b) -> b -> ArrayOf s a -> ST s b
+    genericFoldElem f acc arr = arr.getLength >>= foldM collect acc . enumFromTo 0 . pred
+        where
+            collect acc i = arr.genericGetAt i >>= return . maybe acc (f acc)
 
 
 

--- a/frege/prelude/PreludeArrays.fr
+++ b/frege/prelude/PreludeArrays.fr
@@ -62,7 +62,7 @@ type ArrayOf s a = Mutable s (JArray a)
     Note that there are really two different APIs: 
 
     1. With the 'JArray.getElemAt', 'JArray.getAt', 'JArray.setAt', 'JArray.setElemAt',
-    'JArray.itemAt' and 'JArray.elemAt' it is possible to work on Java objects with
+    'JArray.genericItemAt' and 'JArray.genericElemAt' it is possible to work on Java objects with
     java compile time type  @X[]@ for some (non primitive!) java type @X@.
 
     2. With the 'newArray', 'getElemAt', 'getAt', 'setAt', 
@@ -87,10 +87,10 @@ type ArrayOf s a = Mutable s (JArray a)
     >             Array type            Argument/    Description
     >                                   Result
 
-    > setAt       Mutable (JArray s X)  Maybe X     set null or data element
-    > setElemAt   Mutable (JArray s X)  X           set data element
-    > getAt       Mutable (JArray s X)  Maybe X     get null or data element
-    > getElemAt   Mutable (JArray s X)  X           get data element (unsafe)
+    > setAt       Mutable s (JArray X)  Maybe X     set null or data element
+    > setElemAt   Mutable s (JArray X)  X           set data element
+    > getAt       Mutable s (JArray X)  Maybe X     get null or data element
+    > getElemAt   Mutable s (JArray X)  X           get data element (unsafe)
     > itemAt      JArray s X            Maybe X     get null or data element (pure)
     > elemAt      JArray s X            X           get data element (pure, unsafe)
 
@@ -372,9 +372,9 @@ genericArrayFold !f !acc arr = go acc 0
 class JavaType a => ArrayElement a where
     --- Create a one dimensional array with elements of the instantiated type.
     native newArray "new[]"   :: Int -> ST s (ArrayOf s a)
-    --- Get item at index from immutable array, see 'JArray.itemAt'
+    --- Get item at index from immutable array, see 'JArray.genericItemAt'
     pure native itemAt  "[i]"   :: JArray a -> Int -> Maybe a
-    --- Get non-null element at index from immutable array, see 'JArray.elemAt'
+    --- Get non-null element at index from immutable array, see 'JArray.genericElemAt'
     pure native elemAt  "[i]"   :: JArray a -> Int -> a
     --- Get item at index from mutable array, see 'JArray.getAt'
     native getAt        "[i]"   :: Mutable s (JArray a) -> Int -> ST s (Maybe a)

--- a/frege/prelude/PreludeArrays.fr
+++ b/frege/prelude/PreludeArrays.fr
@@ -201,35 +201,16 @@ data JArray a = native "java.lang.Object" where
 
         Can not be used with arrays of primitive values.
     -}
-    genericFromList :: ArrayElement α => [α] -> STMutable β (JArray α)
-    genericFromList xs = do
-        let !len = xs.length 
-        arr <- newArray len
-        zipWithM_ (ArrayElement.setElemAt arr) [0..len-1] xs
-        pure arr
+    genericFromList :: JavaType α => [α] -> STMutable β (JArray α)
+    genericFromList = genericFromIndexList . zip [0..]
+
     {--
         Create a mutable array from a finite index/value list.
 
-        Indexes not mentioned in the list remain @null@ for 
-        non primitive array elements and 0 otherwise.
+        Indexes not mentioned in the list remain @null@.
 
         Can not be used with arrays of primitive values.
     -}
---    genericFromIndexList :: ArrayElement α => [(Int,α)] -> STMutable β (JArray α)
---    genericFromIndexList xs = do
---        let !len = L.fold max 0 (L.map fst xs) 
---        arr <- newArray (if null xs then 0 else len+1)
---        mapM_ (\(i,a) -> ArrayElement.setElemAt arr i a)  xs
---        pure arr
---
---
---    {--
---        Create a mutable generic array from a finite index/value list.
---
---        Indexes not mentioned in the list remain @null@ for 
---        non primitive array elements and 0 otherwise.
---
---    -}
     genericFromIndexList :: JavaType α => [(Int,α)] -> STMutable β (JArray α)
     genericFromIndexList xs = do
         let !len = L.fold max 0 (L.map fst xs) 

--- a/frege/prelude/PreludeArrays.fr
+++ b/frege/prelude/PreludeArrays.fr
@@ -167,6 +167,7 @@ data JArray a = native "java.lang.Object" where
         Can not be used with arrays of primitive values.
     -}
     native       genericSetAt  java.lang.reflect.Array.set {} :: Mutable s (JArray a) -> Int -> Maybe a -> ST s ()
+
     {--
         Modify the element at a certain index of a mutable array by
         function application.
@@ -242,17 +243,46 @@ data JArray a = native "java.lang.Object" where
     genericFromList = genericFromIndexList . zip [0..]
 
     {--
+        Create a mutable array from a finite list.
+
+        @Nothing@s become @null@s in the array.
+
+        Can not be used with arrays of primitive values.
+    -}
+    genericFromMaybeList :: JavaType a => [Maybe a] -> STMutable s (JArray a)
+    genericFromMaybeList xs =
+        flip genericFromIndexListLength (L.length xs)
+        $ mapMaybe (\(idx, m) -> fmap (\a -> (idx, a)) m)
+        $ zip [0..]
+        $ xs
+
+    {--
         Create a mutable array from a finite index/value list.
 
         Indexes not mentioned in the list remain @null@.
+        Negative indexes are ignored.
 
         Can not be used with arrays of primitive values.
     -}
     genericFromIndexList :: JavaType α => [(Int,α)] -> STMutable β (JArray α)
-    genericFromIndexList xs = do
-        let !len = L.fold max 0 (L.map fst xs) 
-        arr <- JArray.new javaClass (if null xs then 0 else len+1)
-        mapM_ (uncurry (JArray.genericSetElemAt arr))  xs
+    genericFromIndexList = flip genericFromIndexListLength 0
+
+    {--
+        Create a mutable array from a finite index/value list.
+
+        The array will have the specified length at least.
+
+        Indexes not mentioned in the list remain @null@.
+        Negative indexes are ignored.
+
+        Can not be used with arrays of primitive values.
+    -}
+    genericFromIndexListLength :: JavaType α => [(Int,α)] -> Int -> STMutable β (JArray α)
+    genericFromIndexListLength xs minLen = do
+        let maxIdx = L.fold max 0 (L.map fst xs)
+            len = max minLen $ if null xs then 0 else maxIdx + 1
+        arr <- JArray.new javaClass len
+        mapM_ (uncurry (JArray.genericSetElemAt arr)) xs
         return arr
 
     {--

--- a/frege/prelude/PreludeArrays.fr
+++ b/frege/prelude/PreludeArrays.fr
@@ -278,8 +278,9 @@ data JArray a = native "java.lang.Object" where
         Can not be used with arrays of primitive values.
     -}
     genericFromIndexListLength :: JavaType α => [(Int,α)] -> Int -> STMutable β (JArray α)
-    genericFromIndexListLength xs minLen = do
-        let maxIdx = L.fold max 0 (L.map fst xs)
+    genericFromIndexListLength xs' minLen = do
+        let xs = L.filter (\(i, _) -> i >= 0) xs'
+            maxIdx = L.fold max 0 (L.map fst xs)
             len = max minLen $ if null xs then 0 else maxIdx + 1
         arr <- JArray.new javaClass len
         mapM_ (uncurry (JArray.genericSetElemAt arr)) xs

--- a/frege/prelude/PreludeArrays.fr
+++ b/frege/prelude/PreludeArrays.fr
@@ -262,10 +262,10 @@ data JArray a = native "java.lang.Object" where
 
         Can not be used with arrays of primitive values.
     -}
-    genericModify :: (Maybe a -> Maybe a) -> ArrayOf s a -> ST s ()
-    genericModify f dest = do
-        max <- dest.getLength
-        mapM_ (\i -> dest.genericModifyAt i f) [0..max-1]
+    genericModify :: ArrayOf s a -> (Maybe a -> Maybe a) -> ST s ()
+    genericModify this f = do
+        max <- this.getLength
+        mapM_ (\i -> this.genericModifyAt i f) [0..max-1]
 
     {--
         Modify a mutable array by applying a function to all its elements.
@@ -274,10 +274,10 @@ data JArray a = native "java.lang.Object" where
 
         Can not be used with arrays of primitive values.
     -}
-    genericModifyElem :: (a -> a) -> ArrayOf s a -> ST s ()
-    genericModifyElem f dest = do
-        max <- dest.getLength
-        mapM_ (\i -> dest.genericModifyAt i $ fmap f) [0..max-1]
+    genericModifyElem :: ArrayOf s a -> (a -> a) -> ST s ()
+    genericModifyElem this f = do
+        max <- this.getLength
+        mapM_ (\i -> this.genericModifyAt i $ fmap f) [0..max-1]
 
     {--
         Equivalent of 'fold' for mutable arrays.
@@ -286,10 +286,10 @@ data JArray a = native "java.lang.Object" where
 
         Can not be used with arrays of primitive values.
     -}
-    genericFold :: (b -> Maybe a -> b) -> b -> ArrayOf s a -> ST s b
-    genericFold f acc arr = arr.getLength >>= foldM collect acc . enumFromTo 0 . pred
+    genericFold :: ArrayOf s a -> (b -> Maybe a -> b) -> b -> ST s b
+    genericFold this f acc = this.getLength >>= foldM collect acc . enumFromTo 0 . pred
         where
-            collect acc i = arr.genericGetAt i >>= return . f acc
+            collect acc i = this.genericGetAt i >>= return . f acc
 
     {--
         Equivalent of 'fold' for mutable arrays.
@@ -298,10 +298,10 @@ data JArray a = native "java.lang.Object" where
 
         Can not be used with arrays of primitive values.
       -}
-    genericFoldElem :: (b -> a -> b) -> b -> ArrayOf s a -> ST s b
-    genericFoldElem f acc arr = arr.getLength >>= foldM collect acc . enumFromTo 0 . pred
+    genericFoldElem :: ArrayOf s a -> (b -> a -> b) -> b -> ST s b
+    genericFoldElem this f acc = this.getLength >>= foldM collect acc . enumFromTo 0 . pred
         where
-            collect acc i = arr.genericGetAt i >>= return . maybe acc (f acc)
+            collect acc i = this.genericGetAt i >>= return . maybe acc (f acc)
 
 
 

--- a/tests/qc/PreludeArraysProp.fr
+++ b/tests/qc/PreludeArraysProp.fr
@@ -1,0 +1,40 @@
+{--
+ - Test properties of the 'frege.prelude.PreludeArrays' module.
+ -}
+module tests.qc.PreludeArraysProp where
+
+import frege.test.QuickCheck as Q (Arbitrary)
+
+--- The non-primitive wrapper of 'Int'
+data RInt = RInt Int
+derive Eq RInt
+derive Show RInt
+derive JavaType RInt
+derive ArrayElement RInt  -- TODO remove
+
+instance Arbitrary RInt where
+  arbitrary = RInt <$> arbitrary
+
+p_JArray_genericFromList = Q.property $ \xs -> ST.run (st xs)
+  where
+    st :: [RInt] -> ST s Bool
+    st xs = do
+        marr <- JArray.genericFromList xs
+        readonly (\parr -> toList parr == xs) marr
+
+p_JArray_genericModify = Q.property $ \(xs, i) -> ST.run (st xs i)
+  where
+    st :: [RInt] -> Int -> ST s Bool
+    st xs i = do
+        marr <- JArray.genericFromList xs
+        let f (RInt x) = RInt $ x + i
+        JArray.genericModify f marr
+        readonly (\parr -> toList parr == map f xs) marr
+
+p_JArray_genericFold = Q.property $ \xs -> ST.run (st xs)
+  where
+    st :: [RInt] -> ST s Bool
+    st xs = do
+        marr <- JArray.genericFromList xs
+        arrsum <- JArray.genericFold (\acc (RInt x) -> acc + x) 0 marr
+        pure $ arrsum == sum [x | RInt x <- xs]

--- a/tests/qc/PreludeArraysProp.fr
+++ b/tests/qc/PreludeArraysProp.fr
@@ -3,6 +3,8 @@
  -}
 module tests.qc.PreludeArraysProp where
 
+import frege.data.List (sortBy)
+import frege.data.Traversable (traverse)
 import frege.test.QuickCheck as Q (Arbitrary)
 
 --- The non-primitive wrapper of 'Int'
@@ -10,10 +12,76 @@ data RInt = RInt Int
 derive Eq RInt
 derive Show RInt
 derive JavaType RInt
-derive ArrayElement RInt  -- TODO remove
 
 instance Arbitrary RInt where
   arbitrary = RInt <$> arbitrary
+
+--- A pair of a non-empty list and an index in the bound of it
+data ListAndIndex a = LI [a] Int
+derive Eq (ListAndIndex a)
+derive Show (ListAndIndex a)
+
+instance Arbitrary a => Arbitrary (ListAndIndex a) where
+  arbitrary = do
+      Q.NonEmptyList.NonEmpty xs <- arbitrary
+      i <- Q.choose (0, length xs - 1)
+      pure $ LI xs i
+
+shuffle :: [a] -> Q.Gen [a]
+shuffle xs = do
+    ixs <- traverse (\x -> arbitrary >>= \i -> pure (i :: Int, x)) xs
+    pure $ map snd $ sortBy (comparing fst) ixs
+
+--- A list of pairs of an index and an element
+data IndexedList a = IndexL [(Int, a)]
+derive Eq (IndexedList a)
+derive Show (IndexedList a)
+
+instance Arbitrary a => Arbitrary (IndexedList a) where
+  arbitrary = do
+      -- from an arbitrary [Maybe a], put indexes,
+      -- take @Just@s (so that some indexes will be missing),
+      -- and shuffle them
+      indexed <-
+        flip fmap arbitrary
+        $ mapMaybe (\(idx, m) -> fmap (\x -> (idx, x)) m)
+        . zip [0..]
+      fmap IndexL $ shuffle indexed
+
+newtype Small = Small Int
+derive Eq Small
+derive Show Small
+
+instance Arbitrary Small where
+  arbitrary = fmap (\(Q.NonNegative.NonNegative x) -> Small $ x `mod` 10) $ arbitrary
+
+modifyListAt :: Int -> (a -> a) -> [a] -> [a]
+modifyListAt _ _ [] = []
+modifyListAt i f (a:as)
+  | i == 0 = f a:as
+  | i <  0 = as
+  | otherwise =
+      let (prefix, suffix) = splitAt i (a:as)
+      in
+      prefix ++ modifyListAt 0 f suffix
+
+p_JArray_genericModifyAt = Q.property $ \(LI xs idx, i) -> ST.run (st xs idx i)
+  where
+    st :: [Maybe RInt] -> Int -> Int -> ST s Bool
+    st xs idx i = do
+        marr <- JArray.genericFromMaybeList xs
+        let f = fmap $ \(RInt x) -> RInt $ x + i
+        marr.genericModifyAt idx f
+        readonly (\parr -> genericToMaybeList parr == modifyListAt idx f xs) marr
+
+p_JArray_genericModifyElemAt = Q.property $ \(LI xs idx, i) -> ST.run (st xs idx i)
+  where
+    st :: [RInt] -> Int -> Int -> ST s Bool
+    st xs idx i = do
+        marr <- JArray.genericFromList xs
+        let f = \(RInt x) -> RInt $ x + i
+        marr.genericModifyElemAt idx f
+        readonly (\parr -> toList parr == modifyListAt idx f xs) marr
 
 p_JArray_genericFromList = Q.property $ \xs -> ST.run (st xs)
   where
@@ -22,19 +90,80 @@ p_JArray_genericFromList = Q.property $ \xs -> ST.run (st xs)
         marr <- JArray.genericFromList xs
         readonly (\parr -> toList parr == xs) marr
 
+p_JArray_genericFromMaybeList = Q.property $ \xs -> ST.run (st xs)
+  where
+    st :: [Maybe RInt] -> ST s Bool
+    st xs = do
+        marr <- JArray.genericFromMaybeList xs
+        readonly (\parr -> genericToMaybeList parr == xs) marr
+
+{--
+ - Checks if a given Java array is equivalent to an indexed list.
+ -
+ - The list doesn't need to be sorted.
+ - @null@ elements in the Java array must be missing in the list.
+ - All of the non-@null@ elements must be present in the list.
+ -}
+checkIndexList :: Eq a => [(Int, a)] -> JArray a -> Bool
+checkIndexList ixs arr =
+  flip all (zip [0..] $ genericToMaybeList arr) $ \(arrIdx, arrElem) ->
+    case arrElem of
+      Just a  -> (arrIdx, a) `elem` ixs
+      Nothing -> all (\(i, _) -> arrIdx /= i) ixs
+
+p_JArray_genericFromIndexList = Q.property $ \(IndexL ixs) -> ST.run (st ixs)
+  where
+    st :: [(Int, RInt)] -> ST s Bool
+    st ixs = do
+        marr <- JArray.genericFromIndexList ixs
+        readonly (checkIndexList ixs) marr
+
+p_JArray_genericFromIndexListLength = Q.property $ \(IndexL ixs, Small n) ->
+    ST.run (st ixs n)
+  where
+    st :: [(Int, RInt)] -> Int -> ST s Bool
+    st ixs n = do
+        marr <- JArray.genericFromIndexListLength ixs n
+        flip readonly marr $ \parr ->
+            parr.length >= n && checkIndexList ixs parr
+
 p_JArray_genericModify = Q.property $ \(xs, i) -> ST.run (st xs i)
   where
-    st :: [RInt] -> Int -> ST s Bool
+    st :: [Maybe RInt] -> Int -> ST s Bool
     st xs i = do
-        marr <- JArray.genericFromList xs
-        let f (RInt x) = RInt $ x + i
-        JArray.genericModify f marr
-        readonly (\parr -> toList parr == map f xs) marr
+        marr <- JArray.genericFromMaybeList xs
+        let f = fmap $ \(RInt x) -> RInt $ x + i
+        marr.genericModify f
+        readonly (\parr -> genericToMaybeList parr == map f xs) marr
+
+p_JArray_genericModifyElem = Q.property $ \(xs, i) -> ST.run (st xs i)
+  where
+    -- use Maybe RInt to make sure that genericModifyElem skips nulls
+    st :: [Maybe RInt] -> Int -> ST s Bool
+    st xs i = do
+        marr <- JArray.genericFromMaybeList xs
+        let f = \(RInt x) -> RInt $ x + i
+        marr.genericModifyElem f
+        readonly (\parr -> genericToMaybeList parr == map (fmap f) xs) marr
 
 p_JArray_genericFold = Q.property $ \xs -> ST.run (st xs)
   where
-    st :: [RInt] -> ST s Bool
+    st :: [Maybe RInt] -> ST s Bool
     st xs = do
-        marr <- JArray.genericFromList xs
-        arrsum <- JArray.genericFold (\acc (RInt x) -> acc + x) 0 marr
-        pure $ arrsum == sum [x | RInt x <- xs]
+        marr <- JArray.genericFromMaybeList xs
+        arrFolded <- marr.genericFold addJustCountNothing (0, 0)
+        pure $ arrFolded == fold addJustCountNothing (0, 0) xs
+    addJustCountNothing :: (Int, Int) -> Maybe RInt -> (Int, Int)
+    addJustCountNothing (sums, nothings) mx =
+      case mx of
+        Just (RInt x) -> (sums + x, nothings)
+        Nothing       -> (sums, nothings + 1)
+
+p_JArray_genericFoldElem = Q.property $ \xs -> ST.run (st xs)
+  where
+    -- use Maybe RInt to make sure that genericFoldElem skips nulls
+    st :: [Maybe RInt] -> ST s Bool
+    st xs = do
+        marr <- JArray.genericFromMaybeList xs
+        arrSum <- marr.genericFoldElem (\acc (RInt x) -> acc + x) 0
+        pure $ arrSum == sum [x | Just (RInt x) <- xs]

--- a/tests/qc/PreludeArraysProp.fr
+++ b/tests/qc/PreludeArraysProp.fr
@@ -118,6 +118,13 @@ p_JArray_genericFromIndexList = Q.property $ \(IndexL ixs) -> ST.run (st ixs)
         marr <- JArray.genericFromIndexList ixs
         readonly (checkIndexList ixs) marr
 
+p_JArray_genericFromIndexList_negative = Q.once $ ST.run st
+  where
+    st :: ST s Bool
+    st = do
+        marr <- JArray.genericFromIndexList [(-1, RInt 1), (1, RInt 2)]
+        readonly (\parr -> genericToMaybeList parr == [Nothing, Just (RInt 2)]) marr
+
 p_JArray_genericFromIndexListLength = Q.property $ \(IndexL ixs, Small n) ->
     ST.run (st ixs n)
   where


### PR DESCRIPTION
Resolves #366

- Changed:
  - `JArray.genericFromList` now requires `JavaType` instead of `ArrayElement`
  - `JArray.genericFromIndexList` now ignores negative indexes instead of throwing NPEs
  - `JArray.genericModify` no longer requires `ArrayElement`
  - `JArray.genericModify` now takes `(Maybe a -> Maybe a)`
  - `JArray.genericFold` no longer requires `ArrayElement`
  - `JArray.genericFold` now takes `(b -> Maybe a -> b)`
- Added:
  - `JArray.genericModifyAt`
  - `JArray.genericModifyElemAt`
    - There is already `JArray.genericModify`, which modifies all of the elements in the array, but not one at a time.
      These methods allow individual updates.
  - `JArray.genericFromMaybeList`
    - Found useful when writing the tests. Symmetric to `genericToMaybeList`.
    - Requires `JavaType`.
  - `JArray.genericFromIndexListLength`
    - Ensures a new array to have at least a specified length.
    - Requires `JavaType`.
  - `JArray.genericModifyElem`
  - `JArray.genericFoldElem`
    - These skips `null`s instead of throwing NPEs.

Also, the order of the arguments were reordered so that (`Mutable s`) `JArray a` comes first for all of `JArray`'s members. This enables `JArray`s to be used as "receiver"s e.g.

```frege.hs
-- old
JArray.genericFold (+) 0 arr
-- new
arr.genericFold (+) 0
```

Added property tests for the changed/added functions before and after changes in order to ensure there are no regressions.

My understanding is that `JavaType` is needed only when constructing non-primitive arrays but not accessing ones, whereas `ArrayElement` is needed on both constructing and accessing possibly primitive arrays. `JArray` involves with non-primitive arrays only, so it looks like it doesn't (shouldn't) need to require `ArrayElement`.
